### PR TITLE
Implements Brave-specific filter options `tag` and `explicitcancel`

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -48,4 +48,9 @@ impl Engine {
         let request = Request::from_urls(&url, &source_url, &request_type).unwrap();
         self.blocker.check(&request)
     }
+
+    pub fn with_tags<'a>(&'a mut self, tags: &[&str]) -> &'a mut Engine {
+        self.blocker.with_tags(tags);
+        self
+    }
 }

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -17,6 +17,7 @@ pub enum FilterError {
     BadFilter,
     NegatedImportant,
     NegatedOptionMatchCase,
+    NegatedExplicitCancel,
     NegatedRedirection,
     NegatedTag,
     EmptyRedirection,
@@ -47,6 +48,7 @@ bitflags! {
         const FUZZY_MATCH = 1 << 15;
         const THIRD_PARTY = 1 << 16;
         const FIRST_PARTY = 1 << 17;
+        const EXPLICIT_CANCEL = 1 << 26;
 
         // Kind of pattern
         const IS_REGEX = 1 << 18;
@@ -346,6 +348,8 @@ impl NetworkFilter {
 
                         redirect = Some(String::from(value));
                     }
+                    ("explicitcancel", true) => return Err(FilterError::NegatedExplicitCancel),
+                    ("explicitcancel", false) => mask.set(NetworkFilterMask::EXPLICIT_CANCEL, true),
                     ("csp", _) => {
                         mask.set(NetworkFilterMask::IS_CSP, true);
                         if !value.is_empty() {
@@ -735,6 +739,10 @@ impl NetworkFilter {
     #[inline]
     pub fn is_redirect(&self) -> bool {
         self.redirect.is_some()
+    }
+    #[inline]
+    pub fn is_explicit_cancel(&self) -> bool {
+        self.mask.contains(NetworkFilterMask::EXPLICIT_CANCEL)
     }
     #[inline]
     pub fn is_regex(&self) -> bool {

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -18,6 +18,7 @@ pub enum FilterError {
     NegatedImportant,
     NegatedOptionMatchCase,
     NegatedRedirection,
+    NegatedTag,
     EmptyRedirection,
     UnrecognisedOption,
     NoRegex,
@@ -172,10 +173,10 @@ pub struct NetworkFilter {
     pub hostname: Option<String>,
     pub csp: Option<String>,
     pub bug: Option<u32>,
+    pub tag: Option<String>,
 
     pub raw_line: Option<String>,
 
-    // Lazy attributes
     pub id: Hash,
     pub fuzzy_signature: Option<Vec<Hash>>,
 
@@ -221,6 +222,7 @@ impl NetworkFilter {
         let mut redirect: Option<String> = None;
         let mut csp: Option<String> = None;
         let mut bug: Option<u32> = None;
+        let mut tag: Option<String> = None;
 
         // Start parsing
         let mut filter_index_start: usize = 0;
@@ -332,6 +334,8 @@ impl NetworkFilter {
                     ("fuzzy", _) => mask.set(NetworkFilterMask::FUZZY_MATCH, true),
                     ("collapse", _) => {}
                     ("bug", _) => bug = value.parse::<u32>().ok(),
+                    ("tag", false) => tag = Some(String::from(value)),
+                    ("tag", true) => return Err(FilterError::NegatedTag),
                     // Negation of redirection doesn't make sense
                     ("redirect", true) => return Err(FilterError::NegatedRedirection),
                     ("redirect", false) => {
@@ -577,6 +581,7 @@ impl NetworkFilter {
             mask,
             opt_domains,
             opt_not_domains,
+            tag,
             raw_line: if debug {
                 Some(String::from(line))
             } else {

--- a/tests/legacy_harness.rs
+++ b/tests/legacy_harness.rs
@@ -706,19 +706,16 @@ mod legacy_misc_tests {
     }
 
     #[test]
-    #[ignore]   // need to implement explicitcancel option
     fn matches_with_filter_info_preserves_explicitcancel() {
         // Testing matchingFilter
         let engine = Engine::from_rules_debug(&[
             String::from("||brianbondy.com^$explicitcancel"),
         ]);
 
-        let checked = engine.check_network_urls("http://tpc.googlesyndication.com/safeframe/1-0-2/html/container.html", "https://test.com", "script");
+        let checked = engine.check_network_urls("https://brianbondy.com/t", "https://test.com", "script");
         assert_eq!(checked.matched, true);
         assert!(checked.filter.is_some(), "Expected filter to match");
-        // let matched_filter = checked.filter.unwrap();
-        // TODO
-        // assert!(matched_filter.is_explicit_cancel(), "Expected explicit cancel option to be preserved");
+        assert!(checked.explicit_cancel, "Expected explicit cancel option to be preserved by {:?}", checked.filter);
         assert!(checked.exception.is_none(), "Expected no exception to match");
     }
 

--- a/tests/legacy_harness.rs
+++ b/tests/legacy_harness.rs
@@ -304,18 +304,14 @@ mod legacy_check_match {
 
     fn check_match<'a>(rules: &[&'a str], blocked: &[&'a str], not_blocked: &[&'a str], tags: &[&'a str]) {
         let rules_owned: Vec<_> = rules.into_iter().map(|&s| String::from(s)).collect();
-        let engine = Engine::from_rules(&rules_owned);                      // first one with the provided rules
+        let mut engine = Engine::from_rules(&rules_owned);                      // first one with the provided rules
+        engine.with_tags(tags);
+            
         let mut engine_deserialized = Engine::from_rules(&vec![]);          // second empty
         {
             let engine_serialized = engine.serialize().unwrap();
             engine_deserialized.deserialize(&engine_serialized).unwrap();   // override from serialized copy
         }
-
-        // TODO: handle tags
-        // std::for_each(tags.begin(), tags.end(),
-        //     [&client](string const &tag) {
-        //     client.addTag(tag);
-        // });
 
         for to_block in blocked {
             assert!(
@@ -409,7 +405,6 @@ mod legacy_check_match {
     }
 
     #[test]
-    #[ignore] // FIXME: need to implement tag support
     fn tag_tests() {
         // No matching tags should not match a tagged filter
         check_match(&["adv$tag=stuff",


### PR DESCRIPTION
Modifies the engine API to accommodate both options:

- Engine uses builder pattern to choose which tags should be used
- Result structure exposes additional boolean field `explicit_cancel` to signal when a filter with the option set matches