### PR TITLE
Adds blocker engine method to use pre-parsed hostnames

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -49,6 +49,11 @@ impl Engine {
         self.blocker.check(&request)
     }
 
+    pub fn check_network_urls_with_hostnames(&self, url: &str, hostname: &str, source_hostname: &str, request_type: &str, third_party_request: Option<bool>) -> BlockerResult {
+        let request = Request::from_urls_with_hostname(url, hostname, source_hostname, request_type, third_party_request);
+        self.blocker.check(&request)
+    }
+
     pub fn with_tags<'a>(&'a mut self, tags: &[&str]) -> &'a mut Engine {
         self.blocker.with_tags(tags);
         self


### PR DESCRIPTION
Introduces public method for explicitly specifying:
- the hostname of the URL as already available
- hostname instead of full source url
- third-partiness of a request as an Option<bool> (None means undecided and need to compute)