### PR TITLE
Bugfix: if a host-anchored exception contains an empty hostname, pars…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "adblock"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "addr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "adblock"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Andrius Aucinas <aaucinas@brave.com>"]
 edition = "2018"
 

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adblock-rs"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Andrius Aucinas <aaucinas@brave.com>"]
 license = "MPL-2.0"
 build = "build.rs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adblock-rs",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Very fast, Rust-based, native implementation of ad-blocker engine for Node",
   "main": "lib/index.js",
   "author": "Andrius Aucinas <aaucinas@brave.com>",


### PR DESCRIPTION
…ing should succeed and exception apply defined by the rest of the filter

Follows uBo behaviour in applying such rules