### PR TITLE
Tags api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "adblock"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "addr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "adblock"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Andrius Aucinas <aaucinas@brave.com>"]
 edition = "2018"
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -71,4 +71,12 @@ impl Engine {
         self.blocker.with_tags(tags);
         self
     }
+
+    pub fn tags_enable<'a>(&'a mut self, tags: &[&str]) -> () {
+        self.blocker.tags_enable(tags);
+    }
+
+    pub fn tags_disable<'a>(&'a mut self, tags: &[&str]) -> () {
+        self.blocker.tags_disable(tags);
+    }
 }


### PR DESCRIPTION
Adds filter tag management convenience functions

`Engine` now has methods `tags_enable` and `tags_disable` that accept a list of tags to enable or disable in addition to the previous `with_tags` which expects a complete list of active tags.