### PR TITLE
Filter fixes

### DIFF
--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -647,7 +647,7 @@ impl NetworkFilter {
             FilterPart::Simple(f) => {
                 if !self.is_complete_regex() {
                     let skip_last_token =
-                        self.is_plain() && !self.is_right_anchor() && !self.is_fuzzy();
+                        (self.is_plain() || self.is_regex()) && !self.is_right_anchor() && !self.is_fuzzy();
                     let skip_first_token = self.is_right_anchor();
 
                     let mut filter_tokens =

--- a/tests/ublock-coverage.rs
+++ b/tests/ublock-coverage.rs
@@ -65,7 +65,21 @@ fn get_blocker_engine() -> Engine {
 }
 
 #[test]
-fn check_specifics() {
+fn check_specific_rules() {
+    {
+        // exceptions have not effect if important filter matches
+        let engine = Engine::from_rules_debug(&[
+            String::from("||www.facebook.com/*/plugin"),
+        ]);
+
+        let checked = engine.check_network_urls("https://www.facebook.com/v3.2/plugins/comments.ph", "", "");
+
+        assert_eq!(checked.matched, true);
+    }
+}
+
+#[test]
+fn check_specifics_default() {
     let engine = get_blocker_engine();
     {
         let checked = engine.check_network_urls("https://www.youtube.com/youtubei/v1/log_event?alt=json&key=AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8", "", "");


### PR DESCRIPTION
Fixes the case with filter tokenisation where `||www.facebook.com/*/plugin` does not get picked up when matching `https://www.facebook.com/v3.2/plugins/comments.ph`

Adds test case to catch regressions if engine tags get dropped when deserialising