### PR TITLE
changes tag retention behaviour

### DIFF
--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -38,7 +38,10 @@ pub struct Blocker {
     redirects: NetworkFilterList,
     filters_tagged: NetworkFilterList,
     filters: NetworkFilterList,
-
+    
+    // Do not serialize enabled tags - when deserializing, tags of the existing
+    // instance (the one we are recreating lists into) are maintained
+    #[serde(skip_serializing, skip_deserializing)]
     tags_enabled: HashSet<String>,
     tagged_filters_all: Vec<NetworkFilter>,
 
@@ -224,6 +227,10 @@ impl Blocker {
             .collect();
         self.filters_tagged = NetworkFilterList::new(filters, self.enable_optimizations);
         self
+    }
+
+    pub fn tags_enabled(&self) -> Vec<String> {
+        self.tags_enabled.iter().cloned().collect()
     }
 }
 

--- a/tests/legacy_harness.rs
+++ b/tests/legacy_harness.rs
@@ -308,6 +308,7 @@ mod legacy_check_match {
         engine.with_tags(tags);
             
         let mut engine_deserialized = Engine::from_rules(&vec![]);          // second empty
+        engine_deserialized.with_tags(tags);
         {
             let engine_serialized = engine.serialize().unwrap();
             engine_deserialized.deserialize(&engine_serialized).unwrap();   // override from serialized copy


### PR DESCRIPTION
retain tags of current instance, do not serialize.

when deserializing, tags of the existing instance (the one we are recreating lists into) are maintained