### PR TITLE
adds functionality to add filters, check tags

### DIFF
--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -109,6 +109,41 @@ declare_types! {
             };
             Ok(JsNull::new().upcast())
         }
+
+        method tagExists(mut cx) {
+            let tag: String = cx.argument::<JsString>(0)?.value();
+
+            let this = cx.this();
+            let result = {
+                let guard = cx.lock();
+                let mut engine = this.borrow(&guard);
+                engine.tag_exists(&tag)
+            };
+            Ok(cx.boolean(result).upcast())
+        }
+
+        method clearTags(mut cx) {
+            let mut this = cx.this();
+            let guard = cx.lock();
+            {
+                let mut engine = this.borrow_mut(&guard);
+                // enabling an empty list of tags disables all tags
+                engine.tags_enable(&[]);
+            }
+            Ok(JsNull::new().upcast())
+        }
+
+        method addFilter(mut cx) {
+            let filter: String = cx.argument::<JsString>(0)?.value();
+
+            let mut this = cx.this();
+            let guard = cx.lock();
+            {
+                let mut engine = this.borrow_mut(&guard);
+                engine.filter_add(&filter);
+            }
+            Ok(JsNull::new().upcast())
+        }
     }
 }
 

--- a/tests/legacy_harness.rs
+++ b/tests/legacy_harness.rs
@@ -626,37 +626,26 @@ mod legacy_misc_tests {
     }
 
     #[test]
-    #[ignore] // Not Implemented
     fn serialization_tests() {
-        let engine = Engine::from_rules_debug(&[
+        let engine = Engine::from_rules_parametrised(&[
             String::from("||googlesyndication.com$third-party"),
             String::from("@@||googlesyndication.ca"),
             String::from("a$explicitcancel")
-        ]);
+        ], true, false);    // enable debugging and disable optimizations
 
         let serialized = engine.serialize().unwrap();
-        let mut engine2 = Engine::from_rules_debug(&[]);
+        let mut engine2 = Engine::from_rules_parametrised(&[], true, false);
         engine2.deserialize(&serialized).unwrap();
 
-        let f = NetworkFilter::parse("||googlesyndication.com$third-party", false);
-        let f2 = NetworkFilter::parse("||googleayndication.com$third-party", false);
-        
-        // TODO: implement methods to check for rule presence
-        // CHECK(client.hostAnchoredHashSet->Exists(f));
-        // CHECK(client2.hostAnchoredHashSet->Exists(f));
-        // CHECK(!client.hostAnchoredHashSet->Exists(f2));
-        // CHECK(!client2.hostAnchoredHashSet->Exists(f2));
+        assert!(engine.filter_exists("||googlesyndication.com$third-party"));
+        assert!(engine2.filter_exists("||googlesyndication.com$third-party"));
+        assert!(!engine.filter_exists("||googleayndication.com$third-party"));
+        assert!(!engine2.filter_exists("||googleayndication.com$third-party"));
 
-        let f3 = NetworkFilter::parse("@@||googlesyndication.ca", false);
-        let f4 = NetworkFilter::parse("googlesyndication.ca", false);
-        
-        // TODO: implement methods to check for rule presence
-        // CHECK(client.hostAnchoredExceptionHashSet->Exists(f3));
-        // CHECK(client2.hostAnchoredExceptionHashSet->Exists(f3));
-        // CHECK(!client.hostAnchoredExceptionHashSet->Exists(f4));
-        // CHECK(!client2.hostAnchoredExceptionHashSet->Exists(f4));
-        // CHECK(client.noFingerprintFilters[0].filterOption & FOExplicitCancel);
-        // CHECK(client2.noFingerprintFilters[0].filterOption & FOExplicitCancel);
+        assert!(engine.filter_exists("@@||googlesyndication.ca"));
+        assert!(engine2.filter_exists("@@||googlesyndication.ca"));
+        assert!(!engine.filter_exists("googlesyndication.ca"));
+        assert!(!engine2.filter_exists("googlesyndication.ca"));
     }
 
     #[test]


### PR DESCRIPTION
- `tagExists` and `clearTags` methods in the Node API
- `addFilter` method in the Node API

About adding filters: rule optimisations that combine rules together make it non-trivial to check whether or not a rule already exists - a rule fused from multiple rules looks very different from the original rule. Checking for existence is therefore only available when optimisations are siwtched off. With optimisations siwtched on, a rule will get added without checking if it already exists

Note the outer-most `Engine` and corresponding Node APIs fail quietly, with only stderr logging in case of errors with existence checking or addition