### PR TITLE
Update deprecated range patterns and use explicit dyn keyword

### DIFF
--- a/src/url_parser/parser.rs
+++ b/src/url_parser/parser.rs
@@ -319,9 +319,9 @@ impl Parser {
         debug_assert!(self.serialization.is_empty());
         while let Some(c) = input.next() {
             match c {
-                'a'...'z' => self.serialization.push(c),
-                'A'...'Z' => self.serialization.push(c.to_ascii_lowercase()),
-                '0'...'9' | '+' | '-' | '.' => self.serialization.push(c),
+                'a'..='z' => self.serialization.push(c),
+                'A'..='Z' => self.serialization.push(c.to_ascii_lowercase()),
+                '0'..='9' | '+' | '-' | '.' => self.serialization.push(c),
                 ':' => return Ok(input),
                 _ => {
                     self.serialization.clear();
@@ -534,6 +534,6 @@ fn c0_control_or_space(ch: char) -> bool {
 /// https://url.spec.whatwg.org/#ascii-alpha
 #[inline]
 pub fn ascii_alpha(ch: char) -> bool {
-    matches!(ch, 'a'...'z' | 'A'...'Z')
+    matches!(ch, 'a'..='z' | 'A'..='Z')
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -31,7 +31,7 @@ const TOKENS_MAX: usize = TOKENS_BUFFER_SIZE - TOKENS_BUFFER_RESERVED;
 
 fn fast_tokenizer_no_regex(
     pattern: &str,
-    is_allowed_code: &Fn(char) -> bool,
+    is_allowed_code: &dyn Fn(char) -> bool,
     skip_first_token: bool,
     skip_last_token: bool,
     tokens_buffer: &mut Vec<Hash>
@@ -80,7 +80,7 @@ fn fast_tokenizer_no_regex(
 
 fn fast_tokenizer(
     pattern: &str,
-    is_allowed_code: &Fn(char) -> bool,
+    is_allowed_code: &dyn Fn(char) -> bool,
     skip_first_token: bool,
     skip_last_token: bool,
     tokens_buffer: &mut Vec<Hash>) {


### PR DESCRIPTION
There's a bunch of warnings when compiling on Rust 1.38.0-nightly about deprecated syntax, notably:

```
trait objects without an explicit `dyn` are deprecated
`...` range patterns are deprecated
```