### PR TITLE
Includes uBO privacy.txt rules

### DIFF
--- a/src/filter_lists/default.rs
+++ b/src/filter_lists/default.rs
@@ -43,6 +43,18 @@ pub fn default_lists() -> Vec<FilterList> {
             base64_public_key: String::from(""),
         },
         FilterList {
+            uuid: String::from("744e5fb2-5446-4578-a097-68efd098ed5e"),
+            url: String::from(
+                "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/privacy.txt",
+            ),
+            title: String::from("uBlock filters – Privacy"),
+            langs: Vec::new(),
+            support_url: String::from("https://github.com/uBlockOrigin/uAssets"),
+            component_id: String::from(""),
+            base64_public_key: String::from(""),
+            
+        },
+        FilterList {
             uuid: String::from("2FBEB0BC-E2E1-4170-BAA9-05E76AAB5BA5"),
             url: String::from(
                 "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-unbreak.txt",

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -4,6 +4,7 @@ extern crate reqwest;
 use adblock::blocker::{Blocker, BlockerOptions};
 use adblock::engine::Engine;
 use adblock::filters::network::NetworkFilter;
+use adblock::utils;
 
 use serde::{Deserialize};
 use std::fs::File;
@@ -122,4 +123,35 @@ fn check_live_deserialized() {
             "Expected match {} for {} {} {}",
             req.blocked, req.url, req.sourceUrl, req.r#type);
     }
+}
+
+#[test]
+fn check_live_redirects() {
+    let mut engine = get_blocker_engine();
+    let resources_lines = utils::read_file_lines("data/uBlockOrigin/resources.txt");
+    let resources_str = resources_lines.join("\n");
+    engine.with_resources(&resources_str);
+    { 
+        let checked = engine.check_network_urls(
+            "https://c.amazon-adsystem.com/aax2/amzn_ads.js",
+            "https://aussieexotics.com/",
+            "script");
+        assert_eq!(checked.matched, true,
+            "Expected match, got filter {:?}, exception {:?}",
+            checked.filter, checked.exception);
+        assert!(checked.redirect.is_some());
+        // Check for the specific expected return script value in base64
+        assert_eq!(checked.redirect.unwrap(), "data:application/javascript;base64,KGZ1bmN0aW9uKCkgewoJaWYgKCBhbXpuYWRzICkgewoJCXJldHVybjsKCX0KCXZhciB3ID0gd2luZG93OwoJdmFyIG5vb3BmbiA9IGZ1bmN0aW9uKCkgewoJCTsKCX0uYmluZCgpOwoJdmFyIGFtem5hZHMgPSB7CgkJYXBwZW5kU2NyaXB0VGFnOiBub29wZm4sCgkJYXBwZW5kVGFyZ2V0aW5nVG9BZFNlcnZlclVybDogbm9vcGZuLAoJCWFwcGVuZFRhcmdldGluZ1RvUXVlcnlTdHJpbmc6IG5vb3BmbiwKCQljbGVhclRhcmdldGluZ0Zyb21HUFRBc3luYzogbm9vcGZuLAoJCWRvQWxsVGFza3M6IG5vb3BmbiwKCQlkb0dldEFkc0FzeW5jOiBub29wZm4sCgkJZG9UYXNrOiBub29wZm4sCgkJZGV0ZWN0SWZyYW1lQW5kR2V0VVJMOiBub29wZm4sCgkJZ2V0QWRzOiBub29wZm4sCgkJZ2V0QWRzQXN5bmM6IG5vb3BmbiwKCQlnZXRBZEZvclNsb3Q6IG5vb3BmbiwKCQlnZXRBZHNDYWxsYmFjazogbm9vcGZuLAoJCWdldERpc3BsYXlBZHM6IG5vb3BmbiwKCQlnZXREaXNwbGF5QWRzQXN5bmM6IG5vb3BmbiwKCQlnZXREaXNwbGF5QWRzQ2FsbGJhY2s6IG5vb3BmbiwKCQlnZXRLZXlzOiBub29wZm4sCgkJZ2V0UmVmZXJyZXJVUkw6IG5vb3BmbiwKCQlnZXRTY3JpcHRTb3VyY2U6IG5vb3BmbiwKCQlnZXRUYXJnZXRpbmc6IG5vb3BmbiwKCQlnZXRUb2tlbnM6IG5vb3BmbiwKCQlnZXRWYWxpZE1pbGxpc2Vjb25kczogbm9vcGZuLAoJCWdldFZpZGVvQWRzOiBub29wZm4sCgkJZ2V0VmlkZW9BZHNBc3luYzogbm9vcGZuLAoJCWdldFZpZGVvQWRzQ2FsbGJhY2s6IG5vb3BmbiwKCQloYW5kbGVDYWxsQmFjazogbm9vcGZuLAoJCWhhc0Fkczogbm9vcGZuLAoJCXJlbmRlckFkOiBub29wZm4sCgkJc2F2ZUFkczogbm9vcGZuLAoJCXNldFRhcmdldGluZzogbm9vcGZuLAoJCXNldFRhcmdldGluZ0ZvckdQVEFzeW5jOiBub29wZm4sCgkJc2V0VGFyZ2V0aW5nRm9yR1BUU3luYzogbm9vcGZuLAoJCXRyeUdldEFkc0FzeW5jOiBub29wZm4sCgkJdXBkYXRlQWRzOiBub29wZm4KCX07Cgl3LmFtem5hZHMgPSBhbXpuYWRzOwoJdy5hbXpuX2FkcyA9IHcuYW16bl9hZHMgfHwgbm9vcGZuOwoJdy5hYXhfd3JpdGUgPSB3LmFheF93cml0ZSB8fCBub29wZm47Cgl3LmFheF9yZW5kZXJfYWQgPSB3LmFheF9yZW5kZXJfYWQgfHwgbm9vcGZuOwp9KSgpOw==")
+    }
+    {
+        let checked = engine.check_network_urls(
+            "https://www.googletagservices.com/tag/js/gpt.js",
+            "https://winniethepooh.disney.com/",
+            "script");
+        assert_eq!(checked.matched, true,
+            "Expected match, got filter {:?}, exception {:?}",
+            checked.filter, checked.exception);
+        assert!(checked.redirect.is_some());
+    }
+    
 }


### PR DESCRIPTION
Ensures more of the polyfills (e.g. gpt.js) are returned for blocked requests