### PR TITLE
Bump handlebars version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -219,9 +219,9 @@
       }
     },
     "handlebars": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.1.tgz",
-      "integrity": "sha512-lj/malGM5VJjSeqhYVpoOBP3hsugN6uU9NlOvLqq6kSFASpveWVLj3kb1b3w7Q3umSPdRMR1kAbFH/5EEEPiIA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.1.tgz",
+      "integrity": "sha512-c0HoNHzDiHpBt4Kqe99N8tdLPKAnGCQ73gYMPWtAYM4PwGnf7xl8PBUHJqh9ijlzt2uQKaSRxbXRt+rZ7M2/kA==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",


### PR DESCRIPTION
The currently used version of `neon-cli` has a dependency on a version of `handlebars` vulnerable to https://www.npmjs.com/advisories/1164. This upgrades `handlebars` to a fixed version.