### PR TITLE
Add ABPindo regional list brave/ad-block/#229 (WIP)

### DIFF
--- a/src/filter_lists/regions.rs
+++ b/src/filter_lists/regions.rs
@@ -147,7 +147,7 @@ pub fn regions() -> Vec<FilterList> {
             base64_public_key: String::from("MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAraHfJfoceCra3QEYhK2Njl8oUvtDOiT60o/HjpSsarfEgIgCKgqF/sUGK2PVL4c2CsF+fG+YzI4eGrJ85rXL5Z47lmP666r9lZcMVoGs2L7RT8UvsVwpyxiH868kLVxeM0NBas/jIy7jAul5/fGf0fRUF0TbSIG/tghO8nR4bloYEbSri9BWcl6ccMfAKsIalNWnP3uifjC/t7BWIkY486zq/UPXdIuJbRPWqJDTS6EZH5ZXFDkLE8tta3OrRV7n3ei2HdyTnJOVj2DSskKWwAA7fpYGVnmJouBqg++kC6YqSnaW2ElVzQIaiRigwXj4keAZzMoDbTrGh7g+LSVngwIDAQAB")
         },
         FilterList {
-            uuid: String::from("d77410e1-3ce3-4bf3-9f56-9920fb66be92"),
+            uuid: String::from("D77410E1-3CE3-4BF3-9F56-9920FB66BE92"),
             url: String::from("https://raw.githubusercontent.com/heradhis/indonesianadblockrules/master/subscriptions/abpindo.txt"),
             title: String::from("INDO: Indonesia List"),
             langs: [String::from("fa")].to_vec(),

--- a/src/filter_lists/regions.rs
+++ b/src/filter_lists/regions.rs
@@ -147,6 +147,15 @@ pub fn regions() -> Vec<FilterList> {
             base64_public_key: String::from("MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAraHfJfoceCra3QEYhK2Njl8oUvtDOiT60o/HjpSsarfEgIgCKgqF/sUGK2PVL4c2CsF+fG+YzI4eGrJ85rXL5Z47lmP666r9lZcMVoGs2L7RT8UvsVwpyxiH868kLVxeM0NBas/jIy7jAul5/fGf0fRUF0TbSIG/tghO8nR4bloYEbSri9BWcl6ccMfAKsIalNWnP3uifjC/t7BWIkY486zq/UPXdIuJbRPWqJDTS6EZH5ZXFDkLE8tta3OrRV7n3ei2HdyTnJOVj2DSskKWwAA7fpYGVnmJouBqg++kC6YqSnaW2ElVzQIaiRigwXj4keAZzMoDbTrGh7g+LSVngwIDAQAB")
         },
         FilterList {
+            uuid: String::from("d77410e1-3ce3-4bf3-9f56-9920fb66be92"),
+            url: String::from("https://raw.githubusercontent.com/heradhis/indonesianadblockrules/master/subscriptions/abpindo.txt"),
+            title: String::from("INDO: Indonesia List"),
+            langs: [String::from("fa")].to_vec(),
+            support_url: String::from("https://github.com/ABPindo/indonesianadblockrules"),
+            component_id: String::from("dbcccdegkijbppmeaihneimbghfghkd2"),
+            base64_public_key: String::from("MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm3AZE2ne7R55X2j6RxAQHAZKl1hNPgwLOFsYpfAJ6m0uXmKJspguWxatJ9jDBbYLmtXnwX2WORILq1+r4kFtTcN8GNYe7/7o5yDLucI/W9d2vCjmEg95v50MzVQZSwd2gNZVZtL1s0S6pBwX0zI+6kHIFr2xqGV/FNE8L75f30rriQ0xKmenI1OWjyn8gNqIp4mKZW6XxkMRRS9+e0ynDi4ysQA9Ub5YHJxm0t62eqTmIyemgRhP6Rdbi0+GXbqFPjDfC26rtD3wy5f3aYL1V+2ADpdDyCeNlwCH7+vC7LWujqNTgK8wVJ4eH5VbUKC1e9cm/T57OsHJMDC5fbUuswIDAQAB")
+        },
+        FilterList {
             uuid: String::from("C3C2F394-D7BB-4BC2-9793-E0F13B2B5971"),
             url: String::from("https://raw.githubusercontent.com/farrokhi/adblock-iran/master/filter.txt"),
             title: String::from("IRN: AdBlock Iran Filter"),


### PR DESCRIPTION
From the request: https://github.com/brave/ad-block/issues/229 

Unsure how to generate `component_id` and `base64_public_key`