### PR TITLE
Return list of selectors instead of a full stylesheet

### DIFF
--- a/benches/bench_cosmetic_matching.rs
+++ b/benches/bench_cosmetic_matching.rs
@@ -52,7 +52,7 @@ fn by_classes_ids(c: &mut Criterion) {
             let (_, cosmetic_filters) = parse_filters(&rules, false, true, false);
             let cfcache = CosmeticFilterCache::new(cosmetic_filters);
             let exceptions = Default::default();
-            b.iter(|| cfcache.class_id_stylesheet(&vec!["ad".to_owned()][..], &vec!["ad".to_owned()][..], &exceptions))
+            b.iter(|| cfcache.hidden_class_id_selectors(&vec!["ad".to_owned()][..], &vec!["ad".to_owned()][..], &exceptions))
         }).with_function("many lists", move |b| {
             let rules = rules_from_lists(&vec![
                 "data/easylist.to/easylist/easylist.txt".to_owned(),
@@ -63,7 +63,7 @@ fn by_classes_ids(c: &mut Criterion) {
             let (_, cosmetic_filters) = parse_filters(&rules, false, true, false);
             let cfcache = CosmeticFilterCache::new(cosmetic_filters);
             let exceptions = Default::default();
-            b.iter(|| cfcache.class_id_stylesheet(&vec!["ad".to_owned()][..], &vec!["ad".to_owned()][..], &exceptions))
+            b.iter(|| cfcache.hidden_class_id_selectors(&vec!["ad".to_owned()][..], &vec!["ad".to_owned()][..], &exceptions))
         }).with_function("many matching classes and ids", move |b| {
             let rules = rules_from_lists(&vec![
                 "data/easylist.to/easylist/easylist.txt".to_owned(),
@@ -104,7 +104,7 @@ fn by_classes_ids(c: &mut Criterion) {
                 "header".to_owned(),
                 "advertisingModule160x600".to_owned(),
             ];
-            b.iter(|| cfcache.class_id_stylesheet(&class_list[..], &id_list[..], &exceptions))
+            b.iter(|| cfcache.hidden_class_id_selectors(&class_list[..], &id_list[..], &exceptions))
         })
         .throughput(Throughput::Elements(1))
         .sample_size(20)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -218,17 +218,18 @@ impl Engine {
     // Cosmetic filter functionality
 
     /// If any of the provided CSS classes or ids could cause a certain generic CSS hide rule
-    /// (i.e. `{ display: none !important; }`) to be required, this method will return a stylesheet
-    /// including it, providing that the corresponding rule does not have an exception.
+    /// (i.e. `{ display: none !important; }`) to be required, this method will return a list of
+    /// CSS selectors corresponding to rules referencing those classes or ids, provided that the
+    /// corresponding rules are not excepted.
     ///
     /// `exceptions` should be passed directly from `HostnameSpecificResources`.
-    pub fn class_id_stylesheet(&self, classes: &[String], ids: &[String], exceptions: &HashSet<String>) -> Option<String> {
-        self.cosmetic_cache.class_id_stylesheet(classes, ids, exceptions)
+    pub fn hidden_class_id_selectors(&self, classes: &[String], ids: &[String], exceptions: &HashSet<String>) -> Vec<String> {
+        self.cosmetic_cache.hidden_class_id_selectors(classes, ids, exceptions)
     }
 
     /// Returns a set of cosmetic filter resources required for a particular hostname. Once this
     /// has been called, all CSS ids and classes on a page should be passed to
-    /// `class_id_stylesheet` to obtain any stylesheets consisting of generic rules.
+    /// `hidden_class_id_selectors` to obtain any stylesheets consisting of generic rules.
     pub fn hostname_cosmetic_resources(&self, hostname: &str) -> HostnameSpecificResources {
         self.cosmetic_cache.hostname_cosmetic_resources(hostname)
     }


### PR DESCRIPTION
Changes in `brave-core` to determine the first/third-partyness of affected page elements before applying a particular hide rule require access to the original selectors provided by the adblock engine. Building a stylesheet is now delegated to the caller.