### PR TITLE
Forbid nth-ancestor cosmetic rules

### DIFF
--- a/src/filters/cosmetic.rs
+++ b/src/filters/cosmetic.rs
@@ -168,6 +168,7 @@ impl CosmeticFilter {
             || content_after_colon.starts_with("properties")
             || content_after_colon.starts_with("subject")
             || content_after_colon.starts_with("xpath")
+            || content_after_colon.starts_with("nth-ancestor")
             {
                 return Err(CosmeticFilterError::UnsupportedSyntax);
             }


### PR DESCRIPTION
The `nth-ancestor` procedural filter is currently not supported by `adblock-rust`, so it should be marked as unsupported syntax during parsing.