### PR TITLE
Force unused load_network and load_cosmetic to true when serializing

### DIFF
--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -91,7 +91,7 @@ pub struct Blocker {
     debug: bool,
     enable_optimizations: bool,
     _unused: bool,      // This field exists for backwards compatibility only.
-    _unused2: bool,     // This field exists for backwards compatibility only.
+    _unused2: bool,     // This field exists for backwards compatibility only, and *must* be true.
 
     #[serde(default)]
     resources: RedirectResourceStorage,
@@ -303,8 +303,8 @@ impl Blocker {
             // Options
             debug: options.debug,
             enable_optimizations: options.enable_optimizations,
-            _unused: false,
-            _unused2: false,
+            _unused: true,
+            _unused2: true,
 
             resources: RedirectResourceStorage::default(),
             #[cfg(feature = "object-pooling")]


### PR DESCRIPTION
Although these two fields are unused on new versions of this repo, they are still serialized with dummy values to maintain backwards compatibility.

In particular, the second field is checked by older versions of the repo to determine if network blocking should be short-circuited. Thus, it's important that this field stores a value of `true` when serializing DAT files that will be loaded across different versions of `adblock-rust`.