### PR TITLE
Clean index.node from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@ data/
 target/
 adblock-rust-wasm/
 native/target/
+native/index.node
 .git/
 .DS_Store
 .travis.yml


### PR DESCRIPTION
`index.node` is a large binary blob that's generated by `npm run install`; excluding it saves 5MB+ from the overall package size.