### PR TITLE
Added my Nordic list

### DIFF
--- a/src/filter_lists/regions.rs
+++ b/src/filter_lists/regions.rs
@@ -424,8 +424,8 @@ pub fn regions() -> Vec<FilterList> {
         },
         FilterList {
             uuid: String::from("xxxxxxxxxx"),
-            url: String::from("https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianExperimentalList%20alternate%20versions/NordicFiltersBrave.txt"),
-            title: String::from("Dandelion Sprout's Nordic Filters (for Brave Browser)"),
+            url: String::from("https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianList.txt"),
+            title: String::from("Dandelion Sprout's Nordic Filters"),
             langs: [String::from("nb"), String::from("nn"), String::from("no"), String::from("da"), String::from("is")].to_vec(),
             support_url: String::from("https://github.com/DandelionSprout/adfilt/issues"),
             component_id: String::from("xxxxxxxxxx"),

--- a/src/filter_lists/regions.rs
+++ b/src/filter_lists/regions.rs
@@ -421,6 +421,16 @@ pub fn regions() -> Vec<FilterList> {
             component_id: String::from("cklgijeopkpaadeipkhdaodemoenlene"),
             base64_public_key: String::from("MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAymFhKEG/UJ8ZyKjdx4xfRFtECXdWXixG8GoS3mrw/haeVQoB1jXmPBQTZfL2WGZqYvrAkHRRel7XEoZNYziP3bCYbS4yVqKnDUp1u5GIsMsN0Pff1O1SHEbqClb79vAVhftNq1VQkHPpXQdoSiINQ12Om8WbOIuaNxkrTToFW7XRMtbI3tluoLUSy9YTkCEGah68Dl1uL6nOzOxaMV1iQRRk5Pw4ugTzwGHHL2U2kDYDNrlywK8cUIFgtZskqQ/TF1zF6u9xTGjwjB9X319XrTg2llcojCgj/dllBuXL2aJoDsS3qAVzqbSYxIE6bQU8JX8wv+KCDMpJt/dHPQqOMwIDAQAB"),
             desc: String::from("Removes advertisements from Vietnamese websites")
+        },
+        FilterList {
+            uuid: String::from("xxxxxxxxxx"),
+            url: String::from("https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianExperimentalList%20alternate%20versions/NordicFiltersBrave.txt"),
+            title: String::from("Dandelion Sprout's Nordic Filters (for Brave Browser)"),
+            langs: [String::from("nb"), String::from("nn"), String::from("no"), String::from("da"), String::from("is")].to_vec(),
+            support_url: String::from("https://github.com/DandelionSprout/adfilt/issues"),
+            component_id: String::from("xxxxxxxxxx"),
+            base64_public_key: String::from("xxxxxxxxxx"),
+            desc: String::from("Removes advertisements from Norwegian, Danish and Icelandic websites")
         }
     ].to_vec()
 }

--- a/src/filter_lists/regions.rs
+++ b/src/filter_lists/regions.rs
@@ -424,8 +424,8 @@ pub fn regions() -> Vec<FilterList> {
         },
         FilterList {
             uuid: String::from("xxxxxxxxxx"),
-            url: String::from("https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianList.txt"),
-            title: String::from("Dandelion Sprout's Nordic Filters"),
+            url: String::from("https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianExperimentalList%20alternate%20versions/NordicFiltersBrave.txt"),
+            title: String::from("Dandelion Sprout's Nordic Filters (for Brave Browser)"),
             langs: [String::from("nb"), String::from("nn"), String::from("no"), String::from("da"), String::from("is")].to_vec(),
             support_url: String::from("https://github.com/DandelionSprout/adfilt/issues"),
             component_id: String::from("xxxxxxxxxx"),


### PR DESCRIPTION
In light of recent developments that gave me a pretty good list conversion script, and closer connections to Fanboy (who seem to occasionally contribute to you guys), I will hereby do this new attempt at getting my Nordic list added to Brave Browser's adblocker.

Some of the strings I replaced with `"xxxxxxxxxx"`, as it was not obvious to me how to fill them with correct information when they're edited with GitHub's web GUI. You should almost guaranteed have been given full rights to do changes of your own to my PR branch.