### PR TITLE
Adjust component_id/publickey to previous https://github.com/brave/adblock-rust/pull/89

### DIFF
--- a/src/filter_lists/regions.rs
+++ b/src/filter_lists/regions.rs
@@ -218,8 +218,8 @@ pub fn regions() -> Vec<FilterList> {
             title: String::from("Adguard Japanese filters (日本用フィルタ)"),
             langs: [String::from("ja")].to_vec(),
             support_url: String::from("https://github.com/AdguardTeam/AdguardFilters"),
-            component_id: String::from("ebdjjmkojbakgcbhjdjdjclomdelgjnc"),
-            base64_public_key: String::from("MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAytbDtYui42mkzrPa/7uUfSb9RmgzRjBmcYRxfxKdw97b23LuuprbkvVZC3SW7TTktk58k50XLXq7z+774E7/xj+FfhnsYPCHboIWTp5lsZWDORqDAQ9VM8kAFD2/HNDINbk0VIoR1sjKsiesgROiEikIgDwFWYpW1BuMwu9Dev1ts4NHKXxjvR8F7E5gzx0Kv6oHTXdet5D9hmCIvQg5Ttb9rQ49qTpy4b/QurlrqdNmZhNdkAQNFRow8lh5wZG6XhDjYBeS03D26HyYCAXPDUIPjC69O1HJDG6N+9I/qJOp5kI4PhbwPDGJQpmsE4NHheeiuptldaDc2rkEn4lU0wIDAQAB"),
+            component_id: String::from("ghnjmapememheddlfgmklijahiofgkea"),
+            base64_public_key: String::from("MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsOoGwN4i751gHi1QmHMkFZCXFPseO/Q8qKOQViZI7p6THKqF1G3uHNxh8NjwKfsdcJLyZbnWx7BvDeyUw3K9hqWw4Iq6C0Ta1YEqEJFhcltV7J7aCMPJHdjZk5rpya9eXTWX1hfIYOvujPisKuwMNUmnlpaeWThihf4twu9BUn/X6+jcaqVaQ73q5TLS5vp13A9q2qSbEa79f/uUT8oKzN4S/GorQ6faS4bOl3iHuCT9abVXdy80WSut4bBERKgbc+0aJvi1dhpbCeM4DxVViM2ZccKvxSpyx4NvWj56dNKqFLvzoA4/Chz1udxifIXUHh0701s1Y4fLpY0wWP0uXQIDAQAB"),
             desc: String::from("Removes advertisements from Japanese websites")
         },
         FilterList {


### PR DESCRIPTION
Fix component_id and base64_public_key to match previous version used in https://github.com/brave/adblock-rust/pull/89

