### PR TITLE
Ignore new :upward prefix

### DIFF
--- a/src/filters/cosmetic.rs
+++ b/src/filters/cosmetic.rs
@@ -169,6 +169,7 @@ impl CosmeticFilter {
             || content_after_colon.starts_with("subject")
             || content_after_colon.starts_with("xpath")
             || content_after_colon.starts_with("nth-ancestor")
+            || content_after_colon.starts_with("upward")
             {
                 return Err(CosmeticFilterError::UnsupportedSyntax);
             }


### PR DESCRIPTION
Recent commits in https://github.com/gorhill/uBlock/wiki/Procedural-cosmetic-filters#subjectupwardarg and https://github.com/gorhill/uBlock/commit/72bb70056843024b1a31fe1ab9c90bd4e8260ba2

This is replacing 'nth-ancestor`, but its probably safe to keep both in the ignore list.

