### PR TITLE
Allow optionally setting an external host resolver implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lifeguard 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -505,7 +505,7 @@ name = "futures-task"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2003,7 +2003,7 @@ dependencies = [
 "checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 "checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
-"checksum once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
+"checksum once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
 "checksum openssl 0.10.28 (registry+https://github.com/rust-lang/crates.io-index)" = "973293749822d7dd6370d6da1e523b0d1db19f06c459134c658b2a4261378b52"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)" = "1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,15 +19,15 @@ exclude = [
 
 [package.metadata.docs.rs]
 no-default-features = true
-features = ["default-not-docs-rs"]
+features = ["default-docs-rs"]
 
 [dependencies]
-addr = "0.2"
+addr = { version = "0.2", optional = true }
 url = "2.1"
 percent-encoding = "2.1"
 matches = "0.1"
 lazy_static = "1.4"
-once_cell = "1.2"
+once_cell = "1.4"
 regex = "1"
 bitflags = "1.2"
 itertools = "0.8"
@@ -79,13 +79,14 @@ name = "bench_cosmetic_matching"
 harness = false
 
 [features]
-# If disabling default features, be sure to explicitly re-enable the
-# "docs-rs-incompatible" feature, or else the library will not work correctly.
-default = ["default-not-docs-rs", "docs-rs-incompatible"]
-default-not-docs-rs = ["full-regex-handling", "object-pooling"]
+# If disabling default features, consider explicitly re-enabling the
+# "embedded-domain-resolver" feature.
+default = ["default-docs-rs", "docs-rs-incompatible"]
+default-docs-rs = ["full-regex-handling", "object-pooling"]
 full-domain-matching = []
 metrics = []
 full-regex-handling = []
 object-pooling = ["lifeguard"]
 css-validation = ["cssparser", "selectors"]
-docs-rs-incompatible = [] # psl prevents docs.rs builds, see https://github.com/rust-lang/docs.rs/issues/904
+embedded-domain-resolver = ["addr"] # Requires setting an external domain resolver if disabled.
+docs-rs-incompatible = ["embedded-domain-resolver"] # addr prevents docs.rs builds, see https://github.com/rust-lang/docs.rs/issues/904

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -22,9 +22,8 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "psl 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "seahash 3.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -520,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1244,7 +1243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2885278d5fe2adc2f75ced642d52d879bffaceb5a2e0b1d4309ffdfb239b454"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d9c79c952a4a139f44a0fe205c4ee66ce239c0e6ce72cd935f5f7e2f717549dd"
-"checksum once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "891f486f630e5c5a4916c7e16c4b24a53e78c860b646e9f8e005e4f16847bfed"
+"checksum once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
 "checksum openssl 0.10.20 (registry+https://github.com/rust-lang/crates.io-index)" = "5a0d6b781aac4ac1bd6cafe2a2f0ad8c16ae8e1dd5184822a16c50139f8838d9"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.43 (registry+https://github.com/rust-lang/crates.io-index)" = "33c86834957dd5b915623e94f2f4ab2c70dd8f6b70679824155d5ae21dbd495d"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -16,5 +16,5 @@ neon-build = "0.3.3"
 [dependencies]
 neon-serde = "0.3"
 serde =  { version = "1.0", features = ["derive", "rc"] }
-adblock = { path = "../", default-features = false, features = ["css-validation", "docs-rs-incompatible"] }
+adblock = { path = "../", default-features = false, features = ["css-validation", "embedded-domain-resolver"] }
 neon = "0.3.3"

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,4 @@
-use crate::url_parser::{get_host_domain, UrlParser};
+use crate::url_parser;
 use crate::utils;
 
 use idna;
@@ -217,8 +217,8 @@ impl<'a> Request {
         source_url: &str,
         request_type: &str,
     ) -> Result<Request, RequestError> {
-        if let Some(parsed_url) = Request::parse_url(&url) {
-            if let Some(parsed_source) = Request::parse_url(&source_url) {
+        if let Some(parsed_url) = url_parser::parse_url(&url) {
+            if let Some(parsed_source) = url_parser::parse_url(&source_url) {
                 let source_domain = parsed_source.domain();
 
                 let third_party = if source_domain.is_empty() {
@@ -263,14 +263,14 @@ impl<'a> Request {
     ) -> Request {
         let url_norm = url.to_ascii_lowercase();
 
-        let (source_domain_start, source_domain_end) = get_host_domain(&source_hostname);
+        let (source_domain_start, source_domain_end) = url_parser::get_host_domain(&source_hostname);
         let source_domain = &source_hostname[source_domain_start..source_domain_end];
 
         let splitter = url_norm.find(':').unwrap_or(0);
         let schema: &str = &url[..splitter];
 
         let third_party = if third_party_request.is_none() {
-            let (domain_start, domain_end) = get_host_domain(&hostname);
+            let (domain_start, domain_end) = url_parser::get_host_domain(&hostname);
             let domain = &hostname[domain_start..domain_end];
             if source_domain.is_empty() {
                 None

--- a/tests/ublock-coverage.rs
+++ b/tests/ublock-coverage.rs
@@ -2,8 +2,6 @@ extern crate adblock;
 
 use adblock::engine::Engine;
 use adblock::lists::FilterFormat;
-use adblock::request::Request;
-use adblock::url_parser::UrlParser;
 use adblock::utils::rules_from_lists;
 
 use serde::Deserialize;
@@ -220,8 +218,8 @@ fn check_matching_hostnames() {
     let engine = get_blocker_engine();
 
     for req in requests {
-        let url_host = Request::parse_url(&req.url).unwrap();
-        let source_host = Request::parse_url(&req.sourceUrl).unwrap();
+        let url_host = adblock::url_parser::parse_url(&req.url).unwrap();
+        let source_host = adblock::url_parser::parse_url(&req.sourceUrl).unwrap();
         let domain = url_host.domain();
         let source_domain = source_host.domain();
         let third_party = if source_domain.is_empty() {


### PR DESCRIPTION
Fixes #125. Users of the library can now disable the `embedded-domain-resolver` feature, implement `adblock::url_parser::ResolvesDomain` on a custom struct, and pass it to `adblock` using `adblock::url_parser::set_domain_resolver`.

Also should fix #86, by disabling the `addr` dependency on docs.rs builds.