### PR TITLE
Fix multiple hostname regex filters are not working properly.

### DIFF
--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -718,9 +718,11 @@ impl NetworkFilter {
         }
 
         // Append tokens from hostname, if any
-        if let Some(hostname) = self.hostname.as_ref() {
-            let mut hostname_tokens = utils::tokenize(&hostname);
-            tokens.append(&mut hostname_tokens);
+        if !self.mask.contains(NetworkFilterMask::IS_HOSTNAME_REGEX) {
+            if let Some(hostname) = self.hostname.as_ref()  {
+                let mut hostname_tokens = utils::tokenize(&hostname);
+                tokens.append(&mut hostname_tokens);
+            }
         }
 
         // If we got no tokens for the filter/hostname part, then we will dispatch


### PR DESCRIPTION
The blocker is not working under multiple rules with hostname regex.

For example, rules like
" ||alimc*.top^$domain=letv.com
||aa*.top^$domain=letv.com",
url like "https://r.alimc1.top/test.js" with domain "https://minisite.letv.com", which should matches but actually not.

I have figured out that the histogram of the tokens give the first fiter ("||alimc*.top^$domain=letv.com") the least count token "alimc", and url has the token "alimc1", so will not pick the bucket which contains the filter, then match failed.

I've tried to fix this by not recording the hostname of the filters with type of IS_HOSTNAME_REGEX .