### PR TITLE
Replace Rc with Arc

### DIFF
--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -7,8 +7,7 @@ use std::fmt;
 use crate::request;
 use crate::utils;
 use crate::utils::Hash;
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::{Arc, RwLock};
 use twoway;
 
 pub const TOKENS_BUFFER_SIZE: usize = 200;
@@ -205,7 +204,7 @@ pub struct NetworkFilter {
     // When the Regex hasn't been compiled, <None> is stored, afterwards Arc to Some<CompiledRegex>
     // to avoid expensive cloning of the Regex itself.
     #[serde(skip_serializing, skip_deserializing)]
-    regex: Rc<RefCell<Option<Rc<CompiledRegex>>>>
+    regex: Arc<RwLock<Option<Arc<CompiledRegex>>>>
 }
 
 impl NetworkFilter {
@@ -596,7 +595,7 @@ impl NetworkFilter {
             fuzzy_signature: maybe_fuzzy_signature,
             opt_domains_union,
             opt_not_domains_union,
-            regex: Rc::new(RefCell::new(None))
+            regex: Arc::new(RwLock::new(None))
         })
     }
 
@@ -838,7 +837,7 @@ impl NetworkFilter {
 
 pub trait NetworkMatchable {
     fn matches(&self, request: &request::Request) -> bool;
-    fn get_regex(&self) -> Rc<CompiledRegex>;
+    fn get_regex(&self) -> Arc<CompiledRegex>;
 }
 
 impl NetworkMatchable for NetworkFilter {
@@ -847,33 +846,28 @@ impl NetworkMatchable for NetworkFilter {
     }
 
     // Lazily get the regex if the filter has one
-    fn get_regex(&self) -> Rc<CompiledRegex> {
+    fn get_regex(&self) -> Arc<CompiledRegex> {
         if !self.is_regex() && !self.is_complete_regex() {
-            return Rc::new(CompiledRegex::MatchAll);
+            return Arc::new(CompiledRegex::MatchAll);
         }
         // Create a new scope to contain the lifetime of the
-        // dynamic borrow
+        // dynamic read borrow
         {
-            let mut cache = self.regex.borrow_mut();
+            let cache = self.regex.as_ref().read().unwrap();
             if cache.is_some() {
-                return cache.as_ref().unwrap().clone(); // Only clones the Arc, not the entire regex
+                return cache.as_ref().unwrap().clone();
             }
-
-            let regex = compile_regex(
-                &self.filter,
-                self.is_right_anchor(),
-                self.is_left_anchor(),
-                self.is_complete_regex(),
-            );
-
-            *cache = Some(Rc::new(regex));
         }
-        // Recursive call to return the just-cached value.
-        // Note that if we had not let the previous borrow
-        // of the cache fall out of scope then the subsequent
-        // recursive borrow would cause a dynamic thread panic.
-        // This is the major hazard of using `RefCell`.
-        self.get_regex()
+        let mut cache = self.regex.as_ref().write().unwrap();
+        let regex = compile_regex(
+            &self.filter,
+            self.is_right_anchor(),
+            self.is_left_anchor(),
+            self.is_complete_regex(),
+        );
+        let arc_regex = Arc::new(regex);
+        *cache = Some(arc_regex.clone());
+        arc_regex
     }
 }
 
@@ -3129,7 +3123,7 @@ mod match_tests {
         {
             let filter = r#"/^https?:\/\/([0-9a-z\-]+\.)?(9anime|animeland|animenova|animeplus|animetoon|animewow|gamestorrent|goodanime|gogoanime|igg-games|kimcartoon|memecenter|readcomiconline|toonget|toonova|watchcartoononline)\.[a-z]{2,4}\/(?!([Ee]xternal|[Ii]mages|[Ss]cripts|[Uu]ploads|ac|ajax|assets|combined|content|cov|cover|(img\/bg)|(img\/icon)|inc|jwplayer|player|playlist-cat-rss|static|thumbs|wp-content|wp-includes)\/)(.*)/$image,other,script,~third-party,xmlhttprequest,domain=~animeland.hu"#;
             let network_filter = NetworkFilter::parse(filter, true).unwrap();
-            let regex = Rc::try_unwrap(network_filter.get_regex()).unwrap();
+            let regex = Arc::try_unwrap(network_filter.get_regex()).unwrap();
             assert!(
                 matches!(regex, CompiledRegex::Compiled(_)),
                 "Generated incorrect regex: {:?}",


### PR DESCRIPTION
This allows me to build [`python-adblock`](https://github.com/ArniDagur/python-adblock) with `PyO3` version `0.11.1` without any thread safety errors, if I disable the `object-pooling` feature.