### PR TITLE
Fix filters not work with ports number.

### DIFF
--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -463,41 +463,15 @@ impl NetworkFilter {
                 let slash_index = twoway::find_str(&line[filter_index_start..], "/");
                 slash_index
                     .map(|i| {
-                        // Handle filters with port number
-                        let colon_index = twoway::find_str(&line[filter_index_start..filter_index_start + i], ":");
-                        colon_index
-                            .map(|c| {
-                                hostname = Some(String::from(
-                                    &line[filter_index_start..filter_index_start + c],
-                                ));
-                                filter_index_start += c;
-                            })
-                            .or_else(|| {
-                                hostname = Some(String::from(
-                                    &line[filter_index_start..filter_index_start + i],
-                                ));
-                                filter_index_start += i;
-                                mask.set(NetworkFilterMask::IS_LEFT_ANCHOR, true);
-                                None
-                            });
+                        hostname = Some(String::from(
+                            &line[filter_index_start..filter_index_start + i],
+                        ));
+                        filter_index_start += i;
+                        mask.set(NetworkFilterMask::IS_LEFT_ANCHOR, true);
                     })
                     .or_else(|| {
-                        // Handle filters with port number
-                        let colon_index =
-                            twoway::find_str(&line[filter_index_start..filter_index_end], ":");
-                        colon_index
-                            .map(|c| {
-                                hostname = Some(String::from(
-                                    &line[filter_index_start..filter_index_start + c],
-                                ));
-                                filter_index_start += c;
-                            })
-                            .or_else(|| {
-                                hostname =
-                                    Some(String::from(&line[filter_index_start..filter_index_end]));
-                                filter_index_start = filter_index_end;
-                                None
-                            });
+                        hostname = Some(String::from(&line[filter_index_start..filter_index_end]));
+                        filter_index_start = filter_index_end;
                         None
                     });
             }
@@ -1052,7 +1026,7 @@ fn is_anchored_by_hostname(filter_hostname: &str, hostname: &str, wildcard_filte
             // Examples (filter_hostname, hostname):
             //   * (foo, foo.com)
             //   * (sub.foo, sub.foo.com)
-            wildcard_filter_hostname || filter_hostname.ends_with('.') || hostname[filter_hostname_len..].starts_with('.')
+            wildcard_filter_hostname || filter_hostname.ends_with('.') || hostname[filter_hostname_len..].starts_with('.') || hostname[filter_hostname_len..].starts_with(':')
         } else if match_index == hostname_len - filter_hostname_len {
             // `filter_hostname` is a suffix of `hostname`.
             //
@@ -1062,7 +1036,7 @@ fn is_anchored_by_hostname(filter_hostname: &str, hostname: &str, wildcard_filte
             filter_hostname.starts_with('.') || hostname[match_index - 1..].starts_with('.')
         } else {
             // `filter_hostname` is infix of `hostname` and needs match full labels
-            (wildcard_filter_hostname || filter_hostname.ends_with('.') || hostname[filter_hostname_len..].starts_with('.'))
+            (wildcard_filter_hostname || filter_hostname.ends_with('.') || hostname[filter_hostname_len..].starts_with('.') || hostname[filter_hostname_len..].starts_with(':'))
                 && (filter_hostname.starts_with('.') || hostname[match_index - 1..].starts_with('.'))
         }
     }
@@ -1225,6 +1199,15 @@ fn check_pattern_hostname_right_anchor_filter(
                     // positive like ||foo.bar which would match https://foo.bar.baz where
                     // ||foo.bar^ would not.
                     FilterPart::Empty => {
+                        // If the filter has a port number, we should check if the request exactly matches.
+                        // If the filter has no port number, we should check whether the host name part of the request matches.
+                        if !twoway::find_str(&hostname, ":").is_some() {
+                            if let Some(request_colon_index) = twoway::find_str(&request.hostname, ":") {
+                                return request.hostname[..request_colon_index].len() == hostname.len()        
+                                    || request.hostname[..request_colon_index].ends_with(hostname)
+                            } 
+                        }
+                        
                         request.hostname.len() == hostname.len()        // if lengths are equal, hostname equality is implied by anchoring check
                             || request.hostname.ends_with(hostname)
                     }
@@ -2878,6 +2861,26 @@ mod match_tests {
         filter_match_url(
             "||test.com:8080/test",
             "https://test.com:8080/test/1.jpg",
+            true,
+        );
+        filter_match_url(
+            "||test.com:8081/test",
+            "https://test.com:8080/test/1.jpg",
+            false,
+        );
+        filter_match_url(
+            "||2008xxx.com^",
+            "https://www.2008xxx.com:888/a/a.html",
+            true,
+        );
+        filter_match_url(
+            "||2008xxx.com:8^",
+            "https://www.2008xxx.com:888/a/a.html",
+            false,
+        );
+        filter_match_url(
+            "||2008xxx.com:8^",
+            "https://www.2008xxx.com:8/a/a.html",
             true,
         );
     }

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -463,15 +463,41 @@ impl NetworkFilter {
                 let slash_index = twoway::find_str(&line[filter_index_start..], "/");
                 slash_index
                     .map(|i| {
-                        hostname = Some(String::from(
-                            &line[filter_index_start..filter_index_start + i],
-                        ));
-                        filter_index_start += i;
-                        mask.set(NetworkFilterMask::IS_LEFT_ANCHOR, true);
+                        // Handle filters with port number
+                        let colon_index = twoway::find_str(&line[filter_index_start..filter_index_start + i], ":");
+                        colon_index
+                            .map(|c| {
+                                hostname = Some(String::from(
+                                    &line[filter_index_start..filter_index_start + c],
+                                ));
+                                filter_index_start += c;
+                            })
+                            .or_else(|| {
+                                hostname = Some(String::from(
+                                    &line[filter_index_start..filter_index_start + i],
+                                ));
+                                filter_index_start += i;
+                                mask.set(NetworkFilterMask::IS_LEFT_ANCHOR, true);
+                                None
+                            });
                     })
                     .or_else(|| {
-                        hostname = Some(String::from(&line[filter_index_start..filter_index_end]));
-                        filter_index_start = filter_index_end;
+                        // Handle filters with port number
+                        let colon_index =
+                            twoway::find_str(&line[filter_index_start..filter_index_end], ":");
+                        colon_index
+                            .map(|c| {
+                                hostname = Some(String::from(
+                                    &line[filter_index_start..filter_index_start + c],
+                                ));
+                                filter_index_start += c;
+                            })
+                            .or_else(|| {
+                                hostname =
+                                    Some(String::from(&line[filter_index_start..filter_index_end]));
+                                filter_index_start = filter_index_end;
+                                None
+                            });
                         None
                     });
             }
@@ -2840,6 +2866,20 @@ mod match_tests {
         filter_match_url("||*com/bar", "https://foo.com/bar", true);
         filter_match_url("||*com*/bar", "https://foo.com/bar", true);
         filter_match_url("||*com*^bar", "https://foo.com/bar", true);
+    }
+
+    #[test]
+    fn check_host_with_port_works() {
+        filter_match_url(
+            "||2008xxx.com:888",
+            "https://www.2008xxx.com:888/a/a.html",
+            true,
+        );
+        filter_match_url(
+            "||test.com:8080/test",
+            "https://test.com:8080/test/1.jpg",
+            true,
+        );
     }
 
     #[test]

--- a/src/url_parser/parser.rs
+++ b/src/url_parser/parser.rs
@@ -483,9 +483,17 @@ impl Parser {
         let mut has_ignored_chars = false;
         let mut non_ignored_chars = 0;
         let mut bytes = 0;
+        let mut has_port_number = false;
         for c in input_str.chars() {
             match c {
-                ':' if !inside_square_brackets => break,
+                ':' => {
+                    if !inside_square_brackets && has_port_number {
+                        break;
+                    }
+                    if !has_port_number {
+                        has_port_number = true;
+                    }
+                }
                 '\\' if scheme_type.is_special() => break,
                 '/' | '?' | '#' => break,
                 '\t' | '\n' | '\r' => {


### PR DESCRIPTION
The filter does not work properly when processing rules like "||abc.com:8080". The parsed filter will not match url "https://www.abc.com:8080/". Because the parsed filter has host name "abc.com:8080" , and the parsed url request has  host name "abc.com" without port number. I tried to fix it , and also wrote some test cases.