### PR TITLE
update DAT generation for part 1 of redirect/important fixes

### DIFF
--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -309,6 +309,13 @@ impl Blocker {
                 } else if filter.is_exception() {
                     exceptions.push(filter);
                 } else if filter.is_important() {
+                    // Add `$important,redirect` filters twice for temporary compatibility while
+                    // fixing #131
+                    if filter.is_redirect() {
+                        let mut filter = filter.clone();
+                        filter.mask.set(crate::filters::network::NetworkFilterMask::IS_IMPORTANT, false);
+                        redirects.push(filter);
+                    }
                     importants.push(filter);
                 } else if filter.is_redirect() {
                     redirects.push(filter);


### PR DESCRIPTION
Provides the necessary server-side fixes for #131.

Overall strategy is to map any `$important,redirect` rules at serverside DAT creation into two separate filters: one placed into the `importants` list, the other one placed into the `redirects` list without the `important` option. This mirrors uBlock Origin's `redirect`-splitting behavior. Then, later, the client will be updated to check redirects regardless of whether or not an important filter was found. This will allow `redirect`s to work even when a separate `important` rule exists.

Technically, the `redirect` option should not exist on the rule in the `important`s list. However, it's left in place not to break older clients.

This way, older clients will check for importants, find the `$important,redirect` rule, and use both options from it.
Newer clients will check importants and redirects independently, find one in each, and use the corresponding options from each.

The client-side code can be updated much later to correctly split `$redirect` rules into one with an internal redirect flag, and one blocking rule, giving us trivial support for the `$redirect-rule` option as well.