### PR TITLE
Remove $fuzzy option

### DIFF
--- a/benches/bench_redirect_performance.rs
+++ b/benches/bench_redirect_performance.rs
@@ -67,7 +67,6 @@ fn get_redirect_rules() -> Vec<NetworkFilter> {
             rule.mask.remove(NetworkFilterMask::IS_HOSTNAME_REGEX);
             rule.mask.remove(NetworkFilterMask::IS_REGEX);
             rule.mask.remove(NetworkFilterMask::IS_COMPLETE_REGEX);
-            rule.mask.remove(NetworkFilterMask::FUZZY_MATCH);
 
             rule
         })

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -932,36 +932,6 @@ mod tests {
     }
 
     #[test]
-    fn network_filter_list_check_works_fuzzy_filter() {
-        let filters = vec![
-            "f$fuzzy",
-            "foo$fuzzy",
-            "foo/bar$fuzzy",
-            "foo bar$fuzzy",
-            "foo bar baz$fuzzy",
-            "coo car caz 42$fuzzy",
-        ];
-
-        let url_results = vec![
-            ("https://bar.com/f", true),
-            ("https://bar.com/foo", true),
-            ("https://bar.com/foo/baz", true),
-            ("http://bar.foo.baz", true),
-            ("http://car.coo.caz.43", false),
-        ];
-
-        let request_expectations: Vec<_> = url_results
-            .into_iter()
-            .map(|(url, expected_result)| {
-                let request = Request::from_url(url).unwrap();
-                (request, expected_result)
-            })
-            .collect();
-
-        test_requests_filters(&filters, &request_expectations);
-    }
-
-    #[test]
     fn network_filter_list_check_works_hostname_anchor() {
         let filters = vec![
             "||foo.com",

--- a/src/content_blocking.rs
+++ b/src/content_blocking.rs
@@ -126,8 +126,6 @@ pub enum CbRuleCreationFailure {
     NoSupportedNetworkOptions(NetworkFilterMask),
     /// Network rules with redirect options cannot be represented in content blocking syntax.
     NetworkRedirectUnsupported,
-    /// Network rules with fuzzy matching options cannot be represented in content blocking syntax.
-    NetworkFuzzyMatchUnsupported,
     /// Network rules with generichide options cannot be supported in content blocking syntax.
     NetworkGenerichideUnsupported,
     /// Network rules with explicitcancel options cannot be supported in content blocking syntax.
@@ -220,9 +218,6 @@ impl TryFrom<NetworkFilter> for CbRuleEquivalent {
         if let Some(raw_line) = v.raw_line {
             if v.redirect.is_some() {
                 return Err(CbRuleCreationFailure::NetworkRedirectUnsupported);
-            }
-            if v.mask.contains(NetworkFilterMask::FUZZY_MATCH) {
-                return Err(CbRuleCreationFailure::NetworkFuzzyMatchUnsupported);
             }
             if v.mask.contains(NetworkFilterMask::GENERIC_HIDE) {
                 return Err(CbRuleCreationFailure::NetworkGenerichideUnsupported);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -556,4 +556,25 @@ mod tests {
             assert_eq!(result.generichide, expected_generichide);
         });
     }
+
+    #[test]
+    fn important_redirect() {
+        let mut filter_set = FilterSet::new(true);
+        filter_set.add_filters(&vec![
+            "||addthis.com^$important,3p,domain=~missingkids.com|~missingkids.org|~sainsburys.jobs|~sitecore.com|~amd.com".to_string(),
+            "||addthis.com/*/addthis_widget.js$script,redirect=addthis.com/addthis_widget.js".to_string(),
+        ], FilterFormat::Standard);
+        let mut engine = Engine::from_filter_set(filter_set, false);
+
+        engine.add_resource(Resource {
+            name: "addthis.com/addthis_widget.js".to_owned(),
+            aliases: vec![],
+            kind: ResourceType::Mime(MimeType::ApplicationJavascript),
+            content: "window.addthis = undefined".to_string(),
+        });
+
+        let result = engine.check_network_urls("https://s7.addthis.com/js/250/addthis_widget.js?pub=resto", "https://www.rhmodern.com/catalog/product/product.jsp?productId=prod14970086&categoryId=cat7150028", "script");
+
+        assert!(result.redirect.is_some());
+    }
 }

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -119,8 +119,7 @@ impl Optimization for SimplePatternGroup {
         format!("{:b}:{:?}", filter.mask, filter.is_complete_regex())
     }
     fn select(&self, filter: &NetworkFilter) -> bool {
-        !filter.is_fuzzy()
-            && filter.opt_domains.is_none()
+        filter.opt_domains.is_none()
             && filter.opt_not_domains.is_none()
             && !filter.is_hostname_anchor()
             && !filter.is_redirect()
@@ -185,8 +184,7 @@ impl Optimization for UnionDomainGroup {
     }
 
     fn select(&self, filter: &NetworkFilter) -> bool {
-        !filter.is_fuzzy()
-            && !filter.is_csp()
+        !filter.is_csp()
             && !filter.has_bug()
             && (filter.opt_domains.is_some() || filter.opt_not_domains.is_some())
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -134,25 +134,6 @@ fn compact_tokens<T: std::cmp::Ord>(tokens: &mut Vec<T>) {
     tokens.dedup();
 }
 
-
-pub fn create_fuzzy_signature(pattern: &str) -> Vec<Hash> {
-    let mut tokens: Vec<Hash> = Vec::with_capacity(TOKENS_BUFFER_SIZE);
-    fast_tokenizer(pattern, &is_allowed_filter, false, false, &mut tokens);
-    compact_tokens(&mut tokens);
-    tokens
-}
-
-
-pub fn create_combined_fuzzy_signature(patterns: &[String]) -> Vec<Hash> {
-    let mut tokens: Vec<Hash> = Vec::with_capacity(TOKENS_BUFFER_SIZE);
-    for p in patterns {
-        fast_tokenizer(p, &is_allowed_filter, false, false, &mut tokens);
-    }
-
-    compact_tokens(&mut tokens);
-    tokens
-}
-
 pub fn bin_lookup<T: Ord>(arr: &[T], elt: T) -> bool {
     arr.binary_search(&elt).is_ok()
 }
@@ -299,16 +280,6 @@ mod tests {
             tokenize("*foo.barƬ*").as_slice(),
             t(&vec![]).as_slice()
         );
-    }
-
-    #[test]
-    fn create_fuzzy_signature_works() {
-        assert_eq!(create_fuzzy_signature("").as_slice(), t(&vec![]).as_slice());
-        let mut tokens = t(&vec!["bar", "foo"]);
-        tokens.sort_unstable();
-        assert_eq!(create_fuzzy_signature("foo bar").as_slice(), tokens.as_slice());
-        assert_eq!(create_fuzzy_signature("bar foo").as_slice(), tokens.as_slice());
-        assert_eq!(create_fuzzy_signature("foo bar foo foo").as_slice(), tokens.as_slice());
     }
 
     #[test]


### PR DESCRIPTION
The `$fuzzy` option appears to be specific to the Cliqz adblocker, but otherwise nonstandard and not present in any other adblockers or lists. The 32-bit `NetworkFilterMask` is close to getting fully used up; this is a good candidate for removal.