### PR TITLE
Fix filters not work with ports number.

### DIFF
--- a/src/url_parser/parser.rs
+++ b/src/url_parser/parser.rs
@@ -483,9 +483,17 @@ impl Parser {
         let mut has_ignored_chars = false;
         let mut non_ignored_chars = 0;
         let mut bytes = 0;
+        let mut has_port_number = false;
         for c in input_str.chars() {
             match c {
-                ':' if !inside_square_brackets => break,
+                ':' => {
+                    if !inside_square_brackets && has_port_number {
+                        break;
+                    }
+                    if !has_port_number {
+                        has_port_number = true;
+                    }
+                }
                 '\\' if scheme_type.is_special() => break,
                 '/' | '?' | '#' => break,
                 '\t' | '\n' | '\r' => {


### PR DESCRIPTION
This is a closed pull request that I created a few days ago, I fix some match errors and then resubmit the changes https://github.com/brave/adblock-rust/pull/134.

> The filter does not work properly when processing rules like "||abc.com:8080". The parsed filter will not match url "https://www.abc.com:8080/". Because the parsed filter has host name "abc.com:8080" , and the parsed url request has host name "abc.com" without port number. I tried to fix it , and also wrote some test cases.