### PR TITLE
Fix document filter not works.

### DIFF
--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -81,7 +81,8 @@ bitflags::bitflags! {
             Self::FROM_STYLESHEET.bits |
             Self::FROM_SUBDOCUMENT.bits |
             Self::FROM_WEBSOCKET.bits |
-            Self::FROM_XMLHTTPREQUEST.bits;
+            Self::FROM_XMLHTTPREQUEST.bits | 
+            Self::FROM_DOCUMENT.bits;
 
         // Unless filter specifies otherwise, all these options are set by default
         const DEFAULT_OPTIONS = Self::FROM_ANY.bits |
@@ -2943,6 +2944,23 @@ mod match_tests {
 
         filter_match_url("foo", "https://example.com/Ѥ/foo", true);
         filter_match_url("Ѥ", "https://example.com/Ѥ/foo", true);
+    }
+
+    #[test]
+    fn check_document_filter_works() {
+        {
+            let filter = "||abc.com$document";
+                let network_filter = NetworkFilter::parse(filter, true).unwrap();
+                let url = "https://abc.com/";
+                let source = "";
+                let request = request::Request::from_urls(url, source, "document").unwrap();
+                assert!(
+                    network_filter.matches(&request) == true,
+                    "Expected match for {} on {}",
+                    filter,
+                    url
+                );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Filters such as "||abc.com$document" were not processed correctly.  Due to the following code 
```
pub fn check_cpt_allowed(filter: &NetworkFilter, cpt: &request::RequestType) -> bool {
match NetworkFilterMask::from(cpt) {
        NetworkFilterMask::FROM_DOCUMENT => filter.get_cpt_mask().contains(NetworkFilterMask::FROM_DOCUMENT) || filter.is_exception(),
       mask => filter.mask.contains(mask),
    }
}
```
```
 const FROM_ANY = Self::FROM_FONT.bits |
            Self::FROM_IMAGE.bits |
            Self::FROM_MEDIA.bits |
            Self::FROM_OBJECT.bits |
            Self::FROM_OTHER.bits |
            Self::FROM_PING.bits |
            Self::FROM_SCRIPT.bits |
            Self::FROM_STYLESHEET.bits |
            Self::FROM_SUBDOCUMENT.bits |
            Self::FROM_WEBSOCKET.bits |
            Self::FROM_XMLHTTPREQUEST.bits | 
            Self::FROM_DOCUMENT.bits;
```

```
fn get_cpt_mask(&self) -> NetworkFilterMask {
        self.mask & NetworkFilterMask::FROM_ANY
    }
```
Since the bit of FROM_DOCUMENT is not add to FROM_ANY, the return value of get_cpt_mask will never contain the bit, so will never match the URL .
