### PR TITLE
Add support for document option on network filters

### DIFF
--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -1440,12 +1440,11 @@ mod legacy_rule_parsing_tests {
     // easyList = { 24478, 31144, 0, 5589 };
     // not handling (and not including) filters with the following options:
     // - $popup
-    // - $document
     // - $elemhide
     // difference from original counts caused by not handling document/subdocument options and possibly miscounting on the blocker side.
     // Printing all non-cosmetic, non-html, non-comment/-empty rules and ones with no unsupported options yields 29142 items
     // This engine also handles 3 rules that old one does not
-    const EASY_LIST: ListCounts = ListCounts { filters: 24062+3, cosmetic_filters: 31163, exceptions: 5800 };
+    const EASY_LIST: ListCounts = ListCounts { filters: 24065, cosmetic_filters: 31163, exceptions: 5796 };
     // easyPrivacy = { 11817, 0, 0, 1020 };
     // differences in counts explained by hashset size underreporting as detailed in the next two cases
     const EASY_PRIVACY: ListCounts = ListCounts { filters: 11889, cosmetic_filters: 0, exceptions: 1021 };

--- a/src/content_blocking.rs
+++ b/src/content_blocking.rs
@@ -364,7 +364,7 @@ impl TryFrom<NetworkFilter> for CbRuleEquivalent {
                 CbType::Block
             };
 
-            let resource_type = if v.mask.contains(NetworkFilterMask::FROM_ANY) {
+            let resource_type = if v.mask.contains(NetworkFilterMask::FROM_NETWORK_TYPES) {
                 None
             } else {
                 let mut types = HashSet::new();

--- a/tests/legacy_harness.rs
+++ b/tests/legacy_harness.rs
@@ -99,7 +99,7 @@ mod legacy_test_filters {
         test_filter(
             "||ads.example.com^",
             NetworkFilterMask::DEFAULT_OPTIONS
-                // | NetworkFilterMask::IS_REGEX               // this engine handles ^ separators with regexes
+                | NetworkFilterMask::FROM_DOCUMENT
                 | NetworkFilterMask::IS_RIGHT_ANCHOR
                 | NetworkFilterMask::IS_HOSTNAME_ANCHOR, // FTHostAnchored | FTHostOnly
             None,
@@ -257,7 +257,7 @@ mod legacy_test_filters {
     fn check_third_party() {
         test_filter(
             "||googlesyndication.com/safeframe/$third-party",
-            NetworkFilterMask::FROM_ANY
+            NetworkFilterMask::FROM_NETWORK_TYPES
             | NetworkFilterMask::FROM_HTTP
             | NetworkFilterMask::FROM_HTTPS
             | NetworkFilterMask::THIRD_PARTY


### PR DESCRIPTION
The approach here has some minor differences in what's blocked when compared to uBlock Origin, but will allow blocking most intentionally-blocked top-level documents while avoiding any ambiguous cases.

The compatibility differences stem from the fact that uBlock Origin handles the `document` option in a few different ways from other request types:
- top-level document blocking can be enabled implicitly by not specifying any other request types to block. However, top-level blocking enabled explicitly with a `$document` option and implicitly by not specifying any other network blocking types cannot affect each other in exception filters.
- eligibility for top-level document blocking is partially determined _after_ a filter has been matched, to discard any matches that do not start within the hostname and end at its end

The first point makes creation of appropriate exception rules go against intuition at best, or straight up impossible at worst. I have filed [an issue](https://github.com/uBlockOrigin/uBlock-issues/issues/1501) with the uBlock Origin folks to see if this situation can be improved at all. In the meantime, I'm allowing the two to interact, to avoid using another bit of state per-filter. This requires a hack to apply document exceptions more aggressively than would otherwise be necessary, to avoid breaking sites where someone relied on an implicit document blocking exception without specifying types.

The second point appears to be a side-effect of logic churn over several years, where eligibility criteria for top-level document blocking have become stricter over time. With the currently-implemented rules, I think it makes more sense to fully handle eligibility for document blocking during filter parse/match time. We also don't currently pass specific enough information to recreate the block decision when filters are parsed without debug information. I've chosen to only ever implicitly add document blocking capability to filters of the form `||the.host.name^`, or their equivalent hosts-file format. This is a relatively simple rule, and could be improved as necessary with time, but it should cover the majority of cases in current filter lists without introducing any unforeseen webcompat issues. At any rate, it is best to be explicit about intention wherever possible.