### PR TITLE
Support brotli-encoded data format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "addr",
  "base64",
  "bitflags",
+ "brotli",
  "criterion",
  "cssparser",
  "csv",
@@ -21,7 +22,8 @@ dependencies = [
  "percent-encoding",
  "regex",
  "reqwest",
- "rmp-serde",
+ "rmp-serde 0.13.7",
+ "rmp-serde 0.15.5",
  "seahash",
  "selectors",
  "serde",
@@ -54,6 +56,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192ec435945d87bc2f70992b4d818154b5feede43c09fb7592146374eac90a6"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -90,6 +107,27 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "brotli"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f29919120f08613aadcd4383764e00526fc9f18b6c0895814faeed0dd78613e"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1052e1c3b8d4d80eb84a8b94f0a1498797b5fb96314c001156a1c761940ef4ec"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
 
 [[package]]
 name = "bstr"
@@ -1321,6 +1359,17 @@ name = "rmp-serde"
 version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "011e1d58446e9fa3af7cdc1fb91295b10621d3ac4cb3a85cc86385ee9ca50cd3"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723ecff9ad04f4ad92fe1c8ca6c20d2196d9286e9c60727c4cb5511629260e9d"
 dependencies = [
  "byteorder",
  "rmp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,12 @@ itertools = "0.9"
 idna = "0.2"
 serde =  { version = "1.0", features = ["derive", "rc"] }
 flate2 = { version = "1.0", features = ["rust_backend"], default-features = false }
+brotli = "3.3"
 seahash = "3"   # seahash 4 introduces a breaking hash algorithm change
 twoway = "0.2"
 base64 = "0.13"
-rmp-serde = "0.13.7"    # rmp-serde 0.14.0 breaks deserialization by changing how enums are deserialized
+rmp-serde-legacy = { package = "rmp-serde", version = "0.13.7" }    # rmp-serde 0.14.0 breaks deserialization by changing how enums are deserialized
+rmp-serde = "0.15"
 lifeguard = { version = "^ 0.6.1", optional = true }
 cssparser = { version = "0.25", optional = true }
 selectors = { version = "0.21", optional = true }

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -101,6 +101,7 @@ pub struct Blocker {
     pub(crate) redirects: NetworkFilterList,
     pub(crate) filters_tagged: NetworkFilterList,
     pub(crate) filters: NetworkFilterList,
+    pub(crate) generic_hide: NetworkFilterList,
 
     // Enabled tags are not serialized - when deserializing, tags of the existing
     // instance (the one we are recreating lists into) are maintained
@@ -116,8 +117,6 @@ pub struct Blocker {
     // Not serialized
     #[cfg(feature = "object-pooling")]
     pub(crate) pool: TokenPool,
-
-    pub(crate) generic_hide: NetworkFilterList,
 }
 
 impl Blocker {

--- a/src/data_format/mod.rs
+++ b/src/data_format/mod.rs
@@ -1,0 +1,173 @@
+//! Allows serialization of the adblock engine into a compact binary format, as well as subsequent
+//! rapid deserialization back into an engine.
+//!
+//! In order to support multiple format versions simultaneously, this module wraps around different
+//! serialization/deserialization implementations and can automatically dispatch to the appropriate
+//! one.
+
+mod legacy;
+mod v0;
+
+use crate::blocker::Blocker;
+use crate::cosmetic_filter_cache::CosmeticFilterCache;
+
+/// Provides structural aggregration of referenced adblock engine data to allow for allocation-free
+/// serialization.
+///
+/// Note that this does not implement `Serialize` directly, as it is composed of parts which must
+/// be serialized independently. Instead, use the `serialize` method.
+pub enum SerializeFormat<'a> {
+    Legacy(legacy::SerializeFormat<'a>),
+    V0(v0::SerializeFormat<'a>),
+}
+
+#[derive(Debug)]
+pub enum SerializationError {
+    RmpSerdeError(rmp_serde::encode::Error),
+    GzError(std::io::Error),
+}
+
+/// Since two different versions of `rmp-serde` are being used, errors must be converted to a
+/// single implementation.
+impl From<rmp_serde_legacy::encode::Error> for SerializationError {
+    fn from(e: rmp_serde_legacy::encode::Error) -> Self {
+        use rmp_serde_legacy::encode::Error as LegacyEncodeError;
+        use rmp_serde::encode::Error as EncodeError;
+
+        let new_error = match e {
+            LegacyEncodeError::InvalidValueWrite(e) => EncodeError::InvalidValueWrite(e),
+            LegacyEncodeError::UnknownLength => EncodeError::UnknownLength,
+            LegacyEncodeError::DepthLimitExceeded => EncodeError::DepthLimitExceeded,
+            LegacyEncodeError::Syntax(e) => EncodeError::Syntax(e),
+        };
+        Self::RmpSerdeError(new_error)
+    }
+}
+
+impl From<rmp_serde::encode::Error> for SerializationError {
+    fn from(e: rmp_serde::encode::Error) -> Self { Self::RmpSerdeError(e) }
+}
+
+impl From<std::io::Error> for SerializationError {
+    fn from(e: std::io::Error) -> Self { Self::GzError(e) }
+}
+
+impl<'a> SerializeFormat<'a> {
+    pub fn serialize(&self) -> Result<Vec<u8>, SerializationError> {
+        match self {
+            Self::Legacy(v) => v.serialize(),
+            Self::V0(v) => v.serialize(),
+        }
+    }
+}
+
+impl<'a> From<(&'a Blocker, &'a CosmeticFilterCache)> for SerializeFormat<'a> {
+    fn from((blocker, cfc): (&'a Blocker, &'a CosmeticFilterCache)) -> Self {
+        // For now, only support writing the legacy format, even though reading the newer format is
+        // supported. Version 0.4 of the crate will write only the V0 format.
+        Self::Legacy(legacy::SerializeFormat::from((blocker, cfc)))
+    }
+}
+
+/// Structural representation of adblock engine data that can be built up from deserialization and
+/// used directly to construct new `Engine` components without unnecessary allocation.
+///
+/// Note that this does not implement `Deserialize` directly, as it is composed of parts which must
+/// be deserialized independently. Instead, use the `deserialize` method.
+pub enum DeserializeFormat {
+    Legacy(legacy::DeserializeFormat),
+    V0(v0::DeserializeFormat),
+}
+
+#[derive(Debug)]
+pub enum DeserializationError {
+    RmpSerdeError(rmp_serde::decode::Error),
+    UnsupportedFormatVersion(u64),
+}
+
+/// Since two different versions of `rmp-serde` are being used, errors must be converted to a
+/// single implementation.
+impl From<rmp_serde_legacy::decode::Error> for DeserializationError {
+    fn from(e: rmp_serde_legacy::decode::Error) -> Self {
+        use rmp_serde_legacy::decode::Error as LegacyDecodeError;
+        use rmp_serde::decode::Error as DecodeError;
+
+        let new_error = match e {
+            LegacyDecodeError::InvalidMarkerRead(e) => DecodeError::InvalidMarkerRead(e),
+            LegacyDecodeError::InvalidDataRead(e) => DecodeError::InvalidDataRead(e),
+            LegacyDecodeError::TypeMismatch(m) => DecodeError::TypeMismatch(m),
+            LegacyDecodeError::OutOfRange => DecodeError::OutOfRange,
+            LegacyDecodeError::LengthMismatch(l) => DecodeError::LengthMismatch(l),
+            LegacyDecodeError::Uncategorized(e) => DecodeError::Uncategorized(e),
+            LegacyDecodeError::Syntax(e) => DecodeError::Syntax(e),
+            LegacyDecodeError::Utf8Error(e) => DecodeError::Utf8Error(e),
+            LegacyDecodeError::DepthLimitExceeded => DecodeError::DepthLimitExceeded,
+        };
+        Self::RmpSerdeError(new_error)
+    }
+}
+
+impl From<rmp_serde::decode::Error> for DeserializationError {
+    fn from(e: rmp_serde::decode::Error) -> Self { Self::RmpSerdeError(e) }
+}
+
+impl DeserializeFormat {
+    pub fn deserialize(serialized: &[u8]) -> Result<Self, DeserializationError> {
+        // A brotli stream can technically be created with a valid gzip header.
+        // However, the probability of also generating a conformant MessagePack-encoded
+        // legacy::DeserializeFormat is astronomically low, to the point where the legacy and v0+
+        // formats can be considered distinct.
+        //
+        // For correctness, both formats must be attempted before deserialization is considered
+        // "failed". However, in the interest of performance, we can use the exact 10-byte header
+        // sequence generated by the uncustomized flate2 GzEncoder as a heuristic for which method
+        // is most likely to succeed.
+        /// adblock-rust has always used flate2 1.0.x, which has never changed the header sequence
+        /// from these 10 bits when the GzEncoder is left uncustomized.
+        const FLATE2_GZ_HEADER_BYTES: [u8; 10] = [31, 139, 8, 0, 0, 0, 0, 0, 0, 255];
+        // Check for the exact 10-byte header sequence generated by the uncustomized flate2
+        // GzEncoder.
+        if serialized.starts_with(&FLATE2_GZ_HEADER_BYTES) {
+            // If present, attempt to deserialize the legacy format,
+            match legacy::DeserializeFormat::deserialize(serialized) {
+                Ok(d) => Ok(Self::Legacy(d)),
+                Err(e) => {
+                    // but fallback to checking for a brotli stream with a version number if that
+                    // is unsuccessful.
+                    let mut decompressor = brotli::Decompressor::new(serialized, 4096);
+                    if let Ok(version) = rmp_serde::decode::from_read::<_, u64>(&mut decompressor) {
+                        match version {
+                            0 => Ok(Self::V0(v0::DeserializeFormat::deserialize(serialized)?)),
+                            v => Err(DeserializationError::UnsupportedFormatVersion(v)),
+                        }
+                    } else {
+                        Err(e)
+                    }
+                }
+            }
+        } else {
+            // If the sequence is missing, attempt to decode a version number from the buffer as a
+            // brotli stream.
+            let mut decompressor = brotli::Decompressor::new(serialized, 4096);
+            if let Ok(version) = rmp_serde::decode::from_read::<_, u64>(&mut decompressor) {
+                match version {
+                    0 => Ok(Self::V0(v0::DeserializeFormat::deserialize(serialized)?)),
+                    v => Err(DeserializationError::UnsupportedFormatVersion(v)),
+                }
+            } else {
+                // If the data still couldn't be deserialized correctly, and gzip hasn't been attempted
+                // yet, try it.
+                Ok(Self::Legacy(legacy::DeserializeFormat::deserialize(serialized)?))
+            }
+        }
+    }
+}
+
+impl Into<(Blocker, CosmeticFilterCache)> for DeserializeFormat {
+    fn into(self) -> (Blocker, CosmeticFilterCache) {
+        match self {
+            Self::Legacy(v) => v.into(),
+            Self::V0(v) => v.into(),
+        }
+    }
+}

--- a/src/data_format/v0.rs
+++ b/src/data_format/v0.rs
@@ -1,0 +1,166 @@
+//! Contains representations of data from the adblocking engine in a
+//! forwards-and-backwards-compatible format, as well as utilities for converting these to and from
+//! the actual `Engine` components.
+//!
+//! Any new fields should be added to the _end_ of both `SerializeFormat` and `DeserializeFormat`.
+
+use std::collections::{HashSet, HashMap};
+use serde::{Deserialize, Serialize};
+use rmp_serde as rmps;
+
+use crate::blocker::{Blocker, NetworkFilterList};
+use crate::resources::{RedirectResourceStorage, ScriptletResourceStorage};
+use crate::filters::network::NetworkFilter;
+use crate::cosmetic_filter_cache::{CosmeticFilterCache, HostnameRuleDb};
+
+use super::SerializationError;
+use super::DeserializationError;
+
+/// Provides structural aggregration of referenced adblock engine data to allow for allocation-free
+/// serialization.
+#[derive(Serialize)]
+pub struct SerializeFormat<'a> {
+    csp: &'a NetworkFilterList,
+    exceptions: &'a NetworkFilterList,
+    importants: &'a NetworkFilterList,
+    redirects: &'a NetworkFilterList,
+    filters_tagged: &'a NetworkFilterList,
+    filters: &'a NetworkFilterList,
+    generic_hide: &'a NetworkFilterList,
+
+    tagged_filters_all: &'a Vec<NetworkFilter>,
+
+    enable_optimizations: bool,
+
+    resources: &'a RedirectResourceStorage,
+
+    simple_class_rules: &'a HashSet<String>,
+    simple_id_rules: &'a HashSet<String>,
+    complex_class_rules: &'a HashMap<String, Vec<String>>,
+    complex_id_rules: &'a HashMap<String, Vec<String>>,
+
+    specific_rules: &'a HostnameRuleDb,
+
+    misc_generic_selectors: &'a HashSet<String>,
+
+    scriptlets: &'a ScriptletResourceStorage,
+}
+
+impl<'a> SerializeFormat<'a> {
+    pub fn serialize(&self) -> Result<Vec<u8>, SerializationError> {
+        let mut writer = brotli::CompressorWriter::new(Vec::new(), 4096, 11, 24);
+        rmps::encode::write(&mut writer, &0u64)?;
+        rmps::encode::write(&mut writer, &self)?;
+        let compressed = writer.into_inner();
+        Ok(compressed)
+    }
+}
+
+/// Structural representation of adblock engine data that can be built up from deserialization and
+/// used directly to construct new `Engine` components without unnecessary allocation.
+#[derive(Deserialize)]
+pub struct DeserializeFormat {
+    csp: NetworkFilterList,
+    exceptions: NetworkFilterList,
+    importants: NetworkFilterList,
+    redirects: NetworkFilterList,
+    filters_tagged: NetworkFilterList,
+    filters: NetworkFilterList,
+    generic_hide: NetworkFilterList,
+
+    tagged_filters_all: Vec<NetworkFilter>,
+
+    enable_optimizations: bool,
+
+    resources: RedirectResourceStorage,
+
+    simple_class_rules: HashSet<String>,
+    simple_id_rules: HashSet<String>,
+    complex_class_rules: HashMap<String, Vec<String>>,
+    complex_id_rules: HashMap<String, Vec<String>>,
+
+    specific_rules: HostnameRuleDb,
+
+    misc_generic_selectors: HashSet<String>,
+
+    scriptlets: ScriptletResourceStorage,
+}
+
+impl DeserializeFormat {
+    pub fn deserialize(serialized: &[u8]) -> Result<Self, DeserializationError> {
+        let mut decompressor = brotli::Decompressor::new(serialized, 4096);
+        let version: usize = rmps::decode::from_read(&mut decompressor)?;
+        assert_eq!(version, 0);
+        let format: Self = rmps::decode::from_read(&mut decompressor)?;
+        Ok(format)
+    }
+}
+
+impl<'a> From<(&'a Blocker, &'a CosmeticFilterCache)> for SerializeFormat<'a> {
+    fn from(v: (&'a Blocker, &'a CosmeticFilterCache)) -> Self {
+        let (blocker, cfc) = v;
+        Self {
+            csp: &blocker.csp,
+            exceptions: &blocker.exceptions,
+            importants: &blocker.importants,
+            redirects: &blocker.redirects,
+            filters_tagged: &blocker.filters_tagged,
+            filters: &blocker.filters,
+            generic_hide: &blocker.generic_hide,
+
+            tagged_filters_all: &blocker.tagged_filters_all,
+
+            enable_optimizations: blocker.enable_optimizations,
+
+            resources: &blocker.resources,
+
+            simple_class_rules: &cfc.simple_class_rules,
+            simple_id_rules: &cfc.simple_id_rules,
+            complex_class_rules: &cfc.complex_class_rules,
+            complex_id_rules: &cfc.complex_id_rules,
+
+            specific_rules: &cfc.specific_rules,
+
+            misc_generic_selectors: &cfc.misc_generic_selectors,
+
+            scriptlets: &cfc.scriptlets,
+        }
+    }
+}
+
+impl Into<(Blocker, CosmeticFilterCache)> for DeserializeFormat {
+    fn into(self) -> (Blocker, CosmeticFilterCache) {
+        (Blocker {
+            csp: self.csp,
+            exceptions: self.exceptions,
+            importants: self.importants,
+            redirects: self.redirects,
+            filters_tagged: self.filters_tagged,
+            filters: self.filters,
+            generic_hide: self.generic_hide,
+
+            tags_enabled: Default::default(),
+            tagged_filters_all: self.tagged_filters_all,
+
+            hot_filters: Default::default(),
+
+            enable_optimizations: self.enable_optimizations,
+
+            resources: self.resources,
+            #[cfg(feature = "object-pooling")]
+            pool: Default::default(),
+
+        }, CosmeticFilterCache {
+            simple_class_rules: self.simple_class_rules,
+            simple_id_rules: self.simple_id_rules,
+            complex_class_rules: self.complex_class_rules,
+            complex_id_rules: self.complex_id_rules,
+
+            specific_rules: self.specific_rules,
+
+            misc_generic_selectors: self.misc_generic_selectors,
+
+            scriptlets: self.scriptlets,
+        })
+    }
+}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -459,14 +459,17 @@ mod tests {
         assert_eq!(matched_rule.redirect, Some("data:text/plain;base64,".to_owned()), "Expected redirect to contain resource");
     }
 
+    #[test]
     fn deserialization_generate_simple() {
-        let engine = Engine::from_rules(&[
+        let mut engine = Engine::from_rules(&[
             "ad-banner".to_owned()
         ], FilterFormat::Standard);
         let serialized = engine.serialize().unwrap();
         println!("Engine serialized: {:?}", serialized);
+        engine.deserialize(&serialized).unwrap();
     }
 
+    #[test]
     fn deserialization_generate_tags() {
         let mut engine = Engine::from_rules(&[
             "ad-banner$tag=abc".to_owned()
@@ -474,8 +477,10 @@ mod tests {
         engine.use_tags(&["abc"]);
         let serialized = engine.serialize().unwrap();
         println!("Engine serialized: {:?}", serialized);
+        engine.deserialize(&serialized).unwrap();
     }
 
+    #[test]
     fn deserialization_generate_resources() {
         let mut engine = Engine::from_rules(&[
             "ad-banner$redirect=nooptext".to_owned()
@@ -499,6 +504,7 @@ mod tests {
 
         let serialized = engine.serialize().unwrap();
         println!("Engine serialized: {:?}", serialized);
+        engine.deserialize(&serialized).unwrap();
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,6 @@ pub mod url_parser;
 pub mod engine;
 pub mod resources;
 pub mod cosmetic_filter_cache;
-pub mod data_format;
+mod data_format;
 #[cfg(feature = "content-blocking")]
 pub mod content_blocking;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -159,8 +159,8 @@ pub fn rules_from_lists(lists: &[String]) -> Vec<String> {
     rules
 }
 
-pub(crate) fn is_eof_error(e: &rmp_serde::decode::Error) -> bool {
-    if let rmp_serde::decode::Error::InvalidMarkerRead(e) = e {
+pub(crate) fn is_eof_error(e: &rmp_serde_legacy::decode::Error) -> bool {
+    if let rmp_serde_legacy::decode::Error::InvalidMarkerRead(e) = e {
         if e.kind() == std::io::ErrorKind::UnexpectedEof {
             if format!("{}", e) == "failed to fill whole buffer" {
                 return true;


### PR DESCRIPTION
Progress towards https://github.com/brave/adblock-rust/issues/153.

For compatibility during upgrades, the existing gzip format will still be written and read. adblock-rust 0.4 will switch over to writing the new v0 brotli format, and the legacy gzip format will be removed at some point in the future.