### PR TITLE
`redirect-url` filter option

### DIFF
--- a/benches/bench_matching.rs
+++ b/benches/bench_matching.rs
@@ -3,7 +3,6 @@ use criterion::*;
 use serde::{Deserialize, Serialize};
 
 use adblock::utils::rules_from_lists;
-use adblock::lists::FilterFormat;
 use adblock::blocker::{Blocker, BlockerOptions};
 use adblock::request::Request;
 use adblock::url_parser::parse_url;
@@ -24,7 +23,7 @@ fn load_requests() -> Vec<TestRequest> {
 }
 
 fn get_blocker(rules: &Vec<String>) -> Blocker {
-    let (network_filters, _) = adblock::lists::parse_filters(rules, false, FilterFormat::Standard);
+    let (network_filters, _) = adblock::lists::parse_filters(rules, false, Default::default());
 
     let blocker_options = BlockerOptions {
         enable_optimizations: true,
@@ -103,7 +102,7 @@ fn rule_match(c: &mut Criterion) {
                 "data/easylist.to/easylist/easylist.txt".to_owned(),
                 "data/easylist.to/easylist/easyprivacy.txt".to_owned()
             ]);
-            let engine = Engine::from_rules(&rules, FilterFormat::Standard);
+            let engine = Engine::from_rules(&rules, Default::default());
             b.iter(|| bench_rule_matching(&engine, &elep_req))
         },
     );
@@ -113,7 +112,7 @@ fn rule_match(c: &mut Criterion) {
             let rules = rules_from_lists(&vec![
                 "data/easylist.to/easylist/easylist.txt".to_owned(),
             ]);
-            let engine = Engine::from_rules(&rules, FilterFormat::Standard);
+            let engine = Engine::from_rules(&rules, Default::default());
             b.iter(|| bench_rule_matching(&engine, &el_req))
         },
     );
@@ -123,7 +122,7 @@ fn rule_match(c: &mut Criterion) {
             let rules = rules_from_lists(&vec![
                 "data/slim-list.txt".to_owned()
             ]);
-            let engine = Engine::from_rules(&rules, FilterFormat::Standard);
+            let engine = Engine::from_rules(&rules, Default::default());
             b.iter(|| bench_rule_matching(&engine, &slim_req))
         },
     );
@@ -208,7 +207,7 @@ fn serialization(c: &mut Criterion) {
                 String::from("data/easylist.to/easylist/easyprivacy.txt")
             ]);
 
-            let engine = Engine::from_rules(&full_rules, FilterFormat::Standard);
+            let engine = Engine::from_rules(&full_rules, Default::default());
             b.iter(|| assert!(engine.serialize_raw().unwrap().len() > 0))
         },
     );
@@ -219,7 +218,7 @@ fn serialization(c: &mut Criterion) {
                 String::from("data/easylist.to/easylist/easylist.txt"),
             ]);
 
-            let engine = Engine::from_rules(&full_rules, FilterFormat::Standard);
+            let engine = Engine::from_rules(&full_rules, Default::default());
             b.iter(|| assert!(engine.serialize_raw().unwrap().len() > 0))
         }
     );
@@ -230,7 +229,7 @@ fn serialization(c: &mut Criterion) {
                 String::from("data/slim-list.txt"),
             ]);
 
-            let engine = Engine::from_rules(&full_rules, FilterFormat::Standard);
+            let engine = Engine::from_rules(&full_rules, Default::default());
             b.iter(|| assert!(engine.serialize_raw().unwrap().len() > 0))
         }
     );
@@ -251,7 +250,7 @@ fn deserialization(c: &mut Criterion) {
                 String::from("data/easylist.to/easylist/easyprivacy.txt")
             ]);
 
-            let engine = Engine::from_rules(&full_rules, FilterFormat::Standard);
+            let engine = Engine::from_rules(&full_rules, Default::default());
             let serialized = engine.serialize_raw().unwrap();
 
             b.iter(|| {
@@ -267,7 +266,7 @@ fn deserialization(c: &mut Criterion) {
                 String::from("data/easylist.to/easylist/easylist.txt"),
             ]);
 
-            let engine = Engine::from_rules(&full_rules, FilterFormat::Standard);
+            let engine = Engine::from_rules(&full_rules, Default::default());
             let serialized = engine.serialize_raw().unwrap();
 
             b.iter(|| {
@@ -283,7 +282,7 @@ fn deserialization(c: &mut Criterion) {
                 String::from("data/slim-list.txt"),
             ]);
 
-            let engine = Engine::from_rules(&full_rules, FilterFormat::Standard);
+            let engine = Engine::from_rules(&full_rules, Default::default());
             let serialized = engine.serialize_raw().unwrap();
 
             b.iter(|| {
@@ -352,7 +351,7 @@ fn rule_match_browserlike_comparable(c: &mut Criterion) {
                 "data/easylist.to/easylist/easylist.txt".to_owned(),
                 "data/easylist.to/easylist/easyprivacy.txt".to_owned()
             ]);
-            let engine = Engine::from_rules_parametrised(&rules, FilterFormat::Standard, false, true);
+            let engine = Engine::from_rules_parametrised(&rules, Default::default(), false, true);
             b.iter(|| bench_rule_matching_browserlike(&engine, &elep_req))
         },
     );
@@ -362,7 +361,7 @@ fn rule_match_browserlike_comparable(c: &mut Criterion) {
             let rules = rules_from_lists(&vec![
                 "data/easylist.to/easylist/easylist.txt".to_owned(),
             ]);
-            let engine = Engine::from_rules_parametrised(&rules, FilterFormat::Standard, false, true);
+            let engine = Engine::from_rules_parametrised(&rules, Default::default(), false, true);
             b.iter(|| bench_rule_matching_browserlike(&engine, &el_req))
         },
     );
@@ -372,7 +371,7 @@ fn rule_match_browserlike_comparable(c: &mut Criterion) {
             let rules = rules_from_lists(&vec![
                 "data/slim-list.txt".to_owned()
             ]);
-            let engine = Engine::from_rules_parametrised(&rules, FilterFormat::Standard, false, true);
+            let engine = Engine::from_rules_parametrised(&rules, Default::default(), false, true);
             b.iter(|| bench_rule_matching_browserlike(&engine, &slim))
         },
     );

--- a/benches/bench_redirect_performance.rs
+++ b/benches/bench_redirect_performance.rs
@@ -56,7 +56,7 @@ fn get_redirect_rules() -> Vec<NetworkFilter> {
     let async_runtime = Runtime::new().expect("Could not start Tokio runtime");
 
     let filters = async_runtime.block_on(get_all_filters());
-    let (network_filters, _) = adblock::lists::parse_filters(&filters, true, adblock::lists::FilterFormat::Standard);
+    let (network_filters, _) = adblock::lists::parse_filters(&filters, true, Default::default());
 
     network_filters.into_iter()
         .filter(|rule| {

--- a/benches/bench_rules.rs
+++ b/benches/bench_rules.rs
@@ -1,7 +1,6 @@
 use criterion::*;
 use once_cell::sync::Lazy;
 
-use adblock::lists::FilterFormat;
 use adblock::utils::{read_file_lines, rules_from_lists};
 use adblock::blocker::{Blocker, BlockerOptions};
 
@@ -58,7 +57,7 @@ fn bench_parsing_impl(lists: &Vec<Vec<String>>) -> usize {
     let mut dummy = 0;
 
     for list in lists {
-        let (network_filters, _) = adblock::lists::parse_filters(list, false, FilterFormat::Standard);
+        let (network_filters, _) = adblock::lists::parse_filters(list, false, Default::default());
         dummy = dummy + network_filters.len() % 1000000;
     }
   
@@ -85,7 +84,7 @@ fn list_parse(c: &mut Criterion) {
 }
 
 fn get_blocker(rules: &Vec<String>) -> Blocker {
-    let (network_filters, _) = adblock::lists::parse_filters(rules, false, FilterFormat::Standard);
+    let (network_filters, _) = adblock::lists::parse_filters(rules, false, Default::default());
 
     println!("Got {} network filters", network_filters.len());
 

--- a/data/matching-test-requests.json
+++ b/data/matching-test-requests.json
@@ -6186,6 +6186,15 @@
   {
     "check": true,
     "filters": [
+      "||cdn.taboola.com/libtrc/*/loader.js$script,redirect-url=http://noops.js,important,domain=cnet.com"
+    ],
+    "sourceUrl": "https://www.cnet.com",
+    "type": "script",
+    "url": "https://cdn.taboola.com/libtrc/cbsinteractive-cnet/loader.js"
+  },
+  {
+    "check": true,
+    "filters": [
       "||cdn.taboola.com/libtrc/*/loader.js$script,redirect=noopjs,important,domain=cnet.com"
     ],
     "sourceUrl": "https://www.cnet.com",

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,5 +1,4 @@
 use adblock::engine::Engine;
-use adblock::lists::FilterFormat;
 
 fn main() {
     let rules = vec![
@@ -9,7 +8,7 @@ fn main() {
         String::from("-advertisement/script."),
     ];
 
-    let blocker = Engine::from_rules_debug(&rules, FilterFormat::Standard);
+    let blocker = Engine::from_rules_debug(&rules, Default::default());
     let blocker_result = blocker.check_network_urls("http://example.com/-advertisement-icon.", "http://example.com/helloworld", "image");
 
     println!("Blocker result: {:?}", blocker_result);

--- a/examples/generate-dat.rs
+++ b/examples/generate-dat.rs
@@ -1,5 +1,4 @@
 use adblock::engine::Engine;
-use adblock::lists::FilterFormat;
 
 use std::fs::File;
 use std::io::prelude::*;
@@ -12,7 +11,7 @@ fn main() {
     ];
 
     // Serialize
-    let mut engine = Engine::from_rules_debug(&rules, FilterFormat::Standard);
+    let mut engine = Engine::from_rules_debug(&rules, Default::default());
     engine.use_tags(&["twitter-embeds"]);
     assert!(engine.check_network_urls("https://platform.twitter.com/widgets.js", "https://fmarier.github.io/brave-testing/social-widgets.html", "script").exception.is_some());
     let serialized = engine.serialize_raw().expect("Could not serialize!");

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -1214,13 +1214,13 @@ mod tests {
 mod blocker_tests {
 
     use super::*;
-    use crate::lists::{parse_filters, FilterFormat, parse_filters_with_opts, ParseOptions};
+    use crate::lists::{parse_filters, ParseOptions};
     use crate::request::Request;
     use std::collections::HashSet;
     use std::iter::FromIterator;
 
     fn test_requests_filters(filters: &[String], requests: &[(Request, bool)]) {
-        let (network_filters, _) = parse_filters(filters, true, FilterFormat::Standard);
+        let (network_filters, _) = parse_filters(filters, true, Default::default());
 
         let blocker_options: BlockerOptions = BlockerOptions {
             enable_optimizations: false,    // optimizations will reduce number of rules
@@ -1246,9 +1246,9 @@ mod blocker_tests {
 
         let request = Request::from_urls("https://foo.com", "https://foo.com", "script").unwrap();
 
-        let opts = ParseOptions { parse_redirect_urls: true, ..Default::default() };
+        let opts = ParseOptions { include_redirect_urls: true, ..Default::default() };
 
-        let (network_filters, _) = parse_filters_with_opts(&filters, true, opts);
+        let (network_filters, _) = parse_filters(&filters, true, opts);
 
         let blocker_options: BlockerOptions = BlockerOptions {
             enable_optimizations: false,
@@ -1271,7 +1271,7 @@ mod blocker_tests {
 
         let request = Request::from_urls("https://foo.com", "https://foo.com", "script").unwrap();
 
-        let (network_filters, _) = parse_filters(&filters, true, FilterFormat::Standard);
+        let (network_filters, _) = parse_filters(&filters, true, Default::default());
 
         let blocker_options: BlockerOptions = BlockerOptions {
             enable_optimizations: false,
@@ -1293,9 +1293,9 @@ mod blocker_tests {
 
         let request = Request::from_urls("https://foo.com", "https://foo.com", "script").unwrap();
 
-        let opts = ParseOptions { parse_redirect_urls: true, ..Default::default() };
+        let opts = ParseOptions { include_redirect_urls: true, ..Default::default() };
 
-        let (network_filters, _) = parse_filters_with_opts(&filters, true, opts);
+        let (network_filters, _) = parse_filters(&filters, true, opts);
 
         let blocker_options: BlockerOptions = BlockerOptions {
             enable_optimizations: false,
@@ -1319,9 +1319,9 @@ mod blocker_tests {
 
         let request = Request::from_urls("https://imdb-video.media-imdb.com/kBOeI88k1o23eNAi", "https://www.imdb.com/video/13", "media").unwrap();
 
-        let opts = ParseOptions { parse_redirect_urls: true, ..Default::default() };
+        let opts = ParseOptions { include_redirect_urls: true, ..Default::default() };
 
-        let (network_filters, _) = parse_filters_with_opts(&filters, true, opts);
+        let (network_filters, _) = parse_filters(&filters, true, opts);
 
         let blocker_options: BlockerOptions = BlockerOptions {
             enable_optimizations: false,
@@ -1346,7 +1346,7 @@ mod blocker_tests {
 
         let request = Request::from_urls("https://imdb-video.media-imdb.com/kBOeI88k1o23eNAi", "https://www.imdb.com/video/13", "media").unwrap();
 
-        let (network_filters, _) = parse_filters(&filters, true, FilterFormat::Standard);
+        let (network_filters, _) = parse_filters(&filters, true, Default::default());
 
         let blocker_options: BlockerOptions = BlockerOptions {
             enable_optimizations: false,
@@ -1378,7 +1378,7 @@ mod blocker_tests {
 
         let request = Request::from_urls("https://imdb-video.media-imdb.com/kBOeI88k1o23eNAi", "https://www.imdb.com/video/13", "media").unwrap();
 
-        let (network_filters, _) = parse_filters(&filters, true, FilterFormat::Standard);
+        let (network_filters, _) = parse_filters(&filters, true, Default::default());
 
         let blocker_options: BlockerOptions = BlockerOptions {
             enable_optimizations: false,
@@ -1476,7 +1476,7 @@ mod blocker_tests {
             (Request::from_urls("https://r.aabb.top/test.js", "https://minisite.letv.com/", "script").unwrap(), true),
         ];
 
-        let (network_filters, _) = parse_filters(&filters, true, FilterFormat::Standard);
+        let (network_filters, _) = parse_filters(&filters, true, Default::default());
 
         let blocker_options = BlockerOptions {
             enable_optimizations: false,    // optimizations will reduce number of rules
@@ -1506,7 +1506,7 @@ mod blocker_tests {
             String::from("^first-party-only^$csp=script-src 'none',1p"),
         ];
 
-        let (network_filters, _) = parse_filters(&filters, true, FilterFormat::Standard);
+        let (network_filters, _) = parse_filters(&filters, true, Default::default());
 
         let blocker_options = BlockerOptions {
             enable_optimizations: false,
@@ -1564,7 +1564,7 @@ mod blocker_tests {
             (Request::from_url("https://brave.com/about").unwrap(), false),
         ];
 
-        let (network_filters, _) = parse_filters(&filters, true, FilterFormat::Standard);
+        let (network_filters, _) = parse_filters(&filters, true, Default::default());
 
         let blocker_options: BlockerOptions = BlockerOptions {
             enable_optimizations: false,    // optimizations will reduce number of rules
@@ -1600,7 +1600,7 @@ mod blocker_tests {
             (Request::from_url("https://brave.com/about").unwrap(), true),
         ];
 
-        let (network_filters, _) = parse_filters(&filters, true, FilterFormat::Standard);
+        let (network_filters, _) = parse_filters(&filters, true, Default::default());
 
         let blocker_options: BlockerOptions = BlockerOptions {
             enable_optimizations: false,    // optimizations will reduce number of rules
@@ -1637,7 +1637,7 @@ mod blocker_tests {
             (Request::from_url("https://brave.com/about").unwrap(), true),
         ];
 
-        let (network_filters, _) = parse_filters(&filters, true, FilterFormat::Standard);
+        let (network_filters, _) = parse_filters(&filters, true, Default::default());
 
         let blocker_options: BlockerOptions = BlockerOptions {
             enable_optimizations: false,    // optimizations will reduce number of rules
@@ -1774,7 +1774,7 @@ mod blocker_tests {
 #[cfg(test)]
 mod legacy_rule_parsing_tests {
     use crate::utils::rules_from_lists;
-    use crate::lists::{parse_filters, FilterFormat};
+    use crate::lists::{parse_filters, FilterFormat, ParseOptions};
     use crate::blocker::{Blocker, BlockerOptions};
     use crate::blocker::vec_hashmap_len;
 
@@ -1826,7 +1826,7 @@ mod legacy_rule_parsing_tests {
     fn check_list_counts(rule_lists: &[String], format: FilterFormat, expectation: ListCounts) {
         let rules = rules_from_lists(rule_lists);
 
-        let (network_filters, cosmetic_filters) = parse_filters(&rules, true, format);
+        let (network_filters, cosmetic_filters) = parse_filters(&rules, true, ParseOptions { format, ..Default::default() });
 
         assert_eq!(
             (network_filters.len(),

--- a/src/content_blocking.rs
+++ b/src/content_blocking.rs
@@ -546,10 +546,9 @@ impl TryFrom<CosmeticFilter> for CbRule {
 #[cfg(test)]
 mod ab2cb_tests {
     use super::*;
-    use crate::lists::FilterFormat;
 
     fn test_from_abp(abp_rule: &str, cb: &str) {
-        let filter = crate::lists::parse_filter(abp_rule, true, FilterFormat::Standard).expect("Rule under test could not be parsed");
+        let filter = crate::lists::parse_filter(abp_rule, true, Default::default()).expect("Rule under test could not be parsed");
         assert_eq!(CbRuleEquivalent::try_from(filter).unwrap().into_iter().collect::<Vec<_>>(), serde_json::from_str::<Vec<CbRule>>(cb).expect("content blocking rule under test could not be deserialized"));
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,6 +1,6 @@
 use crate::blocker::{Blocker, BlockerError, BlockerOptions, BlockerResult};
 use crate::cosmetic_filter_cache::{CosmeticFilterCache, UrlSpecificResources};
-use crate::lists::{FilterFormat, FilterSet, ParseOptions};
+use crate::lists::{FilterSet, ParseOptions};
 use crate::request::Request;
 use crate::resources::{Resource, RedirectResource};
 
@@ -36,32 +36,20 @@ impl Engine {
     }
 
     /// Loads rules in a single format, enabling optimizations and discarding debug information.
-    pub fn from_rules(rules: &[String], format: FilterFormat) -> Self {
+    pub fn from_rules(rules: &[String], opts: ParseOptions) -> Self {
         let mut filter_set = FilterSet::new(false);
-        filter_set.add_filters(rules, format);
+        filter_set.add_filters(rules, opts);
         Self::from_filter_set(filter_set, true)
     }
 
     /// Loads rules, enabling optimizations and including debug information.
-    pub fn from_rules_debug(rules: &[String], format: FilterFormat) -> Self {
-        let opts = ParseOptions { format, ..Default::default() };
-        Self::from_rules_debug_with_opts(&rules, opts)
+    pub fn from_rules_debug(rules: &[String], opts: ParseOptions) -> Self {
+        Self::from_rules_parametrised(&rules, opts, true, true)
     }
 
-    /// Loads rules, enabling optimizations and including debug information.
-    /// Include opts
-    pub fn from_rules_debug_with_opts(rules: &[String], opts: ParseOptions) -> Self {
-        Self::from_rules_parametrised_with_opts(&rules, opts, true, true)
-    }
-
-    pub fn from_rules_parametrised(filter_rules: &[String], format: FilterFormat, debug: bool, optimize: bool) -> Self {
-        let opts = ParseOptions { format, ..Default::default() };
-        Self::from_rules_parametrised_with_opts(filter_rules, opts, debug, optimize)
-    }
-
-    pub fn from_rules_parametrised_with_opts(filter_rules: &[String], opts: ParseOptions, debug: bool, optimize: bool) -> Self {
+    pub fn from_rules_parametrised(filter_rules: &[String], opts: ParseOptions, debug: bool, optimize: bool) -> Self {
         let mut filter_set = FilterSet::new(debug);
-        filter_set.add_filters_with_opts(filter_rules, opts);
+        filter_set.add_filters(filter_rules, opts);
         Self::from_filter_set(filter_set, optimize)
     }
 
@@ -291,6 +279,7 @@ mod tests {
     use super::*;
     use crate::resources::{ResourceType, MimeType};
     use crate::blocker::Redirection;
+    use crate::lists::FilterFormat;
 
     #[test]
     fn tags_enable_adds_tags() {
@@ -307,7 +296,7 @@ mod tests {
             ("https://brave.com/about", true),
         ];
 
-        let mut engine = Engine::from_rules(&filters, FilterFormat::Standard);
+        let mut engine = Engine::from_rules(&filters, Default::default());
         engine.enable_tags(&["stuff"]);
         engine.enable_tags(&["brian"]);
 
@@ -336,7 +325,7 @@ mod tests {
             ("https://brave.com/about", true),
         ];
 
-        let mut engine = Engine::from_rules(&filters, FilterFormat::Standard);
+        let mut engine = Engine::from_rules(&filters, Default::default());
         engine.enable_tags(&["brian", "stuff"]);
         engine.disable_tags(&["stuff"]);
 
@@ -363,7 +352,7 @@ mod tests {
             ("https://brianbondy.com/advert", true),
         ];
 
-        let engine = Engine::from_rules(&filters, FilterFormat::Standard);
+        let engine = Engine::from_rules(&filters, Default::default());
 
         url_results.into_iter().for_each(|(url, expected_result)| {
             let matched_rule = engine.check_network_urls(&url, "", "");
@@ -388,7 +377,7 @@ mod tests {
             ("https://brianbondy.com/advert", false),
         ];
 
-        let mut engine = Engine::from_rules(&filters, FilterFormat::Standard);
+        let mut engine = Engine::from_rules(&filters, Default::default());
         engine.enable_tags(&["brian", "stuff"]);
 
         url_results.into_iter().for_each(|(url, expected_result)| {
@@ -416,7 +405,7 @@ mod tests {
             ("https://brave.com/about", false),
         ];
 
-        let mut engine = Engine::from_rules(&filters, FilterFormat::Standard);
+        let mut engine = Engine::from_rules(&filters, Default::default());
         engine.enable_tags(&["stuff"]);
         engine.enable_tags(&["brian"]);
         let serialized = engine.serialize_raw().unwrap();
@@ -507,7 +496,7 @@ mod tests {
     fn deserialization_generate_simple() {
         let mut engine = Engine::from_rules(&[
             "ad-banner".to_owned()
-        ], FilterFormat::Standard);
+        ], Default::default());
         let serialized = engine.serialize_compressed().unwrap();
         println!("Engine serialized: {:?}", serialized);
         engine.deserialize(&serialized).unwrap();
@@ -517,7 +506,7 @@ mod tests {
     fn deserialization_generate_tags() {
         let mut engine = Engine::from_rules(&[
             "ad-banner$tag=abc".to_owned()
-        ], FilterFormat::Standard);
+        ], Default::default());
         engine.use_tags(&["abc"]);
         let serialized = engine.serialize_compressed().unwrap();
         println!("Engine serialized: {:?}", serialized);
@@ -528,7 +517,7 @@ mod tests {
     fn deserialization_generate_resources() {
         let mut engine = Engine::from_rules(&[
             "ad-banner$redirect=nooptext".to_owned()
-        ], FilterFormat::Standard);
+        ], Default::default());
 
         let resources = vec![
             Resource {
@@ -555,7 +544,7 @@ mod tests {
     fn redirect_resource_insertion_works() {
         let mut engine = Engine::from_rules(&[
             "ad-banner$redirect=nooptext".to_owned()
-        ], FilterFormat::Standard);
+        ], Default::default());
 
         engine.add_resource(Resource {
             name: "nooptext".to_owned(),
@@ -601,7 +590,7 @@ mod tests {
             String::from("@@||sub.example.com$document"),
         ];
 
-        let engine = Engine::from_rules_debug(&filters, FilterFormat::Standard);
+        let engine = Engine::from_rules_debug(&filters, Default::default());
 
         assert!(engine.check_network_urls("https://example.com", "https://example.com", "document").matched);
         assert!(!engine.check_network_urls("https://example.com", "https://example.com", "script").matched);
@@ -611,35 +600,35 @@ mod tests {
     #[test]
     fn implicit_all() {
         {
-            let engine = Engine::from_rules_debug(&vec![String::from("||example.com^")], FilterFormat::Standard);
+            let engine = Engine::from_rules_debug(&vec![String::from("||example.com^")], Default::default());
             assert!(engine.check_network_urls("https://example.com", "https://example.com", "document").matched);
         }
         {
-            let engine = Engine::from_rules_debug(&vec![String::from("||example.com^$first-party,match-case")], FilterFormat::Standard);
+            let engine = Engine::from_rules_debug(&vec![String::from("||example.com^$first-party,match-case")], Default::default());
             assert!(engine.check_network_urls("https://example.com", "https://example.com", "document").matched);
         }
         {
-            let engine = Engine::from_rules_debug(&vec![String::from("||example.com^$script")], FilterFormat::Standard);
+            let engine = Engine::from_rules_debug(&vec![String::from("||example.com^$script")], Default::default());
             assert!(!engine.check_network_urls("https://example.com", "https://example.com", "document").matched);
         }
         {
-            let engine = Engine::from_rules_debug(&vec![String::from("||example.com^$~script")], FilterFormat::Standard);
+            let engine = Engine::from_rules_debug(&vec![String::from("||example.com^$~script")], Default::default());
             assert!(!engine.check_network_urls("https://example.com", "https://example.com", "document").matched);
         }
         {
-            let engine = Engine::from_rules_debug(&vec![String::from("||example.com^$document"), String::from("@@||example.com^$generichide")], FilterFormat::Standard);
+            let engine = Engine::from_rules_debug(&vec![String::from("||example.com^$document"), String::from("@@||example.com^$generichide")], Default::default());
             assert!(engine.check_network_urls("https://example.com", "https://example.com", "document").matched);
         }
         {
-            let engine = Engine::from_rules_debug(&vec![String::from("example.com")], FilterFormat::Hosts);
+            let engine = Engine::from_rules_debug(&vec![String::from("example.com")], ParseOptions { format: FilterFormat::Hosts, ..Default::default() });
             assert!(engine.check_network_urls("https://example.com", "https://example.com", "document").matched);
         }
         {
-            let engine = Engine::from_rules_debug(&vec![String::from("||example.com/path")], FilterFormat::Standard);
+            let engine = Engine::from_rules_debug(&vec![String::from("||example.com/path")], Default::default());
             assert!(!engine.check_network_urls("https://example.com/path", "https://example.com/path", "document").matched);
         }
         {
-            let engine = Engine::from_rules_debug(&vec![String::from("||example.com/path^")], FilterFormat::Standard);
+            let engine = Engine::from_rules_debug(&vec![String::from("||example.com/path^")], Default::default());
             assert!(!engine.check_network_urls("https://example.com/path", "https://example.com/path", "document").matched);
         }
     }
@@ -663,7 +652,7 @@ mod tests {
             ("https://example2.com/test.html", vec![".block"], true),
         ];
 
-        let engine = Engine::from_rules(&filters, FilterFormat::Standard);
+        let engine = Engine::from_rules(&filters, Default::default());
 
         url_results.into_iter().for_each(|(url, expected_result, expected_generichide)| {
             let result = engine.url_cosmetic_resources(url);
@@ -678,7 +667,7 @@ mod tests {
         filter_set.add_filters(&vec![
             "||addthis.com^$important,3p,domain=~missingkids.com|~missingkids.org|~sainsburys.jobs|~sitecore.com|~amd.com".to_string(),
             "||addthis.com/*/addthis_widget.js$script,redirect=addthis.com/addthis_widget.js".to_string(),
-        ], FilterFormat::Standard);
+        ], Default::default());
         let mut engine = Engine::from_filter_set(filter_set, false);
 
         engine.add_resource(Resource {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -278,6 +278,7 @@ impl Engine {
 mod tests {
     use super::*;
     use crate::resources::{ResourceType, MimeType};
+    use crate::blocker::Redirection;
 
     #[test]
     fn tags_enable_adds_tags() {
@@ -487,7 +488,7 @@ mod tests {
         // TODO - The failure to match here is considered acceptable for now, as it's part of a
         // breaking change (minor version bump). However, the test should be updated at some point.
         //assert!(matched_rule.matched, "Expected match for {}", url);
-        assert_eq!(matched_rule.redirect, Some("data:text/plain;base64,".to_owned()), "Expected redirect to contain resource");
+        assert_eq!(matched_rule.redirect, Some(Redirection::Resource("data:text/plain;base64,".to_owned())), "Expected redirect to contain resource");
     }
 
     #[test]
@@ -554,7 +555,7 @@ mod tests {
         let url = "http://example.com/ad-banner.gif";
         let matched_rule = engine.check_network_urls(url, "", "");
         assert!(matched_rule.matched, "Expected match for {}", url);
-        assert_eq!(matched_rule.redirect, Some("data:text/plain;base64,".to_owned()), "Expected redirect to contain resource");
+        assert_eq!(matched_rule.redirect, Some(Redirection::Resource("data:text/plain;base64,".to_owned())), "Expected redirect to contain resource");
     }
 
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -480,7 +480,13 @@ mod tests {
 
         let url = "http://example.com/ad-banner.gif";
         let matched_rule = deserialized_engine.check_network_urls(url, "", "");
-        assert!(matched_rule.matched, "Expected match for {}", url);
+        // This serialized DAT was generated prior to
+        // https://github.com/brave/adblock-rust/pull/185, so the `redirect` filter did not get
+        // duplicated into the list of blocking filters.
+        //
+        // TODO - The failure to match here is considered acceptable for now, as it's part of a
+        // breaking change (minor version bump). However, the test should be updated at some point.
+        //assert!(matched_rule.matched, "Expected match for {}", url);
         assert_eq!(matched_rule.redirect, Some("data:text/plain;base64,".to_owned()), "Expected redirect to contain resource");
     }
 

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -1641,6 +1641,7 @@ mod parse_tests {
         from_document: bool,
         match_case: bool,
         third_party: bool,
+        is_redirect_url: bool,
     }
 
     impl From<&NetworkFilter> for NetworkFilterBreakdown {
@@ -1680,6 +1681,7 @@ mod parse_tests {
                 from_websocket: filter.mask.contains(NetworkFilterMask::FROM_WEBSOCKET),
                 from_xml_http_request: filter.mask.contains(NetworkFilterMask::FROM_XMLHTTPREQUEST),
                 from_document: filter.mask.contains(NetworkFilterMask::FROM_DOCUMENT),
+                is_redirect_url: filter.is_redirect_url(),
                 match_case: filter.match_case(),
                 third_party: filter.third_party(),
             }
@@ -1724,6 +1726,7 @@ mod parse_tests {
             from_document: false,
             match_case: false,
             third_party: true,
+            is_redirect_url: false,
         }
     }
 
@@ -1731,21 +1734,21 @@ mod parse_tests {
     // pattern
     fn parses_plain_pattern() {
         {
-            let filter = NetworkFilter::parse("ads", true).unwrap();
+            let filter = NetworkFilter::parse("ads", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.filter = Some(String::from("ads"));
             defaults.is_plain = true;
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
         }
         {
-            let filter = NetworkFilter::parse("/ads/foo-", true).unwrap();
+            let filter = NetworkFilter::parse("/ads/foo-", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.filter = Some(String::from("/ads/foo-"));
             defaults.is_plain = true;
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
         }
         {
-            let filter = NetworkFilter::parse("/ads/foo-$important", true).unwrap();
+            let filter = NetworkFilter::parse("/ads/foo-$important", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.filter = Some(String::from("/ads/foo-"));
             defaults.is_plain = true;
@@ -1753,7 +1756,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
         }
         {
-            let filter = NetworkFilter::parse("foo.com/ads$important", true).unwrap();
+            let filter = NetworkFilter::parse("foo.com/ads$important", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.filter = Some(String::from("foo.com/ads"));
             defaults.is_plain = true;
@@ -1766,7 +1769,7 @@ mod parse_tests {
     // ||pattern
     fn parses_hostname_anchor_pattern() {
         {
-            let filter = NetworkFilter::parse("||foo.com", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.filter = None;
             defaults.hostname = Some(String::from("foo.com"));
@@ -1775,7 +1778,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
         }
         {
-            let filter = NetworkFilter::parse("||foo.com$important", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com$important", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.filter = None;
             defaults.hostname = Some(String::from("foo.com"));
@@ -1785,7 +1788,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
         }
         {
-            let filter = NetworkFilter::parse("||foo.com/bar/baz$important", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com/bar/baz$important", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some(String::from("foo.com"));
             defaults.filter = Some(String::from("/bar/baz"));
@@ -1801,7 +1804,7 @@ mod parse_tests {
     // ||pattern|
     fn parses_hostname_right_anchor_pattern() {
         {
-            let filter = NetworkFilter::parse("||foo.com|", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com|", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some(String::from("foo.com"));
             defaults.filter = None;
@@ -1811,7 +1814,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
         }
         {
-            let filter = NetworkFilter::parse("||foo.com|$important", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com|$important", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some(String::from("foo.com"));
             defaults.filter = None;
@@ -1822,7 +1825,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
         }
         {
-            let filter = NetworkFilter::parse("||foo.com/bar/baz|$important", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com/bar/baz|$important", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some(String::from("foo.com"));
             defaults.filter = Some(String::from("/bar/baz"));
@@ -1834,7 +1837,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
         }
         {
-            let filter = NetworkFilter::parse("||foo.com^bar/*baz|$important", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com^bar/*baz|$important", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some(String::from("foo.com"));
             defaults.filter = Some(String::from("^bar/*baz"));
@@ -1851,7 +1854,7 @@ mod parse_tests {
     // |pattern
     fn parses_left_anchor_pattern() {
         {
-            let filter = NetworkFilter::parse("|foo.com", true).unwrap();
+            let filter = NetworkFilter::parse("|foo.com", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.filter = Some(String::from("foo.com"));
             defaults.is_plain = true;
@@ -1859,7 +1862,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
         }
         {
-            let filter = NetworkFilter::parse("|foo.com/bar/baz", true).unwrap();
+            let filter = NetworkFilter::parse("|foo.com/bar/baz", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.filter = Some(String::from("foo.com/bar/baz"));
             defaults.is_plain = true;
@@ -1867,7 +1870,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
         }
         {
-            let filter = NetworkFilter::parse("|foo.com^bar/*baz", true).unwrap();
+            let filter = NetworkFilter::parse("|foo.com^bar/*baz", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.filter = Some(String::from("foo.com^bar/*baz"));
             defaults.is_regex = true;
@@ -1880,7 +1883,7 @@ mod parse_tests {
     // |pattern|
     fn parses_left_right_anchor_pattern() {
         {
-            let filter = NetworkFilter::parse("|foo.com|", true).unwrap();
+            let filter = NetworkFilter::parse("|foo.com|", true, Default::default()).unwrap();
 
             let mut defaults = default_network_filter_breakdown();
             defaults.filter = Some(String::from("foo.com"));
@@ -1890,7 +1893,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
         }
         {
-            let filter = NetworkFilter::parse("|foo.com/bar|", true).unwrap();
+            let filter = NetworkFilter::parse("|foo.com/bar|", true, Default::default()).unwrap();
 
             let mut defaults = default_network_filter_breakdown();
             defaults.filter = Some(String::from("foo.com/bar"));
@@ -1900,7 +1903,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
         }
         {
-            let filter = NetworkFilter::parse("|foo.com*bar^|", true).unwrap();
+            let filter = NetworkFilter::parse("|foo.com*bar^|", true, Default::default()).unwrap();
 
             let mut defaults = default_network_filter_breakdown();
             defaults.filter = Some(String::from("foo.com*bar^"));
@@ -1915,7 +1918,7 @@ mod parse_tests {
     // ||regexp
     fn parses_hostname_anchor_regex_pattern() {
         {
-            let filter = NetworkFilter::parse("||foo.com*bar^", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com*bar^", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some(String::from("foo.com"));
             defaults.filter = Some(String::from("bar^"));
@@ -1925,7 +1928,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
         }
         {
-            let filter = NetworkFilter::parse("||foo.com^bar*/baz^", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com^bar*/baz^", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some(String::from("foo.com"));
             defaults.filter = Some(String::from("^bar*/baz^"));
@@ -1941,7 +1944,7 @@ mod parse_tests {
     // ||regexp|
     fn parses_hostname_right_anchor_regex_pattern() {
         {
-            let filter = NetworkFilter::parse("||foo.com*bar^|", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com*bar^|", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some(String::from("foo.com"));
             defaults.filter = Some(String::from("bar^"));
@@ -1952,7 +1955,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
         }
         {
-            let filter = NetworkFilter::parse("||foo.com^bar*/baz^|", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com^bar*/baz^|", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some(String::from("foo.com"));
             defaults.filter = Some(String::from("^bar*/baz^"));
@@ -1969,7 +1972,7 @@ mod parse_tests {
     // |regexp
     fn parses_hostname_left_anchor_regex_pattern() {
         {
-            let filter = NetworkFilter::parse("|foo.com*bar^", true).unwrap();
+            let filter = NetworkFilter::parse("|foo.com*bar^", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = None;
             defaults.filter = Some(String::from("foo.com*bar^"));
@@ -1979,7 +1982,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
         }
         {
-            let filter = NetworkFilter::parse("|foo.com^bar*/baz^", true).unwrap();
+            let filter = NetworkFilter::parse("|foo.com^bar*/baz^", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = None;
             defaults.filter = Some(String::from("foo.com^bar*/baz^"));
@@ -1994,7 +1997,7 @@ mod parse_tests {
     // |regexp|
     fn parses_hostname_left_right_anchor_regex_pattern() {
         {
-            let filter = NetworkFilter::parse("|foo.com*bar^|", true).unwrap();
+            let filter = NetworkFilter::parse("|foo.com*bar^|", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = None;
             defaults.filter = Some(String::from("foo.com*bar^"));
@@ -2005,7 +2008,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
         }
         {
-            let filter = NetworkFilter::parse("|foo.com^bar*/baz^|", true).unwrap();
+            let filter = NetworkFilter::parse("|foo.com^bar*/baz^|", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = None;
             defaults.filter = Some(String::from("foo.com^bar*/baz^"));
@@ -2021,7 +2024,7 @@ mod parse_tests {
     // @@pattern
     fn parses_exception_pattern() {
         {
-            let filter = NetworkFilter::parse("@@ads", true).unwrap();
+            let filter = NetworkFilter::parse("@@ads", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.is_exception = true;
             defaults.filter = Some(String::from("ads"));
@@ -2029,7 +2032,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter));
         }
         {
-            let filter = NetworkFilter::parse("@@||foo.com/ads", true).unwrap();
+            let filter = NetworkFilter::parse("@@||foo.com/ads", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.is_exception = true;
             defaults.filter = Some(String::from("/ads"));
@@ -2040,7 +2043,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter));
         }
         {
-            let filter = NetworkFilter::parse("@@|foo.com/ads", true).unwrap();
+            let filter = NetworkFilter::parse("@@|foo.com/ads", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.is_exception = true;
             defaults.filter = Some(String::from("foo.com/ads"));
@@ -2049,7 +2052,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter));
         }
         {
-            let filter = NetworkFilter::parse("@@|foo.com/ads|", true).unwrap();
+            let filter = NetworkFilter::parse("@@|foo.com/ads|", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.is_exception = true;
             defaults.filter = Some(String::from("foo.com/ads"));
@@ -2059,7 +2062,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter));
         }
         {
-            let filter = NetworkFilter::parse("@@foo.com/ads|", true).unwrap();
+            let filter = NetworkFilter::parse("@@foo.com/ads|", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.is_exception = true;
             defaults.filter = Some(String::from("foo.com/ads"));
@@ -2068,7 +2071,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter));
         }
         {
-            let filter = NetworkFilter::parse("@@||foo.com/ads|", true).unwrap();
+            let filter = NetworkFilter::parse("@@||foo.com/ads|", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.is_exception = true;
             defaults.filter = Some(String::from("/ads"));
@@ -2086,7 +2089,7 @@ mod parse_tests {
     #[test]
     fn accepts_any_content_type() {
         {
-            let filter = NetworkFilter::parse("||foo.com", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.from_network_types = true;
             defaults.hostname = Some(String::from("foo.com"));
@@ -2096,7 +2099,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter));
         }
         {
-            let filter = NetworkFilter::parse("||foo.com$first-party", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com$first-party", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.from_network_types = true;
             defaults.hostname = Some(String::from("foo.com"));
@@ -2108,7 +2111,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter));
         }
         {
-            let filter = NetworkFilter::parse("||foo.com$third-party", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com$third-party", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.from_network_types = true;
             defaults.hostname = Some(String::from("foo.com"));
@@ -2120,7 +2123,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter));
         }
         {
-            let filter = NetworkFilter::parse("||foo.com$domain=test.com", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com$domain=test.com", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.from_network_types = true;
             defaults.hostname = Some(String::from("foo.com"));
@@ -2132,7 +2135,7 @@ mod parse_tests {
         }
         {
             let filter =
-                NetworkFilter::parse("||foo.com$domain=test.com,match-case", true).unwrap();
+                NetworkFilter::parse("||foo.com$domain=test.com,match-case", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.from_network_types = true;
             defaults.hostname = Some(String::from("foo.com"));
@@ -2148,17 +2151,17 @@ mod parse_tests {
     #[test]
     fn parses_important() {
         {
-            let filter = NetworkFilter::parse("||foo.com$important", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com$important", true, Default::default()).unwrap();
             assert_eq!(filter.is_important(), true);
         }
         {
             // parses ~important
-            let filter = NetworkFilter::parse("||foo.com$~important", true);
+            let filter = NetworkFilter::parse("||foo.com$~important", true, Default::default());
             assert_eq!(filter.err(), Some(NetworkFilterError::NegatedImportant));
         }
         {
             // defaults to false
-            let filter = NetworkFilter::parse("||foo.com", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com", true, Default::default()).unwrap();
             assert_eq!(filter.is_important(), false);
         }
     }
@@ -2166,25 +2169,25 @@ mod parse_tests {
     #[test]
     fn parses_csp() {
         {
-            let filter = NetworkFilter::parse("||foo.com", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com", true, Default::default()).unwrap();
             assert_eq!(filter.csp, None);
         }
         {
             // parses simple CSP
-            let filter = NetworkFilter::parse(r#"||foo.com$csp=self bar """#, true).unwrap();
+            let filter = NetworkFilter::parse(r#"||foo.com$csp=self bar """#, true, Default::default()).unwrap();
             assert_eq!(filter.is_csp(), true);
             assert_eq!(filter.csp, Some(String::from(r#"self bar """#)));
         }
         {
             // parses empty CSP
-            let filter = NetworkFilter::parse("||foo.com$csp", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com$csp", true, Default::default()).unwrap();
             assert_eq!(filter.is_csp(), true);
             assert_eq!(filter.csp, None);
         }
         {
             // CSP mixed with content type is an error
             let filter =
-                NetworkFilter::parse(r#"||foo.com$domain=foo|bar,csp=self bar "",image"#, true);
+                NetworkFilter::parse(r#"||foo.com$domain=foo|bar,csp=self bar "",image"#, true, Default::default());
             assert_eq!(filter.err(), Some(NetworkFilterError::CspWithContentType));
         }
     }
@@ -2193,12 +2196,12 @@ mod parse_tests {
     fn parses_domain() {
         // parses domain
         {
-            let filter = NetworkFilter::parse("||foo.com$domain=bar.com", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com$domain=bar.com", true, Default::default()).unwrap();
             assert_eq!(filter.opt_domains, Some(vec![utils::fast_hash("bar.com")]));
             assert_eq!(filter.opt_not_domains, None);
         }
         {
-            let filter = NetworkFilter::parse("||foo.com$domain=bar.com|baz.com", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com$domain=bar.com|baz.com", true, Default::default()).unwrap();
             let mut domains = vec![utils::fast_hash("bar.com"), utils::fast_hash("baz.com")];
             domains.sort_unstable();
             assert_eq!(filter.opt_domains, Some(domains));
@@ -2207,7 +2210,7 @@ mod parse_tests {
 
         // parses ~domain
         {
-            let filter = NetworkFilter::parse("||foo.com$domain=~bar.com", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com$domain=~bar.com", true, Default::default()).unwrap();
             assert_eq!(filter.opt_domains, None);
             assert_eq!(
                 filter.opt_not_domains,
@@ -2215,7 +2218,7 @@ mod parse_tests {
             );
         }
         {
-            let filter = NetworkFilter::parse("||foo.com$domain=~bar.com|~baz.com", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com$domain=~bar.com|~baz.com", true, Default::default()).unwrap();
             assert_eq!(filter.opt_domains, None);
             let mut domains = vec![utils::fast_hash("bar.com"), utils::fast_hash("baz.com")];
             domains.sort_unstable();
@@ -2223,7 +2226,7 @@ mod parse_tests {
         }
         // parses domain and ~domain
         {
-            let filter = NetworkFilter::parse("||foo.com$domain=~bar.com|baz.com", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com$domain=~bar.com|baz.com", true, Default::default()).unwrap();
             assert_eq!(filter.opt_domains, Some(vec![utils::fast_hash("baz.com")]));
             assert_eq!(
                 filter.opt_not_domains,
@@ -2231,7 +2234,7 @@ mod parse_tests {
             );
         }
         {
-            let filter = NetworkFilter::parse("||foo.com$domain=bar.com|~baz.com", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com$domain=bar.com|~baz.com", true, Default::default()).unwrap();
             assert_eq!(filter.opt_domains, Some(vec![utils::fast_hash("bar.com")]));
             assert_eq!(
                 filter.opt_not_domains,
@@ -2239,7 +2242,7 @@ mod parse_tests {
             );
         }
         {
-            let filter = NetworkFilter::parse("||foo.com$domain=foo|~bar|baz", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com$domain=foo|~bar|baz", true, Default::default()).unwrap();
             let mut domains = vec![utils::fast_hash("foo"), utils::fast_hash("baz")];
             domains.sort();
             assert_eq!(filter.opt_domains, Some(domains));
@@ -2247,42 +2250,101 @@ mod parse_tests {
         }
         // defaults to no constraint
         {
-            let filter = NetworkFilter::parse("||foo.com", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com", true, Default::default()).unwrap();
             assert_eq!(filter.opt_domains, None);
             assert_eq!(filter.opt_not_domains, None);
         }
     }
 
     #[test]
+    fn parses_redirect_urls() {
+        let opts = ParseOptions { parse_redirect_urls: true, ..Default::default() };
+        {
+            // No parsing without parse option
+            let filter = NetworkFilter::parse("||foo.com$redirect-url=http://xyz.com", true, Default::default());
+            let err = filter.clone().err();
+            assert_eq!(err, Some(NetworkFilterError::UnrecognisedOption));
+        }
+        {
+            let filter = NetworkFilter::parse("||foo.com$redirect-url=http://xyz.com", true, opts).unwrap();
+            assert_eq!(filter.redirect, Some(String::from("http://xyz.com")));
+            assert_eq!(filter.is_redirect_url(), true);
+        }
+        {
+            let filter = NetworkFilter::parse("$redirect-url=http://xyz.com", true, opts).unwrap();
+            assert_eq!(filter.is_redirect_url(), true);
+            assert_eq!(filter.redirect, Some(String::from("http://xyz.com")));
+        }
+        // parses ~redirect-url
+        {
+            // ~redirect-url is not a valid option
+            let filter = NetworkFilter::parse("||foo.com$~redirect-url", true, opts);
+            let err = filter.clone().err();
+            assert_eq!(err, Some(NetworkFilterError::NegatedRedirection));
+        }
+        // parses redirect-url without a value
+        {
+            // Not valid
+            let filter = NetworkFilter::parse("||foo.com$redirect-url", true, opts);
+            let err = filter.clone().err();
+            assert_eq!(err, Some(NetworkFilterError::EmptyRedirection));
+        }
+        {
+            let filter = NetworkFilter::parse("||foo.com$redirect-url=", true, opts);
+            let err = filter.clone().err();
+            assert_eq!(err, Some(NetworkFilterError::EmptyRedirection))
+        }
+        {
+            // Has to be valid URL
+            let filter = NetworkFilter::parse("||foo.com$redirect-url=xyz.com", true, opts);
+            let err = filter.clone().err();
+            assert_eq!(err, Some(NetworkFilterError::RedirectionUrlInvalid))
+        }
+        {
+            // only one between redirect and redirect-url can be specified
+            let filter = NetworkFilter::parse("||foo.com$redirect=xyz,redirect-url=http://xyz.com", true, opts);
+            let err = filter.clone().err();
+            assert_eq!(err, Some(NetworkFilterError::MultipleRedirections))
+        }
+        // defaults to false
+        {
+            let filter = NetworkFilter::parse("||foo.com", true, opts).unwrap();
+            assert_eq!(filter.is_redirect_url(), false);
+            assert_eq!(filter.redirect, None);
+        }
+    }
+
+
+    #[test]
     fn parses_redirects() {
         // parses redirect
         {
-            let filter = NetworkFilter::parse("||foo.com$redirect=bar.js", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com$redirect=bar.js", true, Default::default()).unwrap();
             assert_eq!(filter.redirect, Some(String::from("bar.js")));
         }
         {
-            let filter = NetworkFilter::parse("$redirect=bar.js", true).unwrap();
+            let filter = NetworkFilter::parse("$redirect=bar.js", true, Default::default()).unwrap();
             assert_eq!(filter.redirect, Some(String::from("bar.js")));
         }
         // parses ~redirect
         {
             // ~redirect is not a valid option
-            let filter = NetworkFilter::parse("||foo.com$~redirect", true);
+            let filter = NetworkFilter::parse("||foo.com$~redirect", true, Default::default());
             assert_eq!(filter.err(), Some(NetworkFilterError::NegatedRedirection));
         }
         // parses redirect without a value
         {
             // Not valid
-            let filter = NetworkFilter::parse("||foo.com$redirect", true);
+            let filter = NetworkFilter::parse("||foo.com$redirect", true, Default::default());
             assert_eq!(filter.err(), Some(NetworkFilterError::EmptyRedirection));
         }
         {
-            let filter = NetworkFilter::parse("||foo.com$redirect=", true);
+            let filter = NetworkFilter::parse("||foo.com$redirect=", true, Default::default());
             assert_eq!(filter.err(), Some(NetworkFilterError::EmptyRedirection))
         }
         // defaults to false
         {
-            let filter = NetworkFilter::parse("||foo.com", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com", true, Default::default()).unwrap();
             assert_eq!(filter.redirect, None);
         }
     }
@@ -2291,28 +2353,28 @@ mod parse_tests {
     fn parses_match_case() {
         // parses match-case
         {
-            let filter = NetworkFilter::parse("||foo.com$match-case", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com$match-case", true, Default::default()).unwrap();
             assert_eq!(filter.match_case(), true);
         }
         {
-            let filter = NetworkFilter::parse("||foo.com$image,match-case", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com$image,match-case", true, Default::default()).unwrap();
             assert_eq!(filter.match_case(), true);
         }
         {
-            let filter = NetworkFilter::parse("||foo.com$media,match-case,image", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com$media,match-case,image", true, Default::default()).unwrap();
             assert_eq!(filter.match_case(), true);
         }
 
         // parses ~match-case
         {
             // ~match-case is not supported
-            let filter = NetworkFilter::parse("||foo.com$~match-case", true);
+            let filter = NetworkFilter::parse("||foo.com$~match-case", true, Default::default());
             assert_eq!(filter.err(), Some(NetworkFilterError::NegatedOptionMatchCase));
         }
 
         // defaults to false
         {
-            let filter = NetworkFilter::parse("||foo.com", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com", true, Default::default()).unwrap();
             assert_eq!(filter.match_case(), false)
         }
     }
@@ -2321,39 +2383,39 @@ mod parse_tests {
     fn parses_first_party() {
         // parses first-party
         assert_eq!(
-            NetworkFilter::parse("||foo.com$first-party", true)
+            NetworkFilter::parse("||foo.com$first-party", true, Default::default())
                 .unwrap()
                 .first_party(),
             true
         );
         assert_eq!(
-            NetworkFilter::parse("@@||foo.com$first-party", true)
+            NetworkFilter::parse("@@||foo.com$first-party", true, Default::default())
                 .unwrap()
                 .first_party(),
             true
         );
         assert_eq!(
-            NetworkFilter::parse("@@||foo.com|$first-party", true)
+            NetworkFilter::parse("@@||foo.com|$first-party", true, Default::default())
                 .unwrap()
                 .first_party(),
             true
         );
         // parses ~first-party
         assert_eq!(
-            NetworkFilter::parse("||foo.com$~first-party", true)
+            NetworkFilter::parse("||foo.com$~first-party", true, Default::default())
                 .unwrap()
                 .first_party(),
             false
         );
         assert_eq!(
-            NetworkFilter::parse("||foo.com$first-party,~first-party", true)
+            NetworkFilter::parse("||foo.com$first-party,~first-party", true, Default::default())
                 .unwrap()
                 .first_party(),
             false
         );
         // defaults to true
         assert_eq!(
-            NetworkFilter::parse("||foo.com", true)
+            NetworkFilter::parse("||foo.com", true, Default::default())
                 .unwrap()
                 .first_party(),
             true
@@ -2364,45 +2426,45 @@ mod parse_tests {
     fn parses_third_party() {
         // parses third-party
         assert_eq!(
-            NetworkFilter::parse("||foo.com$third-party", true)
+            NetworkFilter::parse("||foo.com$third-party", true, Default::default())
                 .unwrap()
                 .third_party(),
             true
         );
         assert_eq!(
-            NetworkFilter::parse("@@||foo.com$third-party", true)
+            NetworkFilter::parse("@@||foo.com$third-party", true, Default::default())
                 .unwrap()
                 .third_party(),
             true
         );
         assert_eq!(
-            NetworkFilter::parse("@@||foo.com|$third-party", true)
+            NetworkFilter::parse("@@||foo.com|$third-party", true, Default::default())
                 .unwrap()
                 .third_party(),
             true
         );
         assert_eq!(
-            NetworkFilter::parse("||foo.com$~first-party", true)
+            NetworkFilter::parse("||foo.com$~first-party", true, Default::default())
                 .unwrap()
                 .third_party(),
             true
         );
         // parses ~third-party
         assert_eq!(
-            NetworkFilter::parse("||foo.com$~third-party", true)
+            NetworkFilter::parse("||foo.com$~third-party", true, Default::default())
                 .unwrap()
                 .third_party(),
             false
         );
         assert_eq!(
-            NetworkFilter::parse("||foo.com$first-party,~third-party", true)
+            NetworkFilter::parse("||foo.com$first-party,~third-party", true, Default::default())
                 .unwrap()
                 .third_party(),
             false
         );
         // defaults to true
         assert_eq!(
-            NetworkFilter::parse("||foo.com", true)
+            NetworkFilter::parse("||foo.com", true, Default::default())
                 .unwrap()
                 .third_party(),
             true
@@ -2413,24 +2475,24 @@ mod parse_tests {
     fn parses_bug() {
         // parses bug
         {
-            let filter = NetworkFilter::parse("||foo.com$bug=42", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com$bug=42", true, Default::default()).unwrap();
             assert_eq!(filter.has_bug(), true);
             assert_eq!(filter.bug, Some(42));
         }
         {
-            let filter = NetworkFilter::parse("@@||foo.com$bug=1337", true).unwrap();
+            let filter = NetworkFilter::parse("@@||foo.com$bug=1337", true, Default::default()).unwrap();
             assert_eq!(filter.is_exception(), true);
             assert_eq!(filter.has_bug(), true);
             assert_eq!(filter.bug, Some(1337));
         }
         {
-            let filter = NetworkFilter::parse("@@||foo.com|$bug=11111", true).unwrap();
+            let filter = NetworkFilter::parse("@@||foo.com|$bug=11111", true, Default::default()).unwrap();
             assert_eq!(filter.is_exception(), true);
             assert_eq!(filter.has_bug(), true);
             assert_eq!(filter.bug, Some(11111));
         }
         {
-            let filter = NetworkFilter::parse("@@$bug=11111", true).unwrap();
+            let filter = NetworkFilter::parse("@@$bug=11111", true, Default::default()).unwrap();
             assert_eq!(filter.is_exception(), true);
             assert_eq!(filter.has_bug(), true);
             assert_eq!(filter.bug, Some(11111));
@@ -2438,7 +2500,7 @@ mod parse_tests {
 
         // defaults to undefined
         {
-            let filter = NetworkFilter::parse("||foo.com", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com", true, Default::default()).unwrap();
             assert_eq!(filter.has_bug(), false);
             assert_eq!(filter.bug, None);
         }
@@ -2447,27 +2509,27 @@ mod parse_tests {
     #[test]
     fn parses_generic_hide() {
         {
-            let filter = NetworkFilter::parse("||foo.com$generichide", true);
+            let filter = NetworkFilter::parse("||foo.com$generichide", true, Default::default());
             assert!(filter.is_err());
         }
         {
-            let filter = NetworkFilter::parse("@@||foo.com$generichide", true).unwrap();
+            let filter = NetworkFilter::parse("@@||foo.com$generichide", true, Default::default()).unwrap();
             assert_eq!(filter.is_exception(), true);
             assert_eq!(filter.is_generic_hide(), true);
         }
         {
-            let filter = NetworkFilter::parse("@@||foo.com|$generichide", true).unwrap();
+            let filter = NetworkFilter::parse("@@||foo.com|$generichide", true, Default::default()).unwrap();
             assert_eq!(filter.is_exception(), true);
             assert_eq!(filter.is_generic_hide(), true);
         }
         {
-            let filter = NetworkFilter::parse("@@$generichide,domain=example.com", true).unwrap();
+            let filter = NetworkFilter::parse("@@$generichide,domain=example.com", true, Default::default()).unwrap();
             assert_eq!(filter.is_generic_hide(), true);
             let breakdown = NetworkFilterBreakdown::from(&filter);
             assert_eq!(breakdown.opt_domains, Some(vec![utils::fast_hash("example.com")]));
         }
         {
-            let filter = NetworkFilter::parse("||foo.com", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com", true, Default::default()).unwrap();
             assert_eq!(filter.is_generic_hide(), false);
         }
     }
@@ -2520,7 +2582,7 @@ mod parse_tests {
         ];
 
         for option in options {
-            let filter = NetworkFilter::parse(&format!("||foo.com${}", option), true);
+            let filter = NetworkFilter::parse(&format!("||foo.com${}", option), true, Default::default());
             assert!(filter.err().is_some());
         }
     }
@@ -2579,7 +2641,7 @@ mod parse_tests {
         for option in options {
             // positive
             {
-                let filter = NetworkFilter::parse(&format!("||foo.com${}", option), true).unwrap();
+                let filter = NetworkFilter::parse(&format!("||foo.com${}", option), true, Default::default()).unwrap();
                 let mut defaults = default_network_filter_breakdown();
                 defaults.hostname = Some(String::from("foo.com"));
                 defaults.is_hostname_anchor = true;
@@ -2592,7 +2654,7 @@ mod parse_tests {
 
             {
                 let filter =
-                    NetworkFilter::parse(&format!("||foo.com$object,{}", option), true).unwrap();
+                    NetworkFilter::parse(&format!("||foo.com$object,{}", option), true, Default::default()).unwrap();
                 let mut defaults = default_network_filter_breakdown();
                 defaults.hostname = Some(String::from("foo.com"));
                 defaults.is_hostname_anchor = true;
@@ -2606,7 +2668,7 @@ mod parse_tests {
 
             {
                 let filter =
-                    NetworkFilter::parse(&format!("||foo.com$domain=bar.com,{}", option), true)
+                    NetworkFilter::parse(&format!("||foo.com$domain=bar.com,{}", option), true, Default::default())
                         .unwrap();
                 let mut defaults = default_network_filter_breakdown();
                 defaults.hostname = Some(String::from("foo.com"));
@@ -2621,7 +2683,7 @@ mod parse_tests {
 
             // negative
             {
-                let filter = NetworkFilter::parse(&format!("||foo.com$~{}", option), true).unwrap();
+                let filter = NetworkFilter::parse(&format!("||foo.com$~{}", option), true, Default::default()).unwrap();
                 let mut defaults = default_network_filter_breakdown();
                 defaults.hostname = Some(String::from("foo.com"));
                 defaults.is_hostname_anchor = true;
@@ -2634,7 +2696,7 @@ mod parse_tests {
 
             {
                 let filter =
-                    NetworkFilter::parse(&format!("||foo.com${},~{}", option, option), true)
+                    NetworkFilter::parse(&format!("||foo.com${},~{}", option, option), true, Default::default())
                         .unwrap();
                 let mut defaults = default_network_filter_breakdown();
                 defaults.hostname = Some(String::from("foo.com"));
@@ -2647,7 +2709,7 @@ mod parse_tests {
             }
             // default - positive
             {
-                let filter = NetworkFilter::parse(&format!("||foo.com"), true).unwrap();
+                let filter = NetworkFilter::parse(&format!("||foo.com"), true, Default::default()).unwrap();
                 let mut defaults = default_network_filter_breakdown();
                 defaults.hostname = Some(String::from("foo.com"));
                 defaults.is_hostname_anchor = true;
@@ -2663,7 +2725,7 @@ mod parse_tests {
     fn binary_serialization_works() {
         use rmp_serde::{Deserializer, Serializer};
         {
-            let filter = NetworkFilter::parse("||foo.com/bar/baz$important", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com/bar/baz$important", true, Default::default()).unwrap();
 
             let mut encoded = Vec::new();
             filter.serialize(&mut Serializer::new(&mut encoded)).unwrap();
@@ -2680,7 +2742,7 @@ mod parse_tests {
             assert_eq!(defaults, NetworkFilterBreakdown::from(&decoded))
         }
         {
-            let filter = NetworkFilter::parse("||foo.com*bar^", true).unwrap();
+            let filter = NetworkFilter::parse("||foo.com*bar^", true, Default::default()).unwrap();
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some(String::from("foo.com"));
             defaults.filter = Some(String::from("bar^"));
@@ -2701,7 +2763,7 @@ mod parse_tests {
 
     #[test]
     fn parse_empty_host_anchor_exception() {
-        let filter_parsed = NetworkFilter::parse("@@||$domain=auth.wi-fi.ru", true);
+        let filter_parsed = NetworkFilter::parse("@@||$domain=auth.wi-fi.ru", true, Default::default());
         assert!(filter_parsed.is_ok());
 
         let filter = filter_parsed.unwrap();
@@ -2806,7 +2868,7 @@ mod match_tests {
     }
 
     fn filter_match_url(filter: &str, url: &str, matching: bool) {
-        let network_filter = NetworkFilter::parse(filter, true).unwrap();
+        let network_filter = NetworkFilter::parse(filter, true, Default::default()).unwrap();
         let request = request::Request::from_url(url).unwrap();
 
         assert!(
@@ -2988,7 +3050,7 @@ mod match_tests {
         {
             let filter = "@@||fastly.net/ad2/$image,script,xmlhttprequest";
             let url = "https://0914.global.ssl.fastly.net/ad2/script/x.js?cb=1549980040838";
-            let network_filter = NetworkFilter::parse(filter, true).unwrap();
+            let network_filter = NetworkFilter::parse(filter, true, Default::default()).unwrap();
             let request = request::Request::from_urls(
                 url,
                 "https://www.gamespot.com/metro-exodus/",
@@ -3005,7 +3067,7 @@ mod match_tests {
         {
             let filter = "@@||swatchseries.to/public/js/edit-show.js$script,domain=swatchseries.to";
             let url = "https://www1.swatchseries.to/public/js/edit-show.js";
-            let network_filter = NetworkFilter::parse(filter, true).unwrap();
+            let network_filter = NetworkFilter::parse(filter, true, Default::default()).unwrap();
             let request = request::Request::from_urls(
                 url,
                 "https://www1.swatchseries.to/serie/roswell_new_mexico",
@@ -3023,7 +3085,7 @@ mod match_tests {
 
     #[test]
     fn check_ws_vs_http_matching() {
-        let network_filter = NetworkFilter::parse("|ws://$domain=4shared.com", true).unwrap();
+        let network_filter = NetworkFilter::parse("|ws://$domain=4shared.com", true, Default::default()).unwrap();
 
         assert!(network_filter.matches(&request::Request::from_urls("ws://example.com", "https://4shared.com", "websocket").unwrap()));
         assert!(network_filter.matches(&request::Request::from_urls("wss://example.com", "https://4shared.com", "websocket").unwrap()));
@@ -3042,31 +3104,31 @@ mod match_tests {
     fn check_options_works() {
         // cpt test
         {
-            let network_filter = NetworkFilter::parse("||foo$image", true).unwrap();
+            let network_filter = NetworkFilter::parse("||foo$image", true, Default::default()).unwrap();
             let request = request::Request::from_urls("https://foo.com/bar", "", "image").unwrap();
             assert_eq!(check_options(&network_filter, &request), true);
         }
         {
-            let network_filter = NetworkFilter::parse("||foo$image", true).unwrap();
+            let network_filter = NetworkFilter::parse("||foo$image", true, Default::default()).unwrap();
             let request = request::Request::from_urls("https://foo.com/bar", "", "script").unwrap();
             assert_eq!(check_options(&network_filter, &request), false);
         }
         {
-            let network_filter = NetworkFilter::parse("||foo$~image", true).unwrap();
+            let network_filter = NetworkFilter::parse("||foo$~image", true, Default::default()).unwrap();
             let request = request::Request::from_urls("https://foo.com/bar", "", "script").unwrap();
             assert_eq!(check_options(&network_filter, &request), true);
         }
 
         // ~third-party
         {
-            let network_filter = NetworkFilter::parse("||foo$~third-party", true).unwrap();
+            let network_filter = NetworkFilter::parse("||foo$~third-party", true, Default::default()).unwrap();
             let request =
                 request::Request::from_urls("https://foo.com/bar", "http://baz.foo.com", "")
                     .unwrap();
             assert_eq!(check_options(&network_filter, &request), true);
         }
         {
-            let network_filter = NetworkFilter::parse("||foo$~third-party", true).unwrap();
+            let network_filter = NetworkFilter::parse("||foo$~third-party", true, Default::default()).unwrap();
             let request =
                 request::Request::from_urls("https://foo.com/bar", "http://baz.bar.com", "")
                     .unwrap();
@@ -3075,14 +3137,14 @@ mod match_tests {
 
         // ~first-party
         {
-            let network_filter = NetworkFilter::parse("||foo$~first-party", true).unwrap();
+            let network_filter = NetworkFilter::parse("||foo$~first-party", true, Default::default()).unwrap();
             let request =
                 request::Request::from_urls("https://foo.com/bar", "http://baz.bar.com", "")
                     .unwrap();
             assert_eq!(check_options(&network_filter, &request), true);
         }
         {
-            let network_filter = NetworkFilter::parse("||foo$~first-party", true).unwrap();
+            let network_filter = NetworkFilter::parse("||foo$~first-party", true, Default::default()).unwrap();
             let request =
                 request::Request::from_urls("https://foo.com/bar", "http://baz.foo.com", "")
                     .unwrap();
@@ -3091,13 +3153,13 @@ mod match_tests {
 
         // opt-domain
         {
-            let network_filter = NetworkFilter::parse("||foo$domain=foo.com", true).unwrap();
+            let network_filter = NetworkFilter::parse("||foo$domain=foo.com", true, Default::default()).unwrap();
             let request =
                 request::Request::from_urls("https://foo.com/bar", "http://foo.com", "").unwrap();
             assert_eq!(check_options(&network_filter, &request), true);
         }
         {
-            let network_filter = NetworkFilter::parse("||foo$domain=foo.com", true).unwrap();
+            let network_filter = NetworkFilter::parse("||foo$domain=foo.com", true, Default::default()).unwrap();
             let request =
                 request::Request::from_urls("https://foo.com/bar", "http://bar.com", "").unwrap();
             assert_eq!(check_options(&network_filter, &request), false);
@@ -3105,13 +3167,13 @@ mod match_tests {
 
         // opt-not-domain
         {
-            let network_filter = NetworkFilter::parse("||foo$domain=~bar.com", true).unwrap();
+            let network_filter = NetworkFilter::parse("||foo$domain=~bar.com", true, Default::default()).unwrap();
             let request =
                 request::Request::from_urls("https://foo.com/bar", "http://foo.com", "").unwrap();
             assert_eq!(check_options(&network_filter, &request), true);
         }
         {
-            let network_filter = NetworkFilter::parse("||foo$domain=~bar.com", true).unwrap();
+            let network_filter = NetworkFilter::parse("||foo$domain=~bar.com", true, Default::default()).unwrap();
             let request =
                 request::Request::from_urls("https://foo.com/bar", "http://bar.com", "").unwrap();
             assert_eq!(check_options(&network_filter, &request), false);
@@ -3121,7 +3183,7 @@ mod match_tests {
     #[test]
     fn check_domain_option_subsetting_works() {
         {
-            let network_filter = NetworkFilter::parse("adv$domain=example.com|~foo.example.com", true).unwrap();
+            let network_filter = NetworkFilter::parse("adv$domain=example.com|~foo.example.com", true, Default::default()).unwrap();
             assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://example.com", "").unwrap()) == true);
             assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://foo.example.com", "").unwrap()) == false);
             assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://subfoo.foo.example.com", "").unwrap()) == false);
@@ -3129,7 +3191,7 @@ mod match_tests {
             assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://anotherexample.com", "").unwrap()) == false);
         }
         {
-            let network_filter = NetworkFilter::parse("adv$domain=~example.com|~foo.example.com", true).unwrap();
+            let network_filter = NetworkFilter::parse("adv$domain=~example.com|~foo.example.com", true, Default::default()).unwrap();
             assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://example.com", "").unwrap()) == false);
             assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://foo.example.com", "").unwrap()) == false);
             assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://subfoo.foo.example.com", "").unwrap()) == false);
@@ -3137,7 +3199,7 @@ mod match_tests {
             assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://anotherexample.com", "").unwrap()) == true);
         }
         {
-            let network_filter = NetworkFilter::parse("adv$domain=example.com|foo.example.com", true).unwrap();
+            let network_filter = NetworkFilter::parse("adv$domain=example.com|foo.example.com", true, Default::default()).unwrap();
             assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://example.com", "").unwrap()) == true);
             assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://foo.example.com", "").unwrap()) == true);
             assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://subfoo.foo.example.com", "").unwrap()) == true);
@@ -3145,7 +3207,7 @@ mod match_tests {
             assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://anotherexample.com", "").unwrap()) == false);
         }
         {
-            let network_filter = NetworkFilter::parse("adv$domain=~example.com|foo.example.com", true).unwrap();
+            let network_filter = NetworkFilter::parse("adv$domain=~example.com|foo.example.com", true, Default::default()).unwrap();
             assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://example.com", "").unwrap()) == false);
             assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://foo.example.com", "").unwrap()) == false);
             assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://subfoo.foo.example.com", "").unwrap()) == false);
@@ -3153,7 +3215,7 @@ mod match_tests {
             assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://anotherexample.com", "").unwrap()) == false);
         }
         {
-            let network_filter = NetworkFilter::parse("adv$domain=com|~foo.com", true).unwrap();
+            let network_filter = NetworkFilter::parse("adv$domain=com|~foo.com", true, Default::default()).unwrap();
             assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://com", "").unwrap()) == true);
             assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://foo.com", "").unwrap()) == false);
             assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://subfoo.foo.com", "").unwrap()) == false);
@@ -3194,7 +3256,7 @@ mod match_tests {
             // regex escaping "\/" unrecognised
             let filter =
                 r#"/^https?:\/\/.*(bitly|bit)\.(com|ly)\/.*/$domain=123movies.com|1337x.to"#;
-            let network_filter = NetworkFilter::parse(filter, true).unwrap();
+            let network_filter = NetworkFilter::parse(filter, true, Default::default()).unwrap();
             let url = "https://bit.ly/bar/";
             let source = "http://123movies.com";
             let request = request::Request::from_urls(url, source, "").unwrap();
@@ -3208,7 +3270,7 @@ mod match_tests {
         {
             // regex escaping "\:" unrecognised
             let filter = r#"/\:\/\/data.*\.com\/[a-zA-Z0-9]{30,}/$third-party,xmlhttprequest"#;
-            let network_filter = NetworkFilter::parse(filter, true).unwrap();
+            let network_filter = NetworkFilter::parse(filter, true, Default::default()).unwrap();
             let url = "https://data.foo.com/9VjjrjU9Or2aqkb8PDiqTBnULPgeI48WmYEHkYer";
             let source = "http://123movies.com";
             let request = request::Request::from_urls(url, source, "xmlhttprequest").unwrap();
@@ -3222,7 +3284,7 @@ mod match_tests {
         //
         {
             let filter = r#"/\.(accountant|bid|click|club|com|cricket|date|download|faith|link|loan|lol|men|online|party|racing|review|science|site|space|stream|top|trade|webcam|website|win|xyz|com)\/(([0-9]{2,9})(\.|\/)(css|\?)?)$/$script,stylesheet,third-party,xmlhttprequest"#;
-            let network_filter = NetworkFilter::parse(filter, true).unwrap();
+            let network_filter = NetworkFilter::parse(filter, true, Default::default()).unwrap();
             let url = "https://hello.club/123.css";
             let source = "http://123movies.com";
             let request = request::Request::from_urls(url, source, "stylesheet").unwrap();
@@ -3240,7 +3302,7 @@ mod match_tests {
     fn check_lookaround_regex_handled() {
         {
             let filter = r#"/^https?:\/\/([0-9a-z\-]+\.)?(9anime|animeland|animenova|animeplus|animetoon|animewow|gamestorrent|goodanime|gogoanime|igg-games|kimcartoon|memecenter|readcomiconline|toonget|toonova|watchcartoononline)\.[a-z]{2,4}\/(?!([Ee]xternal|[Ii]mages|[Ss]cripts|[Uu]ploads|ac|ajax|assets|combined|content|cov|cover|(img\/bg)|(img\/icon)|inc|jwplayer|player|playlist-cat-rss|static|thumbs|wp-content|wp-includes)\/)(.*)/$image,other,script,~third-party,xmlhttprequest,domain=~animeland.hu"#;
-            let network_filter = NetworkFilter::parse(filter, true).unwrap();
+            let network_filter = NetworkFilter::parse(filter, true, Default::default()).unwrap();
             let regex = Arc::try_unwrap(network_filter.get_regex()).unwrap();
             assert!(
                 matches!(regex, CompiledRegex::Compiled(_)),
@@ -3263,7 +3325,7 @@ mod match_tests {
     fn check_empty_host_anchor_matches() {
         {
             let filter = "||$domain=auth.wi-fi.ru";
-            let network_filter = NetworkFilter::parse(filter, true).unwrap();
+            let network_filter = NetworkFilter::parse(filter, true, Default::default()).unwrap();
             let url = "https://example.com/ad.js";
             let source = "http://auth.wi-fi.ru";
             let request = request::Request::from_urls(url, source, "script").unwrap();
@@ -3276,7 +3338,7 @@ mod match_tests {
         }
         {
             let filter = "@@||$domain=auth.wi-fi.ru";
-            let network_filter = NetworkFilter::parse(filter, true).unwrap();
+            let network_filter = NetworkFilter::parse(filter, true, Default::default()).unwrap();
             let url = "https://example.com/ad.js";
             let source = "http://auth.wi-fi.ru";
             let request = request::Request::from_urls(url, source, "script").unwrap();
@@ -3293,7 +3355,7 @@ mod match_tests {
     fn check_url_path_regex_matches() {
         {
             let filter = "@@||www.google.com/aclk?*&adurl=$document,~third-party";
-            let network_filter = NetworkFilter::parse(filter, true).unwrap();
+            let network_filter = NetworkFilter::parse(filter, true, Default::default()).unwrap();
             let url = "https://www.google.com/aclk?sa=l&ai=DChcSEwioqMfq5ovjAhVvte0KHXBYDKoYABAJGgJkZw&sig=AOD64_0IL5OYOIkZA7qWOBt0yRmKL4hKJw&ctype=5&q=&ved=0ahUKEwjQ88Hq5ovjAhXYiVwKHWAgB5gQww8IXg&adurl=";
             let source = "https://www.google.com/aclk?sa=l&ai=DChcSEwioqMfq5ovjAhVvte0KHXBYDKoYABAJGgJkZw&sig=AOD64_0IL5OYOIkZA7qWOBt0yRmKL4hKJw&ctype=5&q=&ved=0ahUKEwjQ88Hq5ovjAhXYiVwKHWAgB5gQww8IXg&adurl=";
             let request = request::Request::from_urls(url, source, "document").unwrap();
@@ -3307,7 +3369,7 @@ mod match_tests {
         }
         {
             let filter = "@@||www.google.*/aclk?$first-party";
-            let network_filter = NetworkFilter::parse(filter, true).unwrap();
+            let network_filter = NetworkFilter::parse(filter, true, Default::default()).unwrap();
             let url = "https://www.google.com/aclk?sa=l&ai=DChcSEwioqMfq5ovjAhVvte0KHXBYDKoYABAJGgJkZw&sig=AOD64_0IL5OYOIkZA7qWOBt0yRmKL4hKJw&ctype=5&q=&ved=0ahUKEwjQ88Hq5ovjAhXYiVwKHWAgB5gQww8IXg&adurl=";
             let source = "https://www.google.com/aclk?sa=l&ai=DChcSEwioqMfq5ovjAhVvte0KHXBYDKoYABAJGgJkZw&sig=AOD64_0IL5OYOIkZA7qWOBt0yRmKL4hKJw&ctype=5&q=&ved=0ahUKEwjQ88Hq5ovjAhXYiVwKHWAgB5gQww8IXg&adurl=";
             let request = request::Request::from_urls(url, source, "main_frame").unwrap();

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -385,7 +385,7 @@ fn parse_filter_options(raw_options: &str, opts: ParseOptions) -> Result<Vec<Net
             ("redirect-url", true) => return Err(NetworkFilterError::NegatedRedirection),
             ("redirect-url", false) => {
                 // Only parse filter option if parse options allow it
-                if !opts.parse_redirect_urls {
+                if !opts.include_redirect_urls {
                     return Err(NetworkFilterError::UnrecognisedOption);
                 }
                 // Ignore this filter if no redirection resource is specified
@@ -2258,7 +2258,7 @@ mod parse_tests {
 
     #[test]
     fn parses_redirect_urls() {
-        let opts = ParseOptions { parse_redirect_urls: true, ..Default::default() };
+        let opts = ParseOptions { include_redirect_urls: true, ..Default::default() };
         {
             // No parsing without parse option
             let filter = NetworkFilter::parse("||foo.com$redirect-url=http://xyz.com", true, Default::default());

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -28,13 +28,15 @@ pub enum RuleTypes {
 ///     ..ParseOptions::default()
 /// };
 /// ```
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Deserialize)]
 pub struct ParseOptions {
     /// Assume filters are in the given format when parsing. Defaults to `FilterFormat::Standard`.
+    #[serde(default)]
     pub format: FilterFormat,
     /// The `$redirect-url` filter option can redirect to an arbitrary HTTP/HTTPS resource over the
     /// network. By default this is disabled for security concerns, and any rule containing a
     /// `redirect-url` option will be ignored.
+    #[serde(default)]
     pub include_redirect_urls: bool,
 }
 
@@ -212,6 +214,13 @@ pub enum FilterFormat {
     /// For this option, `!` is accepted as a comment character at the beginning of a line, and `#`
     /// is accepted as a comment character anywhere in a line.
     Hosts,
+}
+
+/// Default to parsing lists in `Standard` format.
+impl Default for FilterFormat {
+    fn default() -> Self {
+        Self::Standard
+    }
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -35,14 +35,14 @@ pub struct ParseOptions {
     /// The `$redirect-url` filter option can redirect to an arbitrary HTTP/HTTPS resource over the
     /// network. By default this is disabled for security concerns, and any rule containing a
     /// `redirect-url` option will be ignored.
-    pub parse_redirect_urls: bool,
+    pub include_redirect_urls: bool,
 }
 
 impl Default for ParseOptions {
     fn default() -> Self {
         ParseOptions {
             format: FilterFormat::Standard,
-            parse_redirect_urls: false
+            include_redirect_urls: false
         }
     }
 }
@@ -113,36 +113,22 @@ impl FilterSet {
 
     /// Adds the contents of an entire filter list to this `FilterSet`. Filters that cannot be
     /// parsed successfully are ignored.
-    pub fn add_filter_list(&mut self, filter_list: &str, format: FilterFormat) {
-        let opts = ParseOptions { format, ..Default::default() };
-        self.add_filter_list_with_opts(filter_list, opts);
-    }
-
-    /// Adds the contents of an entire filter list to this `FilterSet` with ParseOptions.
-    /// Filters that cannot be parsed successfully are ignored.
-    pub fn add_filter_list_with_opts(&mut self, filter_list: &str, opts: ParseOptions) {
+    pub fn add_filter_list(&mut self, filter_list: &str, opts: ParseOptions) {
         let rules = filter_list.lines().map(str::to_string).collect::<Vec<_>>();
-        self.add_filters_with_opts(&rules, opts);
+        self.add_filters(&rules, opts);
     }
 
     /// Adds a collection of filter rules to this `FilterSet`. Filters that cannot be parsed
     /// successfully are ignored.
-    pub fn add_filters(&mut self, filters: &[String], format: FilterFormat) {
-        let opts = ParseOptions { format, ..Default::default() };
-        self.add_filters_with_opts(filters, opts);
-    }
-
-    /// Adds a collection of filter rules to this `FilterSet` with ParseOptions.
-    /// Filters that cannot be parsed successfully are ignored.
-    pub fn add_filters_with_opts(&mut self, filters: &[String], opts: ParseOptions) {
-        let (mut parsed_network_filters, mut parsed_cosmetic_filters) = parse_filters_with_opts(&filters, self.debug, opts);
+    pub fn add_filters(&mut self, filters: &[String], opts: ParseOptions) {
+        let (mut parsed_network_filters, mut parsed_cosmetic_filters) = parse_filters(&filters, self.debug, opts);
         self.network_filters.append(&mut parsed_network_filters);
         self.cosmetic_filters.append(&mut parsed_cosmetic_filters);
     }
 
     /// Adds the string representation of a single filter rule to this `FilterSet`.
-    pub fn add_filter(&mut self, filter: &str, format: FilterFormat) -> Result<(), FilterParseError> {
-        let filter_parsed = parse_filter(filter, self.debug, format);
+    pub fn add_filter(&mut self, filter: &str, opts: ParseOptions) -> Result<(), FilterParseError> {
+        let filter_parsed = parse_filter(filter, self.debug, opts);
         match filter_parsed? {
             ParsedFilter::Network(filter) => self.network_filters.push(filter),
             ParsedFilter::Cosmetic(filter) => self.cosmetic_filters.push(filter),
@@ -274,13 +260,12 @@ impl From<CosmeticFilterError> for FilterParseError {
     }
 }
 
-/// Parse a single filter rule with ParseOptions
-pub fn parse_filter_with_opts(
+/// Parse a single filter rule
+pub fn parse_filter(
     line: &str,
     debug: bool,
     opts: ParseOptions,
 ) -> Result<ParsedFilter, FilterParseError> {
-
     let filter = line.trim();
 
     if filter.is_empty() {
@@ -341,26 +326,16 @@ pub fn parse_filter_with_opts(
     }
 }
 
-/// Parse a single filter rule
-pub fn parse_filter(
-    line: &str,
-    debug: bool,
-    format: FilterFormat,
-) -> Result<ParsedFilter, FilterParseError> {
-    return parse_filter_with_opts(line, debug, ParseOptions {format, ..Default::default()});
-}
-
-/// Parse an entire list of filters with ParseOptions, ignoring any errors
-pub fn parse_filters_with_opts(
+/// Parse an entire list of filters, ignoring any errors
+pub fn parse_filters(
     list: &[String],
     debug: bool,
     opts: ParseOptions,
 ) -> (Vec<NetworkFilter>, Vec<CosmeticFilter>) {
-
     let list_iter = list.iter();
 
     let (network_filters, cosmetic_filters): (Vec<_>, Vec<_>) = list_iter
-        .map(|line| parse_filter_with_opts(line, debug, opts))
+        .map(|line| parse_filter(line, debug, opts))
         .filter_map(Result::ok)
         .partition_map(|filter| match filter {
             ParsedFilter::Network(f) => Either::Left(f),
@@ -368,15 +343,6 @@ pub fn parse_filters_with_opts(
         });
 
     (network_filters, cosmetic_filters)
-}
-
-/// Parse an entire list of filters, ignoring any errors
-pub fn parse_filters(
-    list: &[String],
-    debug: bool,
-    format: FilterFormat,
-) -> (Vec<NetworkFilter>, Vec<CosmeticFilter>) {
-    return parse_filters_with_opts(list, debug, ParseOptions {format, ..Default::default()});
 }
 
 /// Given a single line, checks if this would likely be a cosmetic filter, a
@@ -439,62 +405,62 @@ mod tests {
     fn parse_hosts_style() {
         {
             let input = "www.malware.com";
-            let result = parse_filter(input, true, FilterFormat::Hosts);
+            let result = parse_filter(input, true, ParseOptions { format: FilterFormat::Hosts, ..Default::default() });
             assert!(result.is_ok());
         }
         {
             let input = "www.malware.com/virus.txt";
-            let result = parse_filter(input, true, FilterFormat::Hosts);
+            let result = parse_filter(input, true, ParseOptions { format: FilterFormat::Hosts, ..Default::default() });
             assert!(result.is_err());
         }
         {
             let input = "127.0.0.1 www.malware.com";
-            let result = parse_filter(input, true, FilterFormat::Hosts);
+            let result = parse_filter(input, true, ParseOptions { format: FilterFormat::Hosts, ..Default::default() });
             assert!(result.is_ok());
         }
         {
             let input = "127.0.0.1\t\twww.malware.com";
-            let result = parse_filter(input, true, FilterFormat::Hosts);
+            let result = parse_filter(input, true, ParseOptions { format: FilterFormat::Hosts, ..Default::default() });
             assert!(result.is_ok());
         }
         {
             let input = "0.0.0.0    www.malware.com";
-            let result = parse_filter(input, true, FilterFormat::Hosts);
+            let result = parse_filter(input, true, ParseOptions { format: FilterFormat::Hosts, ..Default::default() });
             assert!(result.is_ok());
         }
         {
             let input = "0.0.0.0    www.malware.com     # replace after issue #289336 is addressed";
-            let result = parse_filter(input, true, FilterFormat::Hosts);
+            let result = parse_filter(input, true, ParseOptions { format: FilterFormat::Hosts, ..Default::default() });
             assert!(result.is_ok());
         }
         {
             let input = "! Title: list.txt";
-            let result = parse_filter(input, true, FilterFormat::Hosts);
+            let result = parse_filter(input, true, ParseOptions { format: FilterFormat::Hosts, ..Default::default() });
             assert!(result.is_err());
         }
         {
             let input = "127.0.0.1 localhost";
-            let result = parse_filter(input, true, FilterFormat::Hosts);
+            let result = parse_filter(input, true, ParseOptions { format: FilterFormat::Hosts, ..Default::default() });
             assert!(result.is_err());
         }
         {
             let input = "127.0.0.1 com";
-            let result = parse_filter(input, true, FilterFormat::Hosts);
+            let result = parse_filter(input, true, ParseOptions { format: FilterFormat::Hosts, ..Default::default() });
             assert!(result.is_err());
         }
         {
             let input = ".com";
-            let result = parse_filter(input, true, FilterFormat::Hosts);
+            let result = parse_filter(input, true, ParseOptions { format: FilterFormat::Hosts, ..Default::default() });
             assert!(result.is_err());
         }
         {
             let input = "*.com";
-            let result = parse_filter(input, true, FilterFormat::Hosts);
+            let result = parse_filter(input, true, ParseOptions { format: FilterFormat::Hosts, ..Default::default() });
             assert!(result.is_err());
         }
         {
             let input = "www.";
-            let result = parse_filter(input, true, FilterFormat::Hosts);
+            let result = parse_filter(input, true, ParseOptions { format: FilterFormat::Hosts, ..Default::default() });
             assert!(result.is_err());
         }
     }
@@ -502,20 +468,20 @@ mod tests {
     #[test]
     fn parse_filter_failed_fuzz_1() {
         let input = "Ѥ";
-        let result = parse_filter(input, true, FilterFormat::Standard);
+        let result = parse_filter(input, true, Default::default());
         assert!(result.is_ok());
     }
 
     #[test]
     fn parse_filter_failed_fuzz_2() {
-        assert!(parse_filter(r#"###\\\00DB \008D"#, true, FilterFormat::Standard).is_ok());
-        assert!(parse_filter(r#"###\Û"#, true, FilterFormat::Standard).is_ok());
+        assert!(parse_filter(r#"###\\\00DB \008D"#, true, Default::default()).is_ok());
+        assert!(parse_filter(r#"###\Û"#, true, Default::default()).is_ok());
     }
 
     #[test]
     fn parse_filter_failed_fuzz_3() {
         let input = "||$3p=/";
-        let result = parse_filter(input, true, FilterFormat::Standard);
+        let result = parse_filter(input, true, Default::default());
         assert!(result.is_ok());
     }
 
@@ -525,7 +491,7 @@ mod tests {
         assert!(parse_filter(
             &String::from_utf8(vec![92, 35, 35, 43, 106, 115, 40, 44, 221, 141]).unwrap(),
             true,
-            FilterFormat::Standard,
+            Default::default(),
         ).is_ok());
     }
 }

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -195,7 +195,7 @@ impl Optimization for UnionDomainGroup {
 #[cfg(test)]
 mod optimization_tests_pattern_group {
     use super::*;
-    use crate::lists::{self, FilterFormat};
+    use crate::lists;
     use crate::request::Request;
     use regex::RegexSet;
     use crate::filters::network::CompiledRegex;
@@ -245,7 +245,7 @@ mod optimization_tests_pattern_group {
             String::from("/static/adv/*"),
         ];
 
-        let (filters, _) = lists::parse_filters(&rules, true, FilterFormat::Standard);
+        let (filters, _) = lists::parse_filters(&rules, true, Default::default());
 
         let optimization = SimplePatternGroup {};
 
@@ -290,7 +290,7 @@ mod optimization_tests_pattern_group {
             String::from("/v1/ads/*"),
         ];
 
-        let (filters, _) = lists::parse_filters(&rules, true, FilterFormat::Standard);
+        let (filters, _) = lists::parse_filters(&rules, true, Default::default());
 
         let optimization = SimplePatternGroup {};
 
@@ -321,7 +321,7 @@ mod optimization_tests_pattern_group {
 #[cfg(test)]
 mod optimization_tests_union_domain {
     use super::*;
-    use crate::lists::{self, FilterFormat};
+    use crate::lists;
     use crate::request::Request;
     use crate::filters::network::NetworkMatchable;
     use crate::utils;
@@ -333,7 +333,7 @@ mod optimization_tests_union_domain {
             String::from("/analytics-v1$domain=example.com"),
         ];
 
-        let (filters, _) = lists::parse_filters(&rules, true, FilterFormat::Standard);
+        let (filters, _) = lists::parse_filters(&rules, true, Default::default());
         let optimization = UnionDomainGroup {};
         let (fused, _) = apply_optimisation(&optimization, filters);
 
@@ -363,7 +363,7 @@ mod optimization_tests_union_domain {
             String::from("/analytics-v1"),
         ];
 
-        let (filters, _) = lists::parse_filters(&rules, true, FilterFormat::Standard);
+        let (filters, _) = lists::parse_filters(&rules, true, Default::default());
         let optimization = UnionDomainGroup {};
         let (_, skipped) = apply_optimisation(&optimization, filters);
 
@@ -384,7 +384,7 @@ mod optimization_tests_union_domain {
             String::from("/analytics-v1"),
         ];
 
-        let (filters, _) = lists::parse_filters(&rules, true, FilterFormat::Standard);
+        let (filters, _) = lists::parse_filters(&rules, true, Default::default());
 
         let optimization = UnionDomainGroup {};
 

--- a/tests/hashing_test.rs
+++ b/tests/hashing_test.rs
@@ -1,5 +1,5 @@
 use adblock::utils;
-use adblock::lists::{parse_filters, FilterFormat};
+use adblock::lists::parse_filters;
 use adblock::filters::network::NetworkFilter;
 
 #[cfg(feature="full-domain-matching")]
@@ -11,7 +11,7 @@ fn get_network_filters() -> Vec<NetworkFilter> {
         String::from("data/easylist.to/easylist/easyprivacy.txt"),
     ]);
 
-    let (network_filters, _) = parse_filters(&rules_lists, true, FilterFormat::Standard);
+    let (network_filters, _) = parse_filters(&rules_lists, true, Default::default());
     network_filters
 }
 

--- a/tests/legacy_harness.rs
+++ b/tests/legacy_harness.rs
@@ -11,7 +11,7 @@ mod legacy_test_filters {
         blocked: &[&'a str],
         not_blocked: &[&'a str],
     ) {
-        let filter_res = NetworkFilter::parse(raw_filter, true);
+        let filter_res = NetworkFilter::parse(raw_filter, true, Default::default());
         assert!(
             filter_res.is_ok(),
             "Parsing {} failed: {:?}",
@@ -290,7 +290,7 @@ mod legacy_test_filters {
         );
 
         // explicit, separate testcase construction of the "script" option as it is not the deafult
-        let filter = NetworkFilter::parse("||googlesyndication.com/safeframe/$third-party,script", true).unwrap();
+        let filter = NetworkFilter::parse("||googlesyndication.com/safeframe/$third-party,script", true, Default::default()).unwrap();
         let request = Request::from_urls("http://tpc.googlesyndication.com/safeframe/1-0-2/html/container.html#xpc=sf-gdn-exp-2&p=http%3A//slashdot.org;", "", "script").unwrap();
         assert!(filter.matches(&request));
     }
@@ -656,13 +656,13 @@ mod legacy_misc_tests {
 
     #[test]
     fn host_anchored_filters_parse_correctly() { // Host anchor is calculated correctly
-        let filter = NetworkFilter::parse("||test.com$third-party", false).unwrap();
+        let filter = NetworkFilter::parse("||test.com$third-party", false, Default::default()).unwrap();
         assert_eq!(filter.hostname, Some(String::from("test.com")));
 
-        let filter = NetworkFilter::parse("||test.com/ok$third-party", false).unwrap();
+        let filter = NetworkFilter::parse("||test.com/ok$third-party", false, Default::default()).unwrap();
         assert_eq!(filter.hostname, Some(String::from("test.com")));
 
-        let filter = NetworkFilter::parse("||test.com/ok", false).unwrap();
+        let filter = NetworkFilter::parse("||test.com/ok", false, Default::default()).unwrap();
         assert_eq!(filter.hostname, Some(String::from("test.com")));
     }
 

--- a/tests/legacy_harness.rs
+++ b/tests/legacy_harness.rs
@@ -298,11 +298,11 @@ mod legacy_test_filters {
 
 mod legacy_check_match {
     use adblock::engine::Engine;
-    use adblock::lists::FilterFormat;
+    use adblock::lists::{FilterFormat, ParseOptions};
 
     fn check_match<'a>(rules: &[&'a str], format: FilterFormat, blocked: &[&'a str], not_blocked: &[&'a str], tags: &[&'a str]) {
         let rules_owned: Vec<_> = rules.into_iter().map(|&s| String::from(s)).collect();
-        let mut engine = Engine::from_rules(&rules_owned, format);          // first one with the provided rules
+        let mut engine = Engine::from_rules(&rules_owned, ParseOptions { format, ..Default::default() });          // first one with the provided rules
         engine.use_tags(tags);
 
         let mut engine_deserialized = Engine::default();                    // second empty
@@ -381,7 +381,7 @@ mod legacy_check_match {
                 String::from("/ads/freewheel/*"),
                 String::from("@@||turner.com^*/ads/freewheel/*/AdManager.js$domain=cnn.com")
             ],
-            FilterFormat::Standard,
+            Default::default(),
         );
         let mut engine_deserialized = Engine::default();          // second empty
         {
@@ -482,11 +482,11 @@ mod legacy_check_match {
 
 mod legacy_check_options {
     use adblock::engine::Engine;
-    use adblock::lists::FilterFormat;
+    use adblock::lists::{FilterFormat, ParseOptions};
 
     fn check_option_rule<'a>(rules: &[&'a str], format: FilterFormat, tests: &[(&'a str, &'a str, &'a str, bool)]) {
         let rules_owned: Vec<_> = rules.into_iter().map(|&s| String::from(s)).collect();
-        let engine = Engine::from_rules(&rules_owned, format);              // first one with the provided rules
+        let engine = Engine::from_rules(&rules_owned, ParseOptions { format, ..Default::default() });              // first one with the provided rules
 
         for (url, source_url, request_type, expectation) in tests {
             assert!(engine.check_network_urls(url, source_url, request_type).matched == *expectation,
@@ -640,7 +640,6 @@ mod legacy_check_options {
 mod legacy_misc_tests {
     use adblock::engine::Engine;
     use adblock::filters::network::NetworkFilter;
-    use adblock::lists::FilterFormat;
 
     #[test]
     fn demo_app() { // Demo app test
@@ -648,7 +647,7 @@ mod legacy_misc_tests {
             &[
                 String::from("||googlesyndication.com/safeframe/$third-party")
             ],
-            FilterFormat::Standard,
+            Default::default(),
         );
 
         assert!(engine.check_network_urls("http://tpc.googlesyndication.com/safeframe/1-0-2/html/container.html", "http://slashdot.org", "script").matched)
@@ -672,7 +671,7 @@ mod legacy_misc_tests {
             String::from("||googlesyndication.com$third-party"),
             String::from("@@||googlesyndication.ca"),
             String::from("a$explicitcancel")
-        ], FilterFormat::Standard, true, false);    // enable debugging and disable optimizations
+        ], Default::default(), true, false);    // enable debugging and disable optimizations
 
         let serialized = engine.serialize_compressed().unwrap();
         let mut engine2 = Engine::new(false);
@@ -696,7 +695,7 @@ mod legacy_misc_tests {
                 String::from("||googlesyndication.com/safeframe/$third-party"),
                 String::from("||brianbondy.com/ads"),
             ],
-            FilterFormat::Standard,
+            Default::default(),
         );
 
         let current_page_frame = "http://slashdot.org";
@@ -725,7 +724,7 @@ mod legacy_misc_tests {
                 String::from("||brianbondy.com/ads"),
                 String::from("@@safeframe")
             ],
-            FilterFormat::Standard,
+            Default::default(),
         );
 
         let current_page_frame = "http://slashdot.org";
@@ -750,7 +749,7 @@ mod legacy_misc_tests {
                 String::from("||brianbondy.com^$important"),
                 String::from("@@||brianbondy.com^"),
             ],
-            FilterFormat::Standard,
+            Default::default(),
         );
 
         let checked = engine.check_network_urls("https://brianbondy.com/t", "https://test.com", "script");

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -84,7 +84,7 @@ static ALL_FILTERS: once_cell::sync::Lazy<adblock::lists::FilterSet> = once_cell
             .await
             .iter()
             .for_each(|(format, list)| {
-                filter_set.add_filters(&list.lines().map(|s| s.to_owned()).collect::<Vec<_>>(), *format);
+                filter_set.add_filters(&list.lines().map(|s| s.to_owned()).collect::<Vec<_>>(), adblock::lists::ParseOptions { format: *format, ..Default::default() });
             });
 
         filter_set
@@ -135,7 +135,7 @@ fn get_blocker_engine_deserialized_ios() -> Engine {
         .map(|s| s.to_owned())
         .collect();
     
-    let engine = Engine::from_rules_parametrised(&filters, adblock::lists::FilterFormat::Standard, true, false);
+    let engine = Engine::from_rules_parametrised(&filters, Default::default(), true, false);
     engine
 }
 

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 
 use std::fs::File;
 use std::io::prelude::*;
+use adblock::blocker::Redirection;
+use adblock::lists::ParseOptions;
 
 #[allow(non_snake_case)]
 #[derive(Serialize, Deserialize)]
@@ -31,7 +33,7 @@ fn load_requests() -> Vec<TestRuleRequest> {
 
 fn build_resources_from_filters(filters: &[String]) -> Vec<Resource> {
     filters.iter()
-        .map(|r| NetworkFilter::parse(&r, true))
+        .map(|r| NetworkFilter::parse(&r, true, Default::default()))
         .filter_map(Result::ok)
         .filter(|f| f.is_redirect())
         .map(|f| {
@@ -56,11 +58,16 @@ fn check_filter_matching() {
 
     assert!(requests.len() > 0, "List of parsed request info is empty");
 
+    let opts = ParseOptions {
+        parse_redirect_urls: true,
+        ..Default::default()
+    };
+
     for req in requests {
         for filter in req.filters {
-            let nework_filter_res = NetworkFilter::parse(&filter, true);
-            assert!(nework_filter_res.is_ok(), "Could not parse filter {}", filter);
-            let network_filter = nework_filter_res.unwrap();
+            let network_filter_res = NetworkFilter::parse(&filter, true, opts);
+            assert!(network_filter_res.is_ok(), "Could not parse filter {}", filter);
+            let network_filter = network_filter_res.unwrap();
 
             let request_res = Request::from_urls(&req.url, &req.sourceUrl, &req.r#type);
             // The dataset has cases where URL is set to just "http://" or "https://", which we do not support
@@ -72,7 +79,7 @@ fn check_filter_matching() {
         }
     }
 
-    assert_eq!(requests_checked, 9381); // A catch for regressions
+    assert_eq!(requests_checked, 9382); // A catch for regressions
 }
 
 #[test]
@@ -86,13 +93,14 @@ fn check_engine_matching() {
             continue;
         }
         for filter in req.filters {
-            let mut engine = Engine::from_rules_debug(&[filter.clone()], adblock::lists::FilterFormat::Standard);
+            let opts = ParseOptions { parse_redirect_urls: true, ..Default::default() };
+            let mut engine = Engine::from_rules_debug_with_opts(&[filter.clone()], opts);
             let resources = build_resources_from_filters(&[filter.clone()]);
             engine.use_resources(&resources);
 
-            let nework_filter_res = NetworkFilter::parse(&filter, true);
-            assert!(nework_filter_res.is_ok(), "Could not parse filter {}", filter);
-            let network_filter = nework_filter_res.unwrap();
+            let network_filter_res = NetworkFilter::parse(&filter, true, opts);
+            assert!(network_filter_res.is_ok(), "Could not parse filter {}", filter);
+            let network_filter = network_filter_res.unwrap();
 
             let result = engine.check_network_urls(&req.url, &req.sourceUrl, &req.r#type);
 
@@ -105,9 +113,23 @@ fn check_engine_matching() {
             
             if network_filter.is_redirect() {
                 assert!(result.redirect.is_some(), "Expected {} to trigger redirect rule {}", req.url, filter);
-                let redirect = result.redirect.as_ref().unwrap();
-                // each redirect url is base64 encoded
-                assert!(redirect.contains("base64"));
+                let redirect = result.redirect.unwrap();
+                if network_filter.is_redirect_url() {
+                    // check it's a URL
+                    let url = match redirect {
+                        Redirection::Url(url) => url,
+                        _ => panic!("not a url despite being a redirect-url filter option"),
+                    };
+                    assert!(url.contains("http://") || url.contains("https://"));
+                } else {
+                    // check it's a URL
+                    let resource = match redirect {
+                        Redirection::Resource(resource) => resource,
+                        _ => panic!("not a resource despite being a redirect filter option"),
+                    };
+                    // each redirect resource is base64 encoded
+                    assert!(resource.contains("base64"));
+                }
             }
         }
     }

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -59,7 +59,7 @@ fn check_filter_matching() {
     assert!(requests.len() > 0, "List of parsed request info is empty");
 
     let opts = ParseOptions {
-        parse_redirect_urls: true,
+        include_redirect_urls: true,
         ..Default::default()
     };
 
@@ -93,8 +93,8 @@ fn check_engine_matching() {
             continue;
         }
         for filter in req.filters {
-            let opts = ParseOptions { parse_redirect_urls: true, ..Default::default() };
-            let mut engine = Engine::from_rules_debug_with_opts(&[filter.clone()], opts);
+            let opts = ParseOptions { include_redirect_urls: true, ..Default::default() };
+            let mut engine = Engine::from_rules_debug(&[filter.clone()], opts);
             let resources = build_resources_from_filters(&[filter.clone()]);
             engine.use_resources(&resources);
 

--- a/tests/simple_use.rs
+++ b/tests/simple_use.rs
@@ -1,5 +1,4 @@
 use adblock::engine::Engine;
-use adblock::lists::FilterFormat;
 
 #[test]
 fn check_simple_use() {
@@ -10,7 +9,7 @@ fn check_simple_use() {
         String::from("-advertisement/script."),
     ];
 
-    let blocker = Engine::from_rules(&rules, FilterFormat::Standard);
+    let blocker = Engine::from_rules(&rules, Default::default());
     let blocker_result = blocker.check_network_urls("http://example.com/-advertisement-icon.", "http://example.com/helloworld", "image");
     assert!(blocker_result.matched);
 }

--- a/tests/ublock-coverage.rs
+++ b/tests/ublock-coverage.rs
@@ -82,6 +82,7 @@ fn check_specific_rules() {
     #[cfg(feature = "resource-assembler")]
     {
         use std::path::Path;
+        use adblock::blocker::Redirection;
 
         // exceptions have no effect if important filter matches
         let mut engine = Engine::from_rules_debug(
@@ -98,7 +99,7 @@ fn check_specific_rules() {
 
         let checked = engine.check_network_urls("http://cdn.taboola.com/libtrc/test/loader.js", "http://cnet.com", "script");
         assert_eq!(checked.matched, true);
-        assert_eq!(checked.redirect, Some("data:application/javascript;base64,KGZ1bmN0aW9uKCkgewogICAgJ3VzZSBzdHJpY3QnOwp9KSgpOwo=".to_owned()));
+        assert_eq!(checked.redirect, Some(Redirection::Resource("data:application/javascript;base64,KGZ1bmN0aW9uKCkgewogICAgJ3VzZSBzdHJpY3QnOwp9KSgpOwo=".to_owned())));
     }
 }
 

--- a/tests/ublock-coverage.rs
+++ b/tests/ublock-coverage.rs
@@ -1,5 +1,4 @@
 use adblock::engine::Engine;
-use adblock::lists::FilterFormat;
 use adblock::utils::rules_from_lists;
 
 use serde::Deserialize;
@@ -44,7 +43,7 @@ fn get_blocker_engine() -> Engine {
         String::from("data/regression-testing/easyprivacy.txt"),
     ]);
 
-    Engine::from_rules_parametrised(&rules, FilterFormat::Standard, true, false)
+    Engine::from_rules_parametrised(&rules, Default::default(), true, false)
 }
 
 fn get_blocker_engine_default(extra_rules: &[&str]) -> Engine {
@@ -60,7 +59,7 @@ fn get_blocker_engine_default(extra_rules: &[&str]) -> Engine {
 
     extra_rules.iter().for_each(|rule| rules.push(rule.to_string()));
 
-    Engine::from_rules_parametrised(&rules, FilterFormat::Standard, true, false)
+    Engine::from_rules_parametrised(&rules, Default::default(), true, false)
 }
 
 #[test]
@@ -71,7 +70,7 @@ fn check_specific_rules() {
             &[
                 String::from("||www.facebook.com/*/plugin"),
             ],
-            FilterFormat::Standard,
+            Default::default(),
         );
 
         let checked = engine.check_network_urls("https://www.facebook.com/v3.2/plugins/comments.ph", "", "");
@@ -89,7 +88,7 @@ fn check_specific_rules() {
             &[
                 String::from("||cdn.taboola.com/libtrc/*/loader.js$script,redirect=noopjs,important,domain=cnet.com"),
             ],
-            FilterFormat::Standard,
+            Default::default(),
         );
         let resources = adblock::resources::resource_assembler::assemble_web_accessible_resources(
             Path::new("data/test/fake-uBO-files/web_accessible_resources"),


### PR DESCRIPTION
Add a new filter option to `adblock` called `redirect-url` (similar to `redirect=`) that allows loading of replacement resources via a URL instead of having to bundle all replacement resources in the client.