### PR TITLE
Modify redirect semantics in preparation for redirect-rule support

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -480,7 +480,13 @@ mod tests {
 
         let url = "http://example.com/ad-banner.gif";
         let matched_rule = deserialized_engine.check_network_urls(url, "", "");
-        assert!(matched_rule.matched, "Expected match for {}", url);
+        // This serialized DAT was generated prior to
+        // https://github.com/brave/adblock-rust/pull/185, so the `redirect` filter did not get
+        // duplicated into the list of blocking filters.
+        //
+        // TODO - The failure to match here is considered acceptable for now, as it's part of a
+        // breaking change (minor version bump). However, the test should be updated at some point.
+        //assert!(matched_rule.matched, "Expected match for {}", url);
         assert_eq!(matched_rule.redirect, Some("data:text/plain;base64,".to_owned()), "Expected redirect to contain resource");
     }
 


### PR DESCRIPTION
Second implementation step of [this plan](https://github.com/brave/adblock-rust/issues/169#issuecomment-916471765).

> When updated DATs are available, begin treating redirects as independent from blocking/exception filters. This means exceptions for blocking should only be looked for in `Blocker::exceptions`, and exceptions for redirections should only be looked for in `Blocker::redirects`. `Blocker::redirects` should be checked for all matches rather than the first match (similar to `$csp`), and results should be combined accordingly. At this point, a redirection exception should always occur whenever a blocking exception occurs, but the code should be ready to handle the case when they do not occur together.

This will require a minor version bump. Even though there are no breaking interface changes, it is changing the semantics of how `BlockerResult::matched` and `BlockerResult::redirect` interact; downstream code will have to be updated accordingly.