### PR TITLE
Remove docs and test code from npm package bundle

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,7 @@ native/index.node
 *.code-workspace
 *.diff
 *.tgz
+docs/
+fuzz/
+tests/
+examples/


### PR DESCRIPTION
`benches` cannot be excluded because the paths are referenced by `Cargo.toml`. This causes `npm install` to fail, even though the benchmarks are unused by the bindings.

The biggest saving comes from the removal of `docs/algo.png`.

`npm publish --dry-run` before:
```
npm notice package size:  523.0 kB
npm notice unpacked size: 1.2 MB
```

after:
```
npm notice package size:  138.3 kB
npm notice unpacked size: 711.0 kB
```