### PR TITLE
fix readme rust example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ fn main() {
     let mut filter_set = FilterSet::new(true);
     filter_set.add_filters(&rules, FilterFormat::Standard);
 
-    let blocker = Engine::from_filter_set(&filter_set, true);
+    let blocker = Engine::from_filter_set(filter_set, true);
     let blocker_result = blocker.check_network_urls("http://example.com/-advertisement-icon.", "http://example.com/helloworld", "image");
 
     println!("Blocker result: {:?}", blocker_result);


### PR DESCRIPTION
Previously got an error:

```
error[E0308]: mismatched types
  --> src/main.rs:15:43
   |
15 |     let blocker = Engine::from_filter_set(&filter_set, true);
   |                                           ^^^^^^^^^^^
   |                                           |
   |                                           expected struct `FilterSet`, found `&FilterSet`
   |                                           help: consider removing the borrow: `filter_set`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
error: could not compile `adblock_rs_test`

To learn more, run the command again with --verbose.
```

With the following version:

```
❯ cargo --version
cargo 1.51.0 (43b129a20 2021-03-16)
```