### PR TITLE
Restrict `redirect-url` to only load over HTTPS

### DIFF
--- a/data/matching-test-requests.json
+++ b/data/matching-test-requests.json
@@ -6186,7 +6186,7 @@
   {
     "check": true,
     "filters": [
-      "||cdn.taboola.com/libtrc/*/loader.js$script,redirect-url=http://noops.js,important,domain=cnet.com"
+      "||cdn.taboola.com/libtrc/*/loader.js$script,redirect-url=https://noops.js,important,domain=cnet.com"
     ],
     "sourceUrl": "https://www.cnet.com",
     "type": "script",

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -1241,7 +1241,7 @@ mod blocker_tests {
     #[test]
     fn redirect_url_blocked() {
         let filters = vec![
-            String::from("||foo.com$important,redirect-url=http://xyz.com"),
+            String::from("||foo.com$important,redirect-url=https://xyz.com"),
         ];
 
         let request = Request::from_urls("https://foo.com", "https://foo.com", "script").unwrap();
@@ -1259,14 +1259,14 @@ mod blocker_tests {
         let matched_rule = blocker.check(&request);
         assert_eq!(matched_rule.matched, true);
         assert_eq!(matched_rule.important, true);
-        assert_eq!(matched_rule.redirect, Some(Redirection::Url("http://xyz.com".to_string())));
+        assert_eq!(matched_rule.redirect, Some(Redirection::Url("https://xyz.com".to_string())));
         assert_eq!(matched_rule.error, None);
     }
 
     #[test]
     fn redirect_url_not_recognized_without_parse_opt() {
         let filters = vec![
-            String::from("||foo.com$important,redirect-url=http://xyz.com"),
+            String::from("||foo.com$important,redirect-url=https://xyz.com"),
         ];
 
         let request = Request::from_urls("https://foo.com", "https://foo.com", "script").unwrap();
@@ -1313,7 +1313,7 @@ mod blocker_tests {
     #[test]
     fn redirect_url_exception() {
         let filters = vec![
-            String::from("||imdb-video.media-imdb.com$media,redirect-url=http://xyz.com"),
+            String::from("||imdb-video.media-imdb.com$media,redirect-url=https://xyz.com"),
             String::from("@@||imdb-video.media-imdb.com^$domain=imdb.com"),
         ];
 
@@ -1332,7 +1332,7 @@ mod blocker_tests {
         let matched_rule = blocker.check(&request);
         assert_eq!(matched_rule.matched, false);
         assert_eq!(matched_rule.important, false);
-        assert_eq!(matched_rule.redirect, Some(Redirection::Url("http://xyz.com".to_string())));
+        assert_eq!(matched_rule.redirect, Some(Redirection::Url("https://xyz.com".to_string())));
         assert_eq!(matched_rule.exception, Some("@@||imdb-video.media-imdb.com^$domain=imdb.com".to_string()));
         assert_eq!(matched_rule.error, None);
     }

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -33,7 +33,7 @@ pub struct ParseOptions {
     /// Assume filters are in the given format when parsing. Defaults to `FilterFormat::Standard`.
     #[serde(default)]
     pub format: FilterFormat,
-    /// The `$redirect-url` filter option can redirect to an arbitrary HTTP/HTTPS resource over the
+    /// The `$redirect-url` filter option can redirect to an arbitrary HTTPS resource over the
     /// network. By default this is disabled for security concerns, and any rule containing a
     /// `redirect-url` option will be ignored.
     #[serde(default)]


### PR DESCRIPTION
Given that we're loading arbitrary resources over the network, even if the filter lists are controlled by us, we should only load over HTTPS to prevent MITM attacks.