### PR TITLE
Update to 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adblock"
 version = "0.4.1"
 authors = ["Andrius Aucinas <aaucinas@brave.com>", "Anton Lazarev <alazarev@brave.com>"]
-edition = "2018"
+edition = "2021"
 
 description = "Native Rust module for Adblock Plus syntax (e.g. EasyList, EasyPrivacy) filter parsing and matching."
 repository = "https://github.com/brave/adblock-rust/"


### PR DESCRIPTION
No code changes required :tada: 

Will wait on merging at least until Brave's CI pipelines are updated to use Rust 1.56.