### PR TITLE
Optimize regexp memory usage

### DIFF
--- a/src/data_format/legacy.rs
+++ b/src/data_format/legacy.rs
@@ -195,7 +195,7 @@ impl From<NetworkFilterLegacyDeserializeFmt> for NetworkFilter {
             id: v.id,
             opt_domains_union: v.opt_domains_union,
             opt_not_domains_union: v.opt_not_domains_union,
-            regex: std::sync::Arc::new(std::sync::RwLock::new(None)),
+            regex: std::cell::RefCell::new(None),
         }
     }
 }


### PR DESCRIPTION
Currently, the `regexp` field consumes a lot of memory because of the size of `Arc<RwLock<Option<Arc<CompiledRegex>>>>`.
It takes 40 bytes per item even when `None` is stored. 

Most of the rules is non-regex(~90%).
This approach takes 8 bytes per item for such rules.
It saves about 7Mb of memory in total.

**Important note**: this makes the engine not thread-safe.
In fact, the browser uses adblock from a single sequence => we don't need to synchronize threads.

P.S. Many `Arc` in the code are left untouched to make the diff reasonable.

Memory usage after loading `data/rs-ABPFilterParserData.dat` in `tests/deserialization.rs`
(Release, ubuntu x64, added jemallocator locally to calculate):
``
before: 42094712 bytes allocated/53563392 bytes resident
after:  34332128 bytes allocated/48881664 bytes resident
``