### PR TITLE
Optimize regexp memory usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ harness = false
 [features]
 # If disabling default features, consider explicitly re-enabling the
 # "embedded-domain-resolver" feature.
-default = ["embedded-domain-resolver", "full-regex-handling", "object-pooling"]
+default = ["embedded-domain-resolver", "full-regex-handling", "object-pooling", "thread-safety"]
 full-domain-matching = []
 metrics = []
 full-regex-handling = []
@@ -87,3 +87,4 @@ css-validation = ["cssparser", "selectors"]
 content-blocking = ["serde_json"]
 embedded-domain-resolver = ["addr"] # Requires setting an external domain resolver if disabled.
 resource-assembler = ["serde_json"]
+thread-safety = [] # Slower but thread-safe implementation. Consider disabling it if you don't need multithreading.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,13 +78,13 @@ harness = false
 [features]
 # If disabling default features, consider explicitly re-enabling the
 # "embedded-domain-resolver" feature.
-default = ["embedded-domain-resolver", "full-regex-handling", "object-pooling", "thread-safety"]
+default = ["embedded-domain-resolver", "full-regex-handling", "object-pooling", "unsync-regex-caching"]
 full-domain-matching = []
 metrics = []
 full-regex-handling = []
-object-pooling = ["lifeguard"]
+object-pooling = ["lifeguard"] # disables `Send` and `Sync` on `Engine`.
+unsync-regex-caching = [] # disables `Send` and `Sync` on `Engine`.
 css-validation = ["cssparser", "selectors"]
 content-blocking = ["serde_json"]
 embedded-domain-resolver = ["addr"] # Requires setting an external domain resolver if disabled.
 resource-assembler = ["serde_json"]
-thread-safety = [] # Slower but thread-safe implementation. Consider disabling it if you don't need multithreading.

--- a/README.md
+++ b/README.md
@@ -88,3 +88,8 @@ By default, `adblock-rust` ships with a built-in domain resolution implementatio
 
 `adblock-rust` uses uBlock Origin-compatible resources for scriptlet injection and redirect rules.
 The `resource-assembler` feature allows `adblock-rust` to parse these resources directly from the file formats used by the uBlock Origin repository.
+
+### Thread safety
+
+The `thread-safety` feature enabled by default and allows to use the engine from multiple threads. Disabling the feature optimizes speed and memory usage by dropping some synchronization primitives.
+Consider disabling this feature if you don't use multiply threads in your application. In Brave browser this feature is disabled.

--- a/README.md
+++ b/README.md
@@ -91,5 +91,5 @@ The `resource-assembler` feature allows `adblock-rust` to parse these resources 
 
 ### Thread safety
 
-The `thread-safety` feature enabled by default and allows to use the engine from multiple threads. Disabling the feature optimizes speed and memory usage by dropping some synchronization primitives.
-Consider disabling this feature if you don't use multiply threads in your application. In Brave browser this feature is disabled.
+The `object-pooling` and `unsync-regex-caching` features enable optimizations for rule matching speed and the amount of memory used by the engine.
+These features can be disabled to make the engine `Send + Sync`, although it is recommended to only access the engine on a single thread to maintain optimal performance.

--- a/src/data_format/legacy.rs
+++ b/src/data_format/legacy.rs
@@ -195,7 +195,7 @@ impl From<NetworkFilterLegacyDeserializeFmt> for NetworkFilter {
             id: v.id,
             opt_domains_union: v.opt_domains_union,
             opt_not_domains_union: v.opt_not_domains_union,
-            regex: crate::filters::network::RegExStorage::default(),
+            regex: crate::filters::network::RegexStorage::default(),
         }
     }
 }

--- a/src/data_format/legacy.rs
+++ b/src/data_format/legacy.rs
@@ -195,7 +195,7 @@ impl From<NetworkFilterLegacyDeserializeFmt> for NetworkFilter {
             id: v.id,
             opt_domains_union: v.opt_domains_union,
             opt_not_domains_union: v.opt_not_domains_union,
-            regex: std::cell::RefCell::new(None),
+            regex: crate::filters::network::RegExStorage::default(),
         }
     }
 }

--- a/src/data_format/legacy.rs
+++ b/src/data_format/legacy.rs
@@ -195,7 +195,7 @@ impl From<NetworkFilterLegacyDeserializeFmt> for NetworkFilter {
             id: v.id,
             opt_domains_union: v.opt_domains_union,
             opt_not_domains_union: v.opt_not_domains_union,
-            regex: std::sync::Arc::new(std::sync::RwLock::new(None)),
+            regex: std::cell::RefCell::new(None),
         }
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -268,6 +268,15 @@ impl Engine {
     }
 }
 
+/// Static assertions for `Engine: Send + Sync` traits.
+#[cfg(not(any(feature = "object-pooling", feature = "optimized-regex-cache")))]
+fn _assertions() {
+    fn _assert_send<T: Send>() {}
+    fn _assert_sync<T: Sync>() {}
+
+    _assert_send::<Engine>();
+    _assert_sync::<Engine>();
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -4,7 +4,6 @@ use once_cell::sync::Lazy;
 use crate::url_parser::parse_url;
 
 use std::fmt;
-use std::cell::RefCell;
 use std::sync::Arc;
 
 use crate::request;
@@ -426,6 +425,54 @@ fn parse_filter_options(raw_options: &str, opts: ParseOptions) -> Result<Vec<Net
     Ok(result)
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct RegExStorage {
+  #[cfg(feature = "thread-safety")]
+  pub(crate) regex: Arc<std::sync::RwLock<Option<Arc<CompiledRegex>>>>,
+
+  #[cfg(not(feature = "thread-safety"))]
+  pub(crate) regex: std::cell::RefCell<Option<Arc<CompiledRegex>>>,
+}
+
+impl RegExStorage {
+  pub fn default() -> RegExStorage {
+    #[cfg(feature = "thread-safety")]
+    {
+      RegExStorage {regex: Arc::new(std::sync::RwLock::new(None))}
+    }
+
+    #[cfg(not(feature = "thread-safety"))]
+    {
+      RegExStorage {regex: std::cell::RefCell::new(None)}
+    }
+  }
+
+  pub fn get(&self) -> Option<Arc<CompiledRegex>> {
+    #[cfg(feature = "thread-safety")]
+    if let Some(cache) = &*self.regex.read().unwrap() {
+      return Some(cache.clone());
+    }
+
+    #[cfg(not(feature = "thread-safety"))]
+    if let Some(cache) = &*self.regex.borrow() {
+      return Some(cache.clone());
+    }
+    None
+  }
+
+  pub fn set(&self, regex: Arc<CompiledRegex>) {
+    #[cfg(feature = "thread-safety")]
+    {
+      *self.regex.write().unwrap() = Some(regex);
+    }
+
+    #[cfg(not(feature = "thread-safety"))]
+    {
+      *self.regex.borrow_mut() = Some(regex);
+    }
+  }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkFilter {
     pub mask: NetworkFilterMask,
@@ -453,7 +500,7 @@ pub struct NetworkFilter {
     // Non-thread safe, should be used from a single thread.
     // Atomic Arc is used for the backward-compatibilty with the other code.
     #[serde(skip_serializing, skip_deserializing)]
-    pub(crate) regex: RefCell<Option<Arc<CompiledRegex>>>
+    pub(crate) regex: RegExStorage,
 }
 
 // TODO - restrict the API so that this is always true - i.e. lazy-calculate IDs from actual data,
@@ -831,7 +878,7 @@ impl NetworkFilter {
             id: utils::fast_hash(&line),
             opt_domains_union,
             opt_not_domains_union,
-            regex: RefCell::new(None),
+            regex: RegExStorage::default(),
         })
     }
 
@@ -1057,8 +1104,8 @@ impl NetworkMatchable for NetworkFilter {
         if !self.is_regex() && !self.is_complete_regex() {
             return Arc::new(CompiledRegex::MatchAll);
         }
-        if let Some(cache) = &*self.regex.borrow() {
-          return cache.clone();
+        if let Some(cache) = self.regex.get() {
+          return cache;
         }
         let regex = compile_regex(
             &self.filter,
@@ -1067,7 +1114,7 @@ impl NetworkMatchable for NetworkFilter {
             self.is_complete_regex(),
         );
         let arc_regex = Arc::new(regex);
-        *self.regex.borrow_mut() = Some(arc_regex.clone());
+        self.regex.set(arc_regex.clone());
         arc_regex
     }
 }


### PR DESCRIPTION
Resolves https://github.com/brave/adblock-rust/issues/203
Currently, the regexp field consumes a lot of memory because of the size of `Arc<RwLock<Option<Arc<CompiledRegex>>>>`.
It takes 40 bytes per item even when None is stored.

Most of the rules is non-regex(~90%).
This new approach takes 8 bytes per item for such rules.
It saves about 7Mb of memory in total.

Important note: this makes the engine not thread-safe and wrap under a new feature.
In fact, the browser uses adblock from a single sequence => we don't need to synchronize threads, the `thread-safety` feature should be disabled in browser to get benefit from the optimization.

```
Memory usage after loading data/rs-ABPFilterParserData.dat in tests/deserialization.rs
(Release, ubuntu x64, added jemallocator locally to calculate):
before: 42094712 bytes allocated/53563392 bytes resident after: 34332128 bytes allocated/48881664 bytes resident
```