### PR TITLE
Add BraveServiceKey to live DAT tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,6 @@ jobs:
           cargo audit
 
       - name: Cargo test
+        env:
+          BRAVE_SERVICE_KEY: ${{ env.BRAVE_SERVICE_KEY }}
         run: cargo test --verbose --features "content-blocking, resource-assembler"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
 
       - name: Cargo test
         env:
-          BRAVE_SERVICE_KEY: ${{ env.BRAVE_SERVICE_KEY }}
+          BRAVE_SERVICE_KEY: ${{ secrets.BRAVE_SERVICE_KEY }}
         run: cargo test --verbose --features "content-blocking, resource-assembler"

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -106,7 +106,7 @@ fn get_blocker_engine_deserialized() -> Engine {
     use futures::FutureExt;
     let async_runtime = Runtime::new().expect("Could not start Tokio runtime");
 
-    let brave_service_key = std::env::var("brave_service_key")
+    let brave_service_key = std::env::var("BRAVE_SERVICE_KEY")
         .expect("Must set the $brave_service_key environment variable to execute live tests.");
 
     let dat_url = "https://adblock-data.s3.brave.com/4/rs-ABPFilterParserData.dat";


### PR DESCRIPTION
The endpoint for downloading the most recent DAT file was recently updated to require a service key; this allows the tests which required a live DAT to continue working by setting the `$brave_service_key` environment variable.