### PR TITLE
Add a global RegexManager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "adblock"
 version = "0.6.2"
 dependencies = [
  "addr",
+ "ahash",
  "base64",
  "bitflags",
  "criterion",
@@ -48,6 +49,18 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "ahash"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.2.8",
+ "once_cell",
+ "version_check",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -503,6 +516,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -964,7 +988,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha",
  "rand_core",
@@ -988,7 +1012,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,6 @@ name = "adblock"
 version = "0.6.2"
 dependencies = [
  "addr",
- "ahash",
  "base64",
  "bitflags",
  "criterion",
@@ -49,18 +48,6 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "ahash"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
-dependencies = [
- "cfg-if",
- "getrandom 0.2.8",
- "once_cell",
- "version_check",
-]
 
 [[package]]
 name = "aho-corasick"
@@ -516,17 +503,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -988,7 +964,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.16",
+ "getrandom",
  "libc",
  "rand_chacha",
  "rand_core",
@@ -1012,7 +988,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.16",
+ "getrandom",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
  "idna 0.2.3",
  "itertools",
  "lifeguard",
+ "mock_instant",
  "once_cell",
  "percent-encoding",
  "regex",
@@ -756,6 +757,15 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "mock_instant"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "717e29a243b81f8130e31e24e04fb151b04a44b5a7d05370935f7d937e9de06d"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ exclude = [
 ]
 
 [dependencies]
-ahash = "0.8.0"
 addr = { version = "0.14", default-features = false, features = ["psl"], optional = true }
 url = "2.2"
 percent-encoding = "2.1"
@@ -87,11 +86,12 @@ harness = false
 [features]
 # If disabling default features, consider explicitly re-enabling the
 # "embedded-domain-resolver" feature.
-default = ["embedded-domain-resolver", "full-regex-handling", "object-pooling"]
+default = ["embedded-domain-resolver", "full-regex-handling", "object-pooling", "unsync-regex-caching"]
 metrics = []
 full-regex-handling = []
 object-pooling = ["lifeguard"] # disables `Send` and `Sync` on `Engine`.
 unsync-regex-caching = [] # disables `Send` and `Sync` on `Engine`.
+debug-info = []
 css-validation = ["cssparser", "selectors"]
 content-blocking = ["serde_json"]
 embedded-domain-resolver = ["addr"] # Requires setting an external domain resolver if disabled.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ bitflags = "1.2"
 itertools = "0.10"
 idna = "0.2"
 serde =  { version = "1.0", features = ["derive", "rc"] }
-mock_instant = { version = "0.2", features = ["sync"] }
 flate2 = { version = "1.0", features = ["rust_backend"], default-features = false }
 seahash = "3"   # seahash 4 introduces a breaking hash algorithm change
 twoway = "0.2"
@@ -48,6 +47,7 @@ serde_json = { version = "1.0", optional = true }
 [dev-dependencies]
 criterion = "0.3"
 csv = "1"
+mock_instant = { version = "0.2", features = ["sync"] }
 serde_json = "1.0"
 # By default, reqwest builds openssl from source, which fails on missing/incompatible system dependencies
 reqwest = { version = "0.11", features = ["rustls-tls"], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ default = ["embedded-domain-resolver", "full-regex-handling", "object-pooling"]
 metrics = []
 full-regex-handling = []
 object-pooling = ["lifeguard"] # disables `Send` and `Sync` on `Engine`.
+unsync-regex-caching = [] # disables `Send` and `Sync` on `Engine`.
 css-validation = ["cssparser", "selectors"]
 content-blocking = ["serde_json"]
 embedded-domain-resolver = ["addr"] # Requires setting an external domain resolver if disabled.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ exclude = [
 ]
 
 [dependencies]
+ahash = "0.8.0"
 addr = { version = "0.14", default-features = false, features = ["psl"], optional = true }
 url = "2.2"
 percent-encoding = "2.1"
@@ -86,11 +87,10 @@ harness = false
 [features]
 # If disabling default features, consider explicitly re-enabling the
 # "embedded-domain-resolver" feature.
-default = ["embedded-domain-resolver", "full-regex-handling", "object-pooling", "unsync-regex-caching"]
+default = ["embedded-domain-resolver", "full-regex-handling", "object-pooling"]
 metrics = []
 full-regex-handling = []
 object-pooling = ["lifeguard"] # disables `Send` and `Sync` on `Engine`.
-unsync-regex-caching = [] # disables `Send` and `Sync` on `Engine`.
 css-validation = ["cssparser", "selectors"]
 content-blocking = ["serde_json"]
 embedded-domain-resolver = ["addr"] # Requires setting an external domain resolver if disabled.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ bitflags = "1.2"
 itertools = "0.10"
 idna = "0.2"
 serde =  { version = "1.0", features = ["derive", "rc"] }
+mock_instant = { version = "0.2", features = ["sync"] }
 flate2 = { version = "1.0", features = ["rust_backend"], default-features = false }
 seahash = "3"   # seahash 4 introduces a breaking hash algorithm change
 twoway = "0.2"

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap, HashSet};
 #[cfg(feature = "object-pooling")]
 use lifeguard::Pool;
 
-use crate::filters::network::{NetworkFilter, NetworkMatchable, RegexManager};
+use crate::filters::network::{NetworkFilter, NetworkMatchable, RegexManager, RegexDebugEntry};
 use crate::request::Request;
 use crate::utils::{fast_hash, Hash};
 use crate::optimizer;
@@ -86,7 +86,7 @@ pub enum BlockerError {
 }
 
 pub struct BlockerDebugInfo {
-    pub active_regex_count: u64,
+    pub regex_data: Vec<RegexDebugEntry>,
     pub compiled_regex_count: u64,
 }
 
@@ -722,10 +722,11 @@ impl Blocker {
         self.resources.get_resource(key)
     }
 
+    #[cfg(feature = "debug-info")]
     pub fn get_debug_info(&self) -> BlockerDebugInfo {
         let regex_manager = self.borrow_regex_manager();
         BlockerDebugInfo {
-            active_regex_count: regex_manager.get_active_regex_count(),
+            regex_data: regex_manager.get_debug_regex_data(),
             compiled_regex_count: regex_manager.get_compiled_regex_count(),
         }
     }

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -9,7 +9,8 @@ use std::collections::{HashMap, HashSet};
 #[cfg(feature = "object-pooling")]
 use lifeguard::Pool;
 
-use crate::filters::network::{NetworkFilter, NetworkMatchable, RegexManager, RegexDebugEntry};
+use crate::filters::network::{NetworkFilter, NetworkMatchable};
+use crate::filters::regex_manager::{RegexManager, RegexDebugEntry};
 use crate::request::Request;
 use crate::utils::{fast_hash, Hash};
 use crate::optimizer;

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -88,8 +88,8 @@ pub enum BlockerError {
 }
 
 pub struct BlockerDebugInfo {
-  pub active_regex_count: usize,
-  pub compiled_regex_count: usize,
+    pub active_regex_count: u64,
+    pub compiled_regex_count: u64,
 }
 
 #[cfg(feature = "object-pooling")]
@@ -149,6 +149,7 @@ impl Blocker {
 
     pub fn check_generic_hide(&self, hostname_request: &Request) -> bool {
         let mut regex_manager = self.regex_manager.borrow_mut();
+        regex_manager.borrow_mut().update_time();
         let mut request_tokens;
         #[cfg(feature = "object-pooling")]
         {
@@ -165,6 +166,7 @@ impl Blocker {
 
     pub fn check_parameterised(&self, request: &Request, matched_rule: bool, force_check_exceptions: bool) -> BlockerResult {
         let mut regex_manager = self.regex_manager.borrow_mut();
+        regex_manager.borrow_mut().update_time();
         if !request.is_supported {
             return BlockerResult::default();
         }
@@ -387,6 +389,7 @@ impl Blocker {
 
         let mut request_tokens;
         let mut regex_manager = self.regex_manager.borrow_mut();
+        regex_manager.borrow_mut().update_time();
 
         #[cfg(feature = "object-pooling")]
         {

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -1,6 +1,9 @@
 //! Holds `Blocker`, which handles all network-based adblocking queries.
 
 use once_cell::sync::Lazy;
+use std::borrow::BorrowMut;
+use std::cell::RefCell;
+use std::ops::DerefMut;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::collections::{HashMap, HashSet};
@@ -8,7 +11,7 @@ use std::collections::{HashMap, HashSet};
 #[cfg(feature = "object-pooling")]
 use lifeguard::Pool;
 
-use crate::filters::network::{NetworkFilter, NetworkMatchable};
+use crate::filters::network::{NetworkFilter, NetworkMatchable, RegexManager};
 use crate::request::Request;
 use crate::utils::{fast_hash, Hash};
 use crate::optimizer;
@@ -84,6 +87,11 @@ pub enum BlockerError {
     FilterExists,
 }
 
+pub struct BlockerDebugInfo {
+  pub active_regex_count: usize,
+  pub compiled_regex_count: usize,
+}
+
 #[cfg(feature = "object-pooling")]
 pub struct TokenPool {
     pub pool: Pool<Vec<utils::Hash>>
@@ -127,6 +135,9 @@ pub struct Blocker {
     // Not serialized
     #[cfg(feature = "object-pooling")]
     pub(crate) pool: TokenPool,
+
+    // Not serialized
+    pub(crate) regex_manager: RefCell<RegexManager>,
 }
 
 impl Blocker {
@@ -137,6 +148,7 @@ impl Blocker {
     }
 
     pub fn check_generic_hide(&self, hostname_request: &Request) -> bool {
+        let mut regex_manager = self.regex_manager.borrow_mut();
         let mut request_tokens;
         #[cfg(feature = "object-pooling")]
         {
@@ -148,10 +160,11 @@ impl Blocker {
         }
         hostname_request.get_tokens(&mut request_tokens);
 
-        self.generic_hide.check(hostname_request, &request_tokens, &HashSet::new()).is_some()
+        self.generic_hide.check(hostname_request, &request_tokens, &HashSet::new(), regex_manager.deref_mut()).is_some()
     }
 
     pub fn check_parameterised(&self, request: &Request, matched_rule: bool, force_check_exceptions: bool) -> BlockerResult {
+        let mut regex_manager = self.regex_manager.borrow_mut();
         if !request.is_supported {
             return BlockerResult::default();
         }
@@ -178,17 +191,17 @@ impl Blocker {
         // Always check important filters
         let important_filter = self
             .importants
-            .check(request, &request_tokens, &NO_TAGS);
+            .check(request, &request_tokens, &NO_TAGS, regex_manager.deref_mut());
 
         // only check the rest of the rules if not previously matched
         let filter = if important_filter.is_none() && !matched_rule {
             #[cfg(feature = "metrics")]
             print!("tagged\t");
-            self.filters_tagged.check(request, &request_tokens, &self.tags_enabled)
+            self.filters_tagged.check(request, &request_tokens, &self.tags_enabled, regex_manager.deref_mut())
                 .or_else(|| {
                     #[cfg(feature = "metrics")]
                     print!("filters\t");
-                    self.filters.check(request, &request_tokens, &NO_TAGS)
+                    self.filters.check(request, &request_tokens, &NO_TAGS, regex_manager.deref_mut())
                 })
         } else {
             important_filter
@@ -199,7 +212,7 @@ impl Blocker {
             None if matched_rule || force_check_exceptions => {
                 #[cfg(feature = "metrics")]
                 print!("exceptions\t");
-                self.exceptions.check(request, &request_tokens, &self.tags_enabled)
+                self.exceptions.check(request, &request_tokens, &self.tags_enabled, regex_manager.deref_mut())
             }
             None => None,
             // If matched an important filter, exceptions don't atter
@@ -207,14 +220,14 @@ impl Blocker {
             Some(_) => {
                 #[cfg(feature = "metrics")]
                 print!("exceptions\t");
-                self.exceptions.check(request, &request_tokens, &self.tags_enabled)
+                self.exceptions.check(request, &request_tokens, &self.tags_enabled, regex_manager.deref_mut())
             }
         };
 
         #[cfg(feature = "metrics")]
         println!();
 
-        let redirect_filters = self.redirects.check_all(request, &request_tokens, &NO_TAGS);
+        let redirect_filters = self.redirects.check_all(request, &request_tokens, &NO_TAGS, regex_manager.deref_mut());
 
         // Extract the highest priority redirect directive.
         // So far, priority specifiers are not supported, which means:
@@ -279,7 +292,7 @@ impl Blocker {
         let rewritten_url = if important {
             None
         } else {
-            Self::apply_removeparam(&self.removeparam, request, request_tokens)
+            Self::apply_removeparam(&self.removeparam, request, request_tokens, regex_manager.deref_mut())
         };
 
         // If something has already matched before but we don't know what, still return a match
@@ -295,7 +308,7 @@ impl Blocker {
         }
     }
 
-    fn apply_removeparam(removeparam_filters: &NetworkFilterList, request: &Request, request_tokens: lifeguard::Recycled<Vec<u64>>) -> Option<String> {
+    fn apply_removeparam(removeparam_filters: &NetworkFilterList, request: &Request, request_tokens: lifeguard::Recycled<Vec<u64>>, regex_manager: &mut RegexManager) -> Option<String> {
         /// Represents an `&`-separated argument from a URL query parameter string
         enum QParam<'a> {
             /// Just a key, e.g. `...&key&...`
@@ -333,7 +346,7 @@ impl Blocker {
                 .map(|param| (param, true))
                 .collect();
 
-            let filters = removeparam_filters.check_all(request, &request_tokens, &NO_TAGS);
+            let filters = removeparam_filters.check_all(request, &request_tokens, &NO_TAGS, regex_manager);
             let mut rewrite = false;
             for removeparam_filter in filters {
                 if let Some(removeparam) = &removeparam_filter.modifier_option {
@@ -373,6 +386,8 @@ impl Blocker {
         }
 
         let mut request_tokens;
+        let mut regex_manager = self.regex_manager.borrow_mut();
+
         #[cfg(feature = "object-pooling")]
         {
             request_tokens = self.pool.pool.new();
@@ -383,7 +398,7 @@ impl Blocker {
         }
         request.get_tokens(&mut request_tokens);
 
-        let filters = self.csp.check_all(request, &request_tokens, &self.tags_enabled);
+        let filters = self.csp.check_all(request, &request_tokens, &self.tags_enabled, regex_manager.borrow_mut());
 
         if filters.is_empty() {
             return None;
@@ -511,6 +526,7 @@ impl Blocker {
             resources: RedirectResourceStorage::default(),
             #[cfg(feature = "object-pooling")]
             pool: TokenPool::default(),
+            regex_manager: std::cell::RefCell::new(RegexManager::default()),
         }
     }
 
@@ -634,6 +650,15 @@ impl Blocker {
     pub fn get_resource(&self, key: &str) -> Option<&RedirectResource> {
         self.resources.get_resource(key)
     }
+
+    pub fn get_debug_info(&self) -> BlockerDebugInfo {
+      let regex_manager = self.regex_manager.borrow();
+      BlockerDebugInfo{
+        active_regex_count: regex_manager.get_active_regex_count(),
+        compiled_regex_count: regex_manager.get_compiled_regex_count()
+      }
+    }
+
 }
 
 #[derive(Serialize, Deserialize, Default)]
@@ -776,7 +801,7 @@ impl NetworkFilterList {
     /// match from each would be functionally equivalent. For example, if two different exception
     /// filters match a certain request, it doesn't matter _which_ one is matched - the request
     /// will be excepted either way.
-    pub fn check(&self, request: &Request, request_tokens: &[Hash], active_tags: &HashSet<String>) -> Option<&NetworkFilter> {
+    pub fn check(&self, request: &Request, request_tokens: &[Hash], active_tags: &HashSet<String>, regex_manager: &mut RegexManager) -> Option<&NetworkFilter> {
         #[cfg(feature = "metrics")]
         let mut filters_checked = 0;
         #[cfg(feature = "metrics")]
@@ -803,7 +828,7 @@ impl NetworkFilterList {
                             filters_checked += 1;
                         }
                         // if matched, also needs to be tagged with an active tag (or not tagged at all)
-                        if filter.matches(request) && filter.tag.as_ref().map(|t| active_tags.contains(t)).unwrap_or(true) {
+                        if filter.matches(request, regex_manager) && filter.tag.as_ref().map(|t| active_tags.contains(t)).unwrap_or(true) {
                             #[cfg(feature = "metrics")]
                             print!("true\t{}\t{}\tskipped\t{}\t{}\t", filter_buckets, filters_checked, filter_buckets, filters_checked);
                             return Some(filter);
@@ -828,7 +853,7 @@ impl NetworkFilterList {
                         filters_checked += 1;
                     }
                     // if matched, also needs to be tagged with an active tag (or not tagged at all)
-                    if filter.matches(request) && filter.tag.as_ref().map(|t| active_tags.contains(t)).unwrap_or(true) {
+                    if filter.matches(request, regex_manager) && filter.tag.as_ref().map(|t| active_tags.contains(t)).unwrap_or(true) {
                         #[cfg(feature = "metrics")]
                         print!("true\t{}\t{}\t", filter_buckets, filters_checked);
                         return Some(filter);
@@ -847,7 +872,7 @@ impl NetworkFilterList {
     /// filters where a match from each may carry unique information. For example, if two different
     /// `$csp` filters match a certain request, they may each carry a distinct CSP directive, and
     /// each directive should be combined for the final result.
-    pub fn check_all(&self, request: &Request, request_tokens: &[Hash], active_tags: &HashSet<String>) -> Vec<&NetworkFilter> {
+    pub fn check_all(&self, request: &Request, request_tokens: &[Hash], active_tags: &HashSet<String>, regex_manager: &mut RegexManager) -> Vec<&NetworkFilter> {
         #[cfg(feature = "metrics")]
         let mut filters_checked = 0;
         #[cfg(feature = "metrics")]
@@ -876,7 +901,7 @@ impl NetworkFilterList {
                             filters_checked += 1;
                         }
                         // if matched, also needs to be tagged with an active tag (or not tagged at all)
-                        if filter.matches(request) && filter.tag.as_ref().map(|t| active_tags.contains(t)).unwrap_or(true) {
+                        if filter.matches(request, regex_manager) && filter.tag.as_ref().map(|t| active_tags.contains(t)).unwrap_or(true) {
                             #[cfg(feature = "metrics")]
                             print!("true\t{}\t{}\tskipped\t{}\t{}\t", filter_buckets, filters_checked, filter_buckets, filters_checked);
                             filters.push(filter);
@@ -901,7 +926,7 @@ impl NetworkFilterList {
                         filters_checked += 1;
                     }
                     // if matched, also needs to be tagged with an active tag (or not tagged at all)
-                    if filter.matches(request) && filter.tag.as_ref().map(|t| active_tags.contains(t)).unwrap_or(true) {
+                    if filter.matches(request, regex_manager) && filter.tag.as_ref().map(|t| active_tags.contains(t)).unwrap_or(true) {
                         #[cfg(feature = "metrics")]
                         print!("true\t{}\t{}\t", filter_buckets, filters_checked);
                         filters.push(filter);
@@ -1150,11 +1175,12 @@ mod tests {
             .filter_map(Result::ok)
             .collect();
         let filter_list = NetworkFilterList::new(network_filters, false);
+        let mut regex_manager = RegexManager::default();
 
         requests.into_iter().for_each(|(req, expected_result)| {
             let mut tokens = Vec::new();
             req.get_tokens(&mut tokens);
-            let matched_rule = filter_list.check(&req, &tokens, &HashSet::new());
+            let matched_rule = filter_list.check(&req, &tokens, &HashSet::new(), &mut regex_manager);
             if *expected_result {
                 assert!(matched_rule.is_some(), "Expected match for {}", req.url);
             } else {

--- a/src/data_format/legacy.rs
+++ b/src/data_format/legacy.rs
@@ -19,7 +19,7 @@ use rmp_serde_legacy as rmps;
 
 use crate::blocker::{Blocker, NetworkFilterList};
 use crate::resources::{RedirectResourceStorage, ScriptletResourceStorage};
-use crate::filters::network::NetworkFilter;
+use crate::filters::network::{NetworkFilter, RegexManager};
 use crate::cosmetic_filter_cache::{CosmeticFilterCache, HostnameRuleDb};
 use crate::utils::is_eof_error;
 
@@ -193,7 +193,6 @@ impl From<NetworkFilterLegacyDeserializeFmt> for NetworkFilter {
             id: v.id,
             opt_domains_union: v.opt_domains_union,
             opt_not_domains_union: v.opt_not_domains_union,
-            regex: crate::filters::network::RegexStorage::default(),
         }
     }
 }
@@ -342,6 +341,7 @@ impl From<DeserializeFormat> for (Blocker, CosmeticFilterCache) {
             resources: v.part1.resources,
             #[cfg(feature = "object-pooling")]
             pool: Default::default(),
+            regex_manager: std::cell::RefCell::new(RegexManager::default()),
 
             generic_hide: v.rest.generic_hide.into(),
         }, CosmeticFilterCache {

--- a/src/data_format/legacy.rs
+++ b/src/data_format/legacy.rs
@@ -19,7 +19,7 @@ use rmp_serde_legacy as rmps;
 
 use crate::blocker::{Blocker, NetworkFilterList};
 use crate::resources::{RedirectResourceStorage, ScriptletResourceStorage};
-use crate::filters::network::{NetworkFilter, RegexManager};
+use crate::filters::network::NetworkFilter;
 use crate::cosmetic_filter_cache::{CosmeticFilterCache, HostnameRuleDb};
 use crate::utils::is_eof_error;
 
@@ -341,7 +341,7 @@ impl From<DeserializeFormat> for (Blocker, CosmeticFilterCache) {
             resources: v.part1.resources,
             #[cfg(feature = "object-pooling")]
             pool: Default::default(),
-            regex_manager: std::cell::RefCell::new(RegexManager::default()),
+            regex_manager: Default::default(),
 
             generic_hide: v.rest.generic_hide.into(),
         }, CosmeticFilterCache {

--- a/src/data_format/v0.rs
+++ b/src/data_format/v0.rs
@@ -11,7 +11,7 @@ use rmp_serde as rmps;
 
 use crate::blocker::{Blocker, NetworkFilterList};
 use crate::resources::{RedirectResourceStorage, ScriptletResourceStorage};
-use crate::filters::network::NetworkFilter;
+use crate::filters::network::{NetworkFilter, RegexManager};
 use crate::cosmetic_filter_cache::{CosmeticFilterCache, HostnameRuleDb};
 
 use super::{DeserializationError, SerializationError};
@@ -168,7 +168,6 @@ impl From<NetworkFilterV0DeserializeFmt> for NetworkFilter {
             id: v.id,
             opt_domains_union: v.opt_domains_union,
             opt_not_domains_union: v.opt_not_domains_union,
-            regex: crate::filters::network::RegexStorage::default(),
         }
     }
 }
@@ -277,6 +276,7 @@ impl From<DeserializeFormat> for (Blocker, CosmeticFilterCache) {
             resources: v.resources,
             #[cfg(feature = "object-pooling")]
             pool: Default::default(),
+            regex_manager: std::cell::RefCell::new(RegexManager::default()),
 
         }, CosmeticFilterCache {
             simple_class_rules: v.simple_class_rules,

--- a/src/data_format/v0.rs
+++ b/src/data_format/v0.rs
@@ -11,7 +11,7 @@ use rmp_serde as rmps;
 
 use crate::blocker::{Blocker, NetworkFilterList};
 use crate::resources::{RedirectResourceStorage, ScriptletResourceStorage};
-use crate::filters::network::{NetworkFilter, RegexManager};
+use crate::filters::network::NetworkFilter;
 use crate::cosmetic_filter_cache::{CosmeticFilterCache, HostnameRuleDb};
 
 use super::{DeserializationError, SerializationError};
@@ -276,7 +276,7 @@ impl From<DeserializeFormat> for (Blocker, CosmeticFilterCache) {
             resources: v.resources,
             #[cfg(feature = "object-pooling")]
             pool: Default::default(),
-            regex_manager: std::cell::RefCell::new(RegexManager::default()),
+            regex_manager: Default::default(),
 
         }, CosmeticFilterCache {
             simple_class_rules: v.simple_class_rules,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -272,6 +272,7 @@ impl Engine {
         self.cosmetic_cache.hostname_cosmetic_resources(&request.hostname, generichide)
     }
 
+    #[cfg(feature = "debug-info")]
     pub fn get_debug_info(&self) -> EngineDebugInfo {
         EngineDebugInfo { blocker_debug_info: self.blocker.get_debug_info() }
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -19,6 +19,10 @@ impl Default for Engine {
     }
 }
 
+pub struct EngineDebugInfo {
+    pub blocker_debug_info: crate::blocker::BlockerDebugInfo,
+}
+
 impl Engine {
     /// Creates a new adblocking `Engine`. `Engine`s created without rules should generally only be
     /// used with deserialization.
@@ -267,10 +271,14 @@ impl Engine {
         let generichide = self.blocker.check_generic_hide(&request);
         self.cosmetic_cache.hostname_cosmetic_resources(&request.hostname, generichide)
     }
+
+    pub fn get_debug_info(&self) -> EngineDebugInfo {
+        EngineDebugInfo { blocker_debug_info: self.blocker.get_debug_info() }
+    }
 }
 
 /// Static assertions for `Engine: Send + Sync` traits.
-#[cfg(not(any(feature = "object-pooling", feature = "optimized-regex-cache")))]
+#[cfg(not(any(feature = "object-pooling")))]
 fn _assertions() {
     fn _assert_send<T: Send>() {}
     fn _assert_sync<T: Sync>() {}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -278,7 +278,7 @@ impl Engine {
 }
 
 /// Static assertions for `Engine: Send + Sync` traits.
-#[cfg(not(any(feature = "object-pooling")))]
+#[cfg(not(any(feature = "object-pooling", feature = "unsync-regex-caching")))]
 fn _assertions() {
     fn _assert_send<T: Send>() {}
     fn _assert_sync<T: Sync>() {}

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod network;
 pub mod cosmetic;
+pub mod regex_manager;

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -2,13 +2,14 @@ use regex::{Regex, RegexSet};
 use serde::{Deserialize, Serialize};
 use once_cell::sync::Lazy;
 
-use std::collections::HashMap;
 use std::fmt;
 
 use crate::request;
 use crate::utils;
 use crate::utils::Hash;
 use crate::lists::ParseOptions;
+
+use crate::filters::regex_manager::RegexManager;
 
 pub const TOKENS_BUFFER_SIZE: usize = 200;
 
@@ -269,99 +270,6 @@ impl NetworkFilterOption {
 
     pub fn is_redirection(&self) -> bool {
         matches!(self, Self::Redirect(..) | Self::RedirectRule(..))
-    }
-}
-
-pub struct RegexDebugEntry {
-    regex: String,
-    last_used: std::time::Instant,
-    usage_count: u64,
-}
-
-struct RegexEntry {
-    regex: CompiledRegex,
-    last_used: std::time::Instant,
-    usage_count: u64,
-}
-
-type RandomState = std::hash::BuildHasherDefault<seahash::SeaHasher>;
-
-pub struct RegexManager {
-    map: HashMap<*const NetworkFilter, RegexEntry, RandomState>,
-    compiled_regex_count: u64,
-    now: std::time::Instant,
-    last_cleanup: std::time::Instant,
-}
-
-impl Default for RegexManager {
-    fn default() -> RegexManager {
-        RegexManager {
-            map: Default::default(),
-            compiled_regex_count: 0,
-            now: std::time::Instant::now(),
-            last_cleanup: std::time::Instant::now(),
-        }
-    }
-}
-
-impl RegexManager {
-    pub fn matches(&mut self, filter: &NetworkFilter, pattern: &str) -> bool {
-        if !filter.is_regex() && !filter.is_complete_regex() {
-            return true;
-        }
-        let key = filter as *const NetworkFilter;
-        use std::collections::hash_map::Entry;
-        match self.map.entry(key) {
-            Entry::Occupied(mut e) => {
-                let v = e.get_mut();
-                v.usage_count += 1;
-                v.last_used = self.now;
-                return v.regex.is_match(pattern);
-            }
-            Entry::Vacant(e) => {
-                let regex = compile_regex(
-                    &filter.filter,
-                    filter.is_right_anchor(),
-                    filter.is_left_anchor(),
-                    filter.is_complete_regex(),
-                );
-                self.compiled_regex_count += 1;
-                let new_entry = RegexEntry {
-                    regex,
-                    last_used: self.now,
-                    usage_count: 1,
-                };
-                return e.insert(new_entry).regex.is_match(pattern);
-            }
-        };
-    }
-
-    pub fn update_time(&mut self) {
-        self.now = std::time::Instant::now();
-        if self.now - self.last_cleanup > std::time::Duration::from_secs(30) {
-            self.last_cleanup = self.now;
-            self.cleanup();
-        }
-    }
-
-    pub fn cleanup(&mut self) {
-        let now = self.now;
-        self.map.retain(|_, v| now - v.last_used < std::time::Duration::from_secs(180));
-    }
-
-    #[cfg(feature = "debug-info")]
-    pub fn get_debug_regex_data(&self) -> Vec<RegexDebugEntry> {
-        use itertools::Itertools;
-        self.map.values().map(
-            |e| RegexDebugEntry{regex: e.regex.to_string(),
-                                            last_used : e.last_used,
-                                            usage_count: e.usage_count})
-            .collect_vec()
-    }
-
-    #[cfg(feature = "debug-info")]
-    pub fn get_compiled_regex_count(&self) -> u64 {
-        self.compiled_regex_count
     }
 }
 
@@ -3334,12 +3242,15 @@ mod match_tests {
             let url = "https://data.foo.com/9VjjrjU9Or2aqkb8PDiqTBnULPgeI48WmYEHkYer";
             let source = "http://123movies.com";
             let request = request::Request::from_urls(url, source, "script").unwrap();
+            let mut regex_manager = RegexManager::default();
+            assert!(regex_manager.get_compiled_regex_count() == 0);
             assert!(
-                network_filter.matches_test(&request) == true,
+                network_filter.matches(&request, &mut regex_manager) == true,
                 "Expected match for {} on {}",
                 filter,
                 url
             );
+            assert!(regex_manager.get_compiled_regex_count() == 1);
         }
     }
 

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -275,9 +275,9 @@ impl NetworkFilterOption {
 }
 
 pub struct RegexEntry {
-  regex: CompiledRegex,
-  last_used: std::time::Instant,
-  usage_count: u64,
+    regex: CompiledRegex,
+    last_used: std::time::Instant,
+    usage_count: u64,
 }
 
 pub struct RegexManager {
@@ -301,7 +301,7 @@ impl Default for RegexManager {
 impl RegexManager {
     pub fn matches(&mut self, filter: &NetworkFilter, pattern: &str) -> bool {
         if !filter.is_regex() && !filter.is_complete_regex() {
-              return true;
+            return true;
         }
         let key = filter as *const NetworkFilter;
         use std::collections::hash_map::Entry;
@@ -320,13 +320,13 @@ impl RegexManager {
                     filter.is_complete_regex(),
                 );
                 self.compiled_regex_count += 1;
-                let new_entry = RegexEntry{
+                let new_entry = RegexEntry {
                     regex,
                     last_used: self.now,
                     usage_count: 1,
                 };
                 return e.insert(new_entry).regex.is_match(pattern);
-            },
+            }
         };
     }
 
@@ -1418,7 +1418,11 @@ fn check_pattern_regex_filter_at(
     regex_manager.matches(filter, &request.url[start_from..])
 }
 
-fn check_pattern_regex_filter(filter: &NetworkFilter, request: &request::Request,regex_manager: &mut RegexManager) -> bool {
+fn check_pattern_regex_filter(
+    filter: &NetworkFilter,
+    request: &request::Request,
+    regex_manager: &mut RegexManager,
+) -> bool {
     check_pattern_regex_filter_at(filter, request, 0, regex_manager)
 }
 
@@ -1584,7 +1588,11 @@ fn check_pattern_hostname_anchor_filter(
 
 /// Efficiently checks if a certain network filter matches against a network
 /// request.
-fn check_pattern(filter: &NetworkFilter, request: &request::Request, regex_manager: &mut RegexManager) -> bool {
+fn check_pattern(
+    filter: &NetworkFilter,
+    request: &request::Request,
+    regex_manager: &mut RegexManager,
+) -> bool {
     if filter.is_hostname_anchor() {
         if filter.is_regex() {
             check_pattern_hostname_anchor_regex_filter(filter, request, regex_manager)

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -2,8 +2,10 @@ use regex::{Regex, RegexSet};
 use serde::{Deserialize, Serialize};
 use once_cell::sync::Lazy;
 
+use std::collections::HashMap;
 use std::fmt;
-use std::sync::Arc;
+
+use ahash::RandomState;
 
 use crate::request;
 use crate::utils;
@@ -272,6 +274,53 @@ impl NetworkFilterOption {
     }
 }
 
+pub struct RegexManager {
+    map: HashMap<*const NetworkFilter, CompiledRegex, RandomState>,
+    compiled_regex_count: usize,
+}
+
+impl Default for RegexManager {
+    fn default() -> RegexManager {
+        RegexManager {
+            map: HashMap::<*const NetworkFilter, CompiledRegex, RandomState>::default(),
+            compiled_regex_count: 0,
+        }
+    }
+}
+
+impl RegexManager {
+    pub fn matches(&mut self, filter: &NetworkFilter, pattern: &str) -> bool {
+        if !filter.is_regex() && !filter.is_complete_regex() {
+            return true;
+        }
+        let key = filter as *const NetworkFilter;
+        use std::collections::hash_map::Entry;
+        match self.map.entry(key) {
+            Entry::Occupied(e) => {
+                return e.get().is_match(pattern);
+            }
+            Entry::Vacant(e) => {
+                let regex = compile_regex(
+                    &filter.filter,
+                    filter.is_right_anchor(),
+                    filter.is_left_anchor(),
+                    filter.is_complete_regex(),
+                );
+                self.compiled_regex_count += 1;
+                return e.insert(regex).is_match(pattern);
+            }
+        };
+    }
+
+    pub fn get_active_regex_count(&self) -> usize {
+        self.map.len()
+    }
+
+    pub fn get_compiled_regex_count(&self) -> usize {
+        self.compiled_regex_count
+    }
+}
+
 /// Abstract syntax representation of a network filter. This representation can fully specify the
 /// string representation of a filter as written, with the exception of aliased options like `1p`
 /// or `ghide`. This allows separation of concerns between parsing and interpretation.
@@ -424,50 +473,6 @@ fn parse_filter_options(raw_options: &str) -> Result<Vec<NetworkFilterOption>, N
     Ok(result)
 }
 
-/// Lazily-compiled regex cache. Regex rules are uncommon, so the `unsync-regex-caching` feature
-/// can be used to reduce the memory footprint of unused regex fields at the cost of making the
-/// adblock engine `!Sync` and `!Send`.
-#[derive(Debug, Clone, Default)]
-pub struct RegexStorage {
-    /// Atomic Arc is used for compatibilty with code that accesses the adblock engine from
-    /// multiple threads.
-    #[cfg(not(feature = "unsync-regex-caching"))]
-    pub(crate) regex: Arc<std::sync::RwLock<Option<Arc<CompiledRegex>>>>,
-
-    /// RefCell allows for cloned NetworkFilters to point to the same Option and what is inside.
-    /// When the Regex hasn't been compiled, <None> is stored, afterwards Arc to CompiledRegex
-    /// to avoid expensive cloning of the Regex itself.
-    /// Non-thread safe, should be used from a single thread.
-    #[cfg(feature = "unsync-regex-caching")]
-    pub(crate) regex: std::cell::RefCell<Option<Arc<CompiledRegex>>>,
-}
-
-impl RegexStorage {
-    pub fn get(&self) -> Option<Arc<CompiledRegex>> {
-        #[cfg(not(feature = "unsync-regex-caching"))]
-        if let Some(cache) = &*self.regex.read().unwrap() {
-            return Some(Arc::clone(cache));
-        }
-
-        #[cfg(feature = "unsync-regex-caching")]
-        if let Some(cache) = &*self.regex.borrow() {
-            return Some(Arc::clone(cache));
-        }
-        None
-    }
-
-    pub fn set(&self, regex: Arc<CompiledRegex>) {
-        #[cfg(not(feature = "unsync-regex-caching"))]
-        {
-            *self.regex.write().unwrap() = Some(regex);
-        }
-
-        #[cfg(feature = "unsync-regex-caching")]
-        {
-            *self.regex.borrow_mut() = Some(regex);
-        }
-    }
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkFilter {
@@ -488,10 +493,6 @@ pub struct NetworkFilter {
     // All domain option values (their hashes) OR'ed together to quickly dismiss mis-matches
     pub opt_domains_union: Option<Hash>,
     pub opt_not_domains_union: Option<Hash>,
-
-    // Regex compiled lazily and cached using interior mutability.
-    #[serde(skip_serializing, skip_deserializing)]
-    pub(crate) regex: RegexStorage,
 }
 
 // TODO - restrict the API so that this is always true - i.e. lazy-calculate IDs from actual data,
@@ -883,7 +884,6 @@ impl NetworkFilter {
             id: utils::fast_hash(line),
             opt_domains_union,
             opt_not_domains_union,
-            regex: RegexStorage::default(),
         })
     }
 
@@ -1104,32 +1104,20 @@ impl fmt::Display for NetworkFilter {
 }
 
 pub trait NetworkMatchable {
-    fn matches(&self, request: &request::Request) -> bool;
-    fn get_regex(&self) -> Arc<CompiledRegex>;
+    fn matches(&self, request: &request::Request, regex_manager: &mut RegexManager) -> bool;
+
+    #[cfg(test)]
+    fn matches_test(&self, request: &request::Request) -> bool;
 }
 
 impl NetworkMatchable for NetworkFilter {
-    fn matches(&self, request: &request::Request) -> bool {
-        check_options(self, request) && check_pattern(self, request)
+    fn matches(&self, request: &request::Request, regex_manager: &mut RegexManager) -> bool {
+        check_options(self, request) && check_pattern(self, request, regex_manager)
     }
 
-    // Lazily get the regex if the filter has one
-    fn get_regex(&self) -> Arc<CompiledRegex> {
-        if !self.is_regex() && !self.is_complete_regex() {
-            return Arc::new(CompiledRegex::MatchAll);
-        }
-        if let Some(cache) = self.regex.get() {
-            return cache;
-        }
-        let regex = compile_regex(
-            &self.filter,
-            self.is_right_anchor(),
-            self.is_left_anchor(),
-            self.is_complete_regex(),
-        );
-        let arc_regex = Arc::new(regex);
-        self.regex.set(arc_regex.clone());
-        arc_regex
+    #[cfg(test)]
+    fn matches_test(&self, request: &request::Request) -> bool {
+        self.matches(request, &mut RegexManager::default())
     }
 }
 
@@ -1394,19 +1382,20 @@ fn check_pattern_regex_filter_at(
     filter: &NetworkFilter,
     request: &request::Request,
     start_from: usize,
+    regex_manager: &mut RegexManager,
 ) -> bool {
-    let regex = filter.get_regex();
-    regex.is_match(&request.url[start_from..])
+    regex_manager.matches(filter, &request.url[start_from..])
 }
 
-fn check_pattern_regex_filter(filter: &NetworkFilter, request: &request::Request) -> bool {
-    check_pattern_regex_filter_at(filter, request, 0)
+fn check_pattern_regex_filter(filter: &NetworkFilter, request: &request::Request,regex_manager: &mut RegexManager) -> bool {
+    check_pattern_regex_filter_at(filter, request, 0, regex_manager)
 }
 
 // ||pattern*^
 fn check_pattern_hostname_anchor_regex_filter(
     filter: &NetworkFilter,
     request: &request::Request,
+    regex_manager: &mut RegexManager,
 ) -> bool {
     filter
         .hostname
@@ -1417,6 +1406,7 @@ fn check_pattern_hostname_anchor_regex_filter(
                     filter,
                     request,
                     request.url.find(hostname).unwrap_or_default() + hostname.len(),
+                    regex_manager,
                 )
             } else {
                 false
@@ -1563,10 +1553,10 @@ fn check_pattern_hostname_anchor_filter(
 
 /// Efficiently checks if a certain network filter matches against a network
 /// request.
-fn check_pattern(filter: &NetworkFilter, request: &request::Request) -> bool {
+fn check_pattern(filter: &NetworkFilter, request: &request::Request, regex_manager: &mut RegexManager) -> bool {
     if filter.is_hostname_anchor() {
         if filter.is_regex() {
-            check_pattern_hostname_anchor_regex_filter(filter, request)
+            check_pattern_hostname_anchor_regex_filter(filter, request, regex_manager)
         } else if filter.is_right_anchor() && filter.is_left_anchor() {
             check_pattern_hostname_left_right_anchor_filter(filter, request)
         } else if filter.is_right_anchor() {
@@ -1577,7 +1567,7 @@ fn check_pattern(filter: &NetworkFilter, request: &request::Request) -> bool {
             check_pattern_hostname_anchor_filter(filter, request)
         }
     } else if filter.is_regex() || filter.is_complete_regex() {
-        check_pattern_regex_filter(filter, request)
+        check_pattern_regex_filter(filter, request, regex_manager)
     } else if filter.is_left_anchor() && filter.is_right_anchor() {
         check_pattern_left_right_anchor_filter(filter, request)
     } else if filter.is_left_anchor() {
@@ -2743,8 +2733,7 @@ mod parse_tests {
             let decoded: NetworkFilter = Deserialize::deserialize(&mut de).unwrap();
 
             assert_eq!(defaults, NetworkFilterBreakdown::from(&decoded));
-
-            assert_eq!(decoded.get_regex().is_match("bar/"), true);
+            assert_eq!(RegexManager::default().matches(&decoded, "bar/"), true);
         }
     }
 
@@ -2859,7 +2848,7 @@ mod match_tests {
         let request = request::Request::from_url(url).unwrap();
 
         assert!(
-            network_filter.matches(&request) == matching,
+            network_filter.matches_test(&request) == matching,
             "Expected match={} for {} {:?} on {}",
             matching,
             filter,
@@ -2873,7 +2862,7 @@ mod match_tests {
         let request = request::Request::from_url(url).unwrap();
 
         assert!(
-            network_filter.matches(&request) == matching,
+            network_filter.matches_test(&request) == matching,
             "Expected match={} for {} {:?} on {}",
             matching,
             filter,
@@ -3045,7 +3034,7 @@ mod match_tests {
             )
             .unwrap();
             assert!(
-                network_filter.matches(&request) == true,
+                network_filter.matches_test(&request) == true,
                 "Expected match for {} on {}",
                 filter,
                 url
@@ -3062,7 +3051,7 @@ mod match_tests {
             )
             .unwrap();
             assert!(
-                network_filter.matches(&request) == true,
+                network_filter.matches_test(&request) == true,
                 "Expected match for {} on {}",
                 filter,
                 url
@@ -3074,16 +3063,16 @@ mod match_tests {
     fn check_ws_vs_http_matching() {
         let network_filter = NetworkFilter::parse("|ws://$domain=4shared.com", true, Default::default()).unwrap();
 
-        assert!(network_filter.matches(&request::Request::from_urls("ws://example.com", "https://4shared.com", "websocket").unwrap()));
-        assert!(network_filter.matches(&request::Request::from_urls("wss://example.com", "https://4shared.com", "websocket").unwrap()));
-        assert!(!network_filter.matches(&request::Request::from_urls("http://example.com", "https://4shared.com", "script").unwrap()));
-        assert!(!network_filter.matches(&request::Request::from_urls("https://example.com", "https://4shared.com", "script").unwrap()));
+        assert!(network_filter.matches_test(&request::Request::from_urls("ws://example.com", "https://4shared.com", "websocket").unwrap()));
+        assert!(network_filter.matches_test(&request::Request::from_urls("wss://example.com", "https://4shared.com", "websocket").unwrap()));
+        assert!(!network_filter.matches_test(&request::Request::from_urls("http://example.com", "https://4shared.com", "script").unwrap()));
+        assert!(!network_filter.matches_test(&request::Request::from_urls("https://example.com", "https://4shared.com", "script").unwrap()));
 
         // The `ws://` and `wss://` protocols should be used, rather than the resource type.
-        assert!(network_filter.matches(&request::Request::from_urls("ws://example.com", "https://4shared.com", "script").unwrap()));
-        assert!(network_filter.matches(&request::Request::from_urls("wss://example.com", "https://4shared.com", "script").unwrap()));
-        assert!(!network_filter.matches(&request::Request::from_urls("http://example.com", "https://4shared.com", "websocket").unwrap()));
-        assert!(!network_filter.matches(&request::Request::from_urls("https://example.com", "https://4shared.com", "websocket").unwrap()));
+        assert!(network_filter.matches_test(&request::Request::from_urls("ws://example.com", "https://4shared.com", "script").unwrap()));
+        assert!(network_filter.matches_test(&request::Request::from_urls("wss://example.com", "https://4shared.com", "script").unwrap()));
+        assert!(!network_filter.matches_test(&request::Request::from_urls("http://example.com", "https://4shared.com", "websocket").unwrap()));
+        assert!(!network_filter.matches_test(&request::Request::from_urls("https://example.com", "https://4shared.com", "websocket").unwrap()));
     }
 
     #[test]
@@ -3171,43 +3160,43 @@ mod match_tests {
     fn check_domain_option_subsetting_works() {
         {
             let network_filter = NetworkFilter::parse("adv$domain=example.com|~foo.example.com", true, Default::default()).unwrap();
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://example.com", "").unwrap()) == true);
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://foo.example.com", "").unwrap()) == false);
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://subfoo.foo.example.com", "").unwrap()) == false);
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://bar.example.com", "").unwrap()) == true);
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://anotherexample.com", "").unwrap()) == false);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://example.com", "").unwrap()) == true);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://foo.example.com", "").unwrap()) == false);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://subfoo.foo.example.com", "").unwrap()) == false);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://bar.example.com", "").unwrap()) == true);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://anotherexample.com", "").unwrap()) == false);
         }
         {
             let network_filter = NetworkFilter::parse("adv$domain=~example.com|~foo.example.com", true, Default::default()).unwrap();
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://example.com", "").unwrap()) == false);
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://foo.example.com", "").unwrap()) == false);
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://subfoo.foo.example.com", "").unwrap()) == false);
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://bar.example.com", "").unwrap()) == false);
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://anotherexample.com", "").unwrap()) == true);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://example.com", "").unwrap()) == false);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://foo.example.com", "").unwrap()) == false);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://subfoo.foo.example.com", "").unwrap()) == false);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://bar.example.com", "").unwrap()) == false);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://anotherexample.com", "").unwrap()) == true);
         }
         {
             let network_filter = NetworkFilter::parse("adv$domain=example.com|foo.example.com", true, Default::default()).unwrap();
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://example.com", "").unwrap()) == true);
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://foo.example.com", "").unwrap()) == true);
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://subfoo.foo.example.com", "").unwrap()) == true);
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://bar.example.com", "").unwrap()) == true);
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://anotherexample.com", "").unwrap()) == false);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://example.com", "").unwrap()) == true);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://foo.example.com", "").unwrap()) == true);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://subfoo.foo.example.com", "").unwrap()) == true);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://bar.example.com", "").unwrap()) == true);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://anotherexample.com", "").unwrap()) == false);
         }
         {
             let network_filter = NetworkFilter::parse("adv$domain=~example.com|foo.example.com", true, Default::default()).unwrap();
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://example.com", "").unwrap()) == false);
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://foo.example.com", "").unwrap()) == false);
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://subfoo.foo.example.com", "").unwrap()) == false);
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://bar.example.com", "").unwrap()) == false);
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://anotherexample.com", "").unwrap()) == false);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://example.com", "").unwrap()) == false);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://foo.example.com", "").unwrap()) == false);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://subfoo.foo.example.com", "").unwrap()) == false);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://bar.example.com", "").unwrap()) == false);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://anotherexample.com", "").unwrap()) == false);
         }
         {
             let network_filter = NetworkFilter::parse("adv$domain=com|~foo.com", true, Default::default()).unwrap();
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://com", "").unwrap()) == true);
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://foo.com", "").unwrap()) == false);
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://subfoo.foo.com", "").unwrap()) == false);
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://bar.com", "").unwrap()) == true);
-            assert!(network_filter.matches(&request::Request::from_urls("http://example.net/adv", "http://co.uk", "").unwrap()) == false);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://com", "").unwrap()) == true);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://foo.com", "").unwrap()) == false);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://subfoo.foo.com", "").unwrap()) == false);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://bar.com", "").unwrap()) == true);
+            assert!(network_filter.matches_test(&request::Request::from_urls("http://example.net/adv", "http://co.uk", "").unwrap()) == false);
         }
     }
 
@@ -3248,7 +3237,7 @@ mod match_tests {
             let source = "http://123movies.com";
             let request = request::Request::from_urls(url, source, "").unwrap();
             assert!(
-                network_filter.matches(&request) == true,
+                network_filter.matches_test(&request) == true,
                 "Expected match for {} on {}",
                 filter,
                 url
@@ -3262,7 +3251,7 @@ mod match_tests {
             let source = "http://123movies.com";
             let request = request::Request::from_urls(url, source, "xmlhttprequest").unwrap();
             assert!(
-                network_filter.matches(&request) == true,
+                network_filter.matches_test(&request) == true,
                 "Expected match for {} on {}",
                 filter,
                 url
@@ -3276,7 +3265,7 @@ mod match_tests {
             let source = "http://123movies.com";
             let request = request::Request::from_urls(url, source, "stylesheet").unwrap();
             assert!(
-                network_filter.matches(&request) == true,
+                network_filter.matches_test(&request) == true,
                 "Expected match for {} on {}",
                 filter,
                 url
@@ -3290,17 +3279,11 @@ mod match_tests {
         {
             let filter = r#"/^https?:\/\/([0-9a-z\-]+\.)?(9anime|animeland|animenova|animeplus|animetoon|animewow|gamestorrent|goodanime|gogoanime|igg-games|kimcartoon|memecenter|readcomiconline|toonget|toonova|watchcartoononline)\.[a-z]{2,4}\/(?!([Ee]xternal|[Ii]mages|[Ss]cripts|[Uu]ploads|ac|ajax|assets|combined|content|cov|cover|(img\/bg)|(img\/icon)|inc|jwplayer|player|playlist-cat-rss|static|thumbs|wp-content|wp-includes)\/)(.*)/$image,other,script,~third-party,xmlhttprequest,domain=~animeland.hu"#;
             let network_filter = NetworkFilter::parse(filter, true, Default::default()).unwrap();
-            let regex = Arc::try_unwrap(network_filter.get_regex()).unwrap();
-            assert!(
-                matches!(regex, CompiledRegex::Compiled(_)),
-                "Generated incorrect regex: {:?}",
-                regex
-            );
             let url = "https://data.foo.com/9VjjrjU9Or2aqkb8PDiqTBnULPgeI48WmYEHkYer";
             let source = "http://123movies.com";
             let request = request::Request::from_urls(url, source, "script").unwrap();
             assert!(
-                network_filter.matches(&request) == true,
+                network_filter.matches_test(&request) == true,
                 "Expected match for {} on {}",
                 filter,
                 url
@@ -3317,7 +3300,7 @@ mod match_tests {
             let source = "http://auth.wi-fi.ru";
             let request = request::Request::from_urls(url, source, "script").unwrap();
             assert!(
-                network_filter.matches(&request) == true,
+                network_filter.matches_test(&request) == true,
                 "Expected match for {} on {}",
                 filter,
                 url
@@ -3330,7 +3313,7 @@ mod match_tests {
             let source = "http://auth.wi-fi.ru";
             let request = request::Request::from_urls(url, source, "script").unwrap();
             assert!(
-                network_filter.matches(&request) == true,
+                network_filter.matches_test(&request) == true,
                 "Expected match for {} on {}",
                 filter,
                 url
@@ -3348,7 +3331,7 @@ mod match_tests {
             let request = request::Request::from_urls(url, source, "document").unwrap();
             assert_eq!(request.is_third_party, Some(false));
             assert!(
-                network_filter.matches(&request) == true,
+                network_filter.matches_test(&request) == true,
                 "Expected match for {} on {}",
                 filter,
                 url
@@ -3362,7 +3345,7 @@ mod match_tests {
             let request = request::Request::from_urls(url, source, "main_frame").unwrap();
             assert_eq!(request.is_third_party, Some(false));
             assert!(
-                network_filter.matches(&request) == true,
+                network_filter.matches_test(&request) == true,
                 "Expected match for {} on {}",
                 filter,
                 url

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -152,7 +152,6 @@ impl From<&request::RequestType> for NetworkFilterMask {
 pub enum CompiledRegex {
     Compiled(Regex),
     CompiledSet(RegexSet),
-    None,
     MatchAll,
     RegexParsingError(regex::Error),
 }
@@ -160,7 +159,6 @@ pub enum CompiledRegex {
 impl CompiledRegex {
     pub fn is_match(&self, pattern: &str) -> bool {
         match &self {
-            CompiledRegex::None => {panic!("use of CompiledRegex::None")} // No value, invalid call.
             CompiledRegex::MatchAll => true, // simple case for matching everything, e.g. for empty filter
             CompiledRegex::RegexParsingError(_e) => false, // no match if regex didn't even compile
             CompiledRegex::Compiled(r) => r.is_match(pattern),
@@ -176,7 +174,6 @@ impl CompiledRegex {
 impl fmt::Display for CompiledRegex {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self {
-            CompiledRegex::None => write!(f, "None"), // No value
             CompiledRegex::MatchAll => write!(f, ".*"), // simple case for matching everything, e.g. for empty filter
             CompiledRegex::RegexParsingError(_e) => write!(f, "ERROR"), // no match if regex didn't even compile
             CompiledRegex::Compiled(r) => write!(f, "{}", r.as_str()),

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -152,6 +152,7 @@ impl From<&request::RequestType> for NetworkFilterMask {
 pub enum CompiledRegex {
     Compiled(Regex),
     CompiledSet(RegexSet),
+    None,
     MatchAll,
     RegexParsingError(regex::Error),
 }
@@ -159,6 +160,7 @@ pub enum CompiledRegex {
 impl CompiledRegex {
     pub fn is_match(&self, pattern: &str) -> bool {
         match &self {
+            CompiledRegex::None => {panic!("use of CompiledRegex::None")} // No value, invalid call.
             CompiledRegex::MatchAll => true, // simple case for matching everything, e.g. for empty filter
             CompiledRegex::RegexParsingError(_e) => false, // no match if regex didn't even compile
             CompiledRegex::Compiled(r) => r.is_match(pattern),
@@ -174,6 +176,7 @@ impl CompiledRegex {
 impl fmt::Display for CompiledRegex {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self {
+            CompiledRegex::None => write!(f, "None"), // No value
             CompiledRegex::MatchAll => write!(f, ".*"), // simple case for matching everything, e.g. for empty filter
             CompiledRegex::RegexParsingError(_e) => write!(f, "ERROR"), // no match if regex didn't even compile
             CompiledRegex::Compiled(r) => write!(f, "{}", r.as_str()),

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -3235,6 +3235,7 @@ mod match_tests {
 
     #[test]
     #[ignore] // Not going to handle lookaround regexes
+    #[cfg(feature = "debug-info")]
     fn check_lookaround_regex_handled() {
         {
             let filter = r#"/^https?:\/\/([0-9a-z\-]+\.)?(9anime|animeland|animenova|animeplus|animetoon|animewow|gamestorrent|goodanime|gogoanime|igg-games|kimcartoon|memecenter|readcomiconline|toonget|toonova|watchcartoononline)\.[a-z]{2,4}\/(?!([Ee]xternal|[Ii]mages|[Ss]cripts|[Uu]ploads|ac|ajax|assets|combined|content|cov|cover|(img\/bg)|(img\/icon)|inc|jwplayer|player|playlist-cat-rss|static|thumbs|wp-content|wp-includes)\/)(.*)/$image,other,script,~third-party,xmlhttprequest,domain=~animeland.hu"#;

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -274,16 +274,26 @@ impl NetworkFilterOption {
     }
 }
 
+pub struct RegexEntry {
+  regex: CompiledRegex,
+  last_used: std::time::Instant,
+  usage_count: u64,
+}
+
 pub struct RegexManager {
-    map: HashMap<*const NetworkFilter, CompiledRegex, RandomState>,
-    compiled_regex_count: usize,
+    map: HashMap<*const NetworkFilter, RegexEntry, RandomState>,
+    compiled_regex_count: u64,
+    now: std::time::Instant,
+    last_cleanup: std::time::Instant,
 }
 
 impl Default for RegexManager {
     fn default() -> RegexManager {
         RegexManager {
-            map: HashMap::<*const NetworkFilter, CompiledRegex, RandomState>::default(),
+            map: HashMap::<*const NetworkFilter, RegexEntry, RandomState>::default(),
             compiled_regex_count: 0,
+            now: std::time::Instant::now(),
+            last_cleanup: std::time::Instant::now(),
         }
     }
 }
@@ -291,13 +301,16 @@ impl Default for RegexManager {
 impl RegexManager {
     pub fn matches(&mut self, filter: &NetworkFilter, pattern: &str) -> bool {
         if !filter.is_regex() && !filter.is_complete_regex() {
-            return true;
+              return true;
         }
         let key = filter as *const NetworkFilter;
         use std::collections::hash_map::Entry;
         match self.map.entry(key) {
-            Entry::Occupied(e) => {
-                return e.get().is_match(pattern);
+            Entry::Occupied(mut e) => {
+                let v = e.get_mut();
+                v.usage_count += 1;
+                v.last_used = self.now;
+                return v.regex.is_match(pattern);
             }
             Entry::Vacant(e) => {
                 let regex = compile_regex(
@@ -307,16 +320,34 @@ impl RegexManager {
                     filter.is_complete_regex(),
                 );
                 self.compiled_regex_count += 1;
-                return e.insert(regex).is_match(pattern);
-            }
+                let new_entry = RegexEntry{
+                    regex,
+                    last_used: self.now,
+                    usage_count: 1,
+                };
+                return e.insert(new_entry).regex.is_match(pattern);
+            },
         };
     }
 
-    pub fn get_active_regex_count(&self) -> usize {
-        self.map.len()
+    pub fn update_time(&mut self) {
+        self.now = std::time::Instant::now();
+        if self.now - self.last_cleanup > std::time::Duration::from_secs(30) {
+            self.last_cleanup = self.now;
+            self.cleanup();
+        }
     }
 
-    pub fn get_compiled_regex_count(&self) -> usize {
+    pub fn cleanup(&mut self) {
+        let now = self.now;
+        self.map.retain(|_, v| now - v.last_used < std::time::Duration::from_secs(180));
+    }
+
+    pub fn get_active_regex_count(&self) -> u64 {
+        self.map.len() as u64
+    }
+
+    pub fn get_compiled_regex_count(&self) -> u64 {
         self.compiled_regex_count
     }
 }

--- a/src/filters/regex_manager.rs
+++ b/src/filters/regex_manager.rs
@@ -1,0 +1,97 @@
+use std::collections::HashMap;
+
+use crate::filters::network::{compile_regex, CompiledRegex, NetworkFilter};
+
+pub struct RegexDebugEntry {
+    regex: String,
+    last_used: std::time::Instant,
+    usage_count: u64,
+}
+
+struct RegexEntry {
+    regex: CompiledRegex,
+    last_used: std::time::Instant,
+    usage_count: u64,
+}
+
+type RandomState = std::hash::BuildHasherDefault<seahash::SeaHasher>;
+
+pub struct RegexManager {
+    map: HashMap<*const NetworkFilter, RegexEntry, RandomState>,
+    compiled_regex_count: u64,
+    now: std::time::Instant,
+    last_cleanup: std::time::Instant,
+}
+
+impl Default for RegexManager {
+    fn default() -> RegexManager {
+        RegexManager {
+            map: Default::default(),
+            compiled_regex_count: 0,
+            now: std::time::Instant::now(),
+            last_cleanup: std::time::Instant::now(),
+        }
+    }
+}
+
+
+impl RegexManager {
+    pub fn matches(&mut self, filter: &NetworkFilter, pattern: &str) -> bool {
+        if !filter.is_regex() && !filter.is_complete_regex() {
+            return true;
+        }
+        let key = filter as *const NetworkFilter;
+        use std::collections::hash_map::Entry;
+        match self.map.entry(key) {
+            Entry::Occupied(mut e) => {
+                let v = e.get_mut();
+                v.usage_count += 1;
+                v.last_used = self.now;
+                return v.regex.is_match(pattern);
+            }
+            Entry::Vacant(e) => {
+                let regex = compile_regex(
+                    &filter.filter,
+                    filter.is_right_anchor(),
+                    filter.is_left_anchor(),
+                    filter.is_complete_regex(),
+                );
+                self.compiled_regex_count += 1;
+                let new_entry = RegexEntry {
+                    regex,
+                    last_used: self.now,
+                    usage_count: 1,
+                };
+                return e.insert(new_entry).regex.is_match(pattern);
+            }
+        };
+    }
+
+    pub fn update_time(&mut self) {
+        self.now = std::time::Instant::now();
+        if self.now - self.last_cleanup > std::time::Duration::from_secs(30) {
+            self.last_cleanup = self.now;
+            self.cleanup();
+        }
+    }
+
+    pub fn cleanup(&mut self) {
+        let now = self.now;
+        self.map.retain(|_, v| now - v.last_used < std::time::Duration::from_secs(180));
+    }
+
+    #[cfg(feature = "debug-info")]
+    pub fn get_debug_regex_data(&self) -> Vec<RegexDebugEntry> {
+        use itertools::Itertools;
+        self.map.values().map(
+            |e| RegexDebugEntry{regex: e.regex.to_string(),
+                                            last_used : e.last_used,
+                                            usage_count: e.usage_count})
+            .collect_vec()
+    }
+
+    pub fn get_compiled_regex_count(&self) -> u64 {
+        self.compiled_regex_count
+    }
+
+}

--- a/src/filters/regex_manager.rs
+++ b/src/filters/regex_manager.rs
@@ -130,7 +130,9 @@ impl RegexManager {
 #[cfg(feature = "debug-info")]
 mod tests {
     use super::*;
-    use crate::{filters::network::NetworkMatchable, request};
+    #[cfg(test)]
+    use crate::filters::network::NetworkMatchable;
+    use crate::request;
 
     fn make_filter(line: &str) -> NetworkFilter {
         NetworkFilter::parse(line, true, Default::default()).unwrap()

--- a/src/filters/regex_manager.rs
+++ b/src/filters/regex_manager.rs
@@ -1,9 +1,17 @@
 //! A manager that creates/stores all regular expressions used by filters.
 //! Rarely used entries could be discarded to save memory.
 //! Non thread safe, the access must be synchronized externally.
-use std::{collections::HashMap, time::Instant};
-
+use std::collections::HashMap;
 use crate::filters::network::{compile_regex, CompiledRegex, NetworkFilter};
+use std::time::Duration;
+#[cfg(test)]
+use mock_instant::{Instant, MockClock};
+
+#[cfg(not(test))]
+use std::time::Instant;
+
+const REGEX_MANAGER_CLEAN_UP_INTERVAL: Duration = Duration::from_secs(30);
+const REGEX_MANAGER_DISCARD_TIME: Duration = Duration::from_secs(180);
 
 pub struct RegexDebugEntry {
     regex: String,
@@ -60,7 +68,8 @@ impl RegexManager {
                 v.last_used = self.now;
                 if matches!(v.regex, CompiledRegex::None) {
                     // A discarded entry, recreate it:
-                    v.regex = make_regexp(filter)
+                    v.regex = make_regexp(filter);
+                    self.compiled_regex_count += 1;
                 }
                 return v.regex.is_match(pattern);
             }
@@ -78,7 +87,7 @@ impl RegexManager {
 
     pub fn update_time(&mut self) {
         self.now = Instant::now();
-        if self.now - self.last_cleanup > std::time::Duration::from_secs(30) {
+        if self.now - self.last_cleanup >= REGEX_MANAGER_CLEAN_UP_INTERVAL {
             self.last_cleanup = self.now;
             self.cleanup();
         }
@@ -87,14 +96,14 @@ impl RegexManager {
     pub fn cleanup(&mut self) {
         let now = self.now;
         for (_, v) in &mut self.map {
-            if now - v.last_used < std::time::Duration::from_secs(180) {
+            if now - v.last_used >= REGEX_MANAGER_DISCARD_TIME {
                 // Discard the regex to save memory.
                 v.regex = CompiledRegex::None;
             }
         }
     }
 
-    #[cfg(feature = "debug-info")]
+    #[cfg(any(feature = "debug-info", test))]
     pub fn get_debug_regex_data(&self) -> Vec<RegexDebugEntry> {
         use itertools::Itertools;
         self.map.values().map(
@@ -104,8 +113,80 @@ impl RegexManager {
             .collect_vec()
     }
 
+    #[cfg(any(feature = "debug-info", test))]
     pub fn get_compiled_regex_count(&self) -> u64 {
         self.compiled_regex_count
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{request, filters::network::NetworkMatchable};
+
+    fn make_filter(line: &str) -> NetworkFilter{
+        NetworkFilter::parse(line, true, Default::default()).unwrap()
+    }
+
+    fn make_request(url: &str) -> request::Request {
+        request::Request::from_url(url).unwrap()
+    }
+
+    fn get_active_regex_count(regex_manager: &RegexManager) -> i32 {
+        regex_manager.get_debug_regex_data().iter().fold(0,
+            |acc, x| if x.regex == CompiledRegex::None.to_string() {acc} else {acc + 1})
+    }
+
+    #[test]
+    fn simple_match() {
+        let mut regex_manager = RegexManager::default();
+        regex_manager.update_time();
+
+        let filter = make_filter("||geo*.hltv.org^");
+        assert!(filter.matches(
+            &make_request("https://geo2.hltv.org/"),
+            &mut regex_manager));
+        assert_eq!(get_active_regex_count(&regex_manager), 1);
+        assert_eq!(regex_manager.get_debug_regex_data().len(), 1);
+  }
+
+    #[test]
+    fn discard_and_recreate() {
+        let mut regex_manager = RegexManager::default();
+        regex_manager.update_time();
+
+        let filter = make_filter("||geo*.hltv.org^");
+        assert!(filter.matches(
+            &make_request("https://geo2.hltv.org/"),
+            &mut regex_manager));
+        assert_eq!(regex_manager.get_compiled_regex_count(), 1);
+        assert_eq!(get_active_regex_count(&regex_manager), 1);
+
+        MockClock::advance(REGEX_MANAGER_DISCARD_TIME - Duration::from_secs(1));
+        regex_manager.update_time();
+        // The entry shouldn't be discarded because was used during
+        // last REGEX_MANAGER_DISCARD_TIME.
+        assert_eq!(get_active_regex_count(&regex_manager), 1);
+
+        // The entry is entry is outdated, but should be discarded only
+        // in the next cleanup() call. The call was 2 sec ago and is throttled
+        // now.
+        MockClock::advance(REGEX_MANAGER_CLEAN_UP_INTERVAL - Duration::from_secs(1));
+        regex_manager.update_time();
+        assert_eq!(get_active_regex_count(&regex_manager), 1);
+
+        MockClock::advance(Duration::from_secs(2));
+        regex_manager.update_time();
+        // The entry is now outdated & cleanup() should be called => discard.
+        assert_eq!(get_active_regex_count(&regex_manager), 0);
+
+        // The entry is recreated, get_compiled_regex_count() increased +1.
+        assert!(filter.matches(
+            &make_request("https://geo2.hltv.org/"),
+            &mut regex_manager));
+        assert_eq!(regex_manager.get_compiled_regex_count(), 2);
+        assert_eq!(get_active_regex_count(&regex_manager), 1);
     }
 
 }

--- a/src/filters/regex_manager.rs
+++ b/src/filters/regex_manager.rs
@@ -127,7 +127,7 @@ impl RegexManager {
     }
 }
 
-#[cfg(feature = "debug-info")]
+#[cfg(all(test, feature = "debug-info"))]
 mod tests {
     use super::*;
     #[cfg(test)]
@@ -144,9 +144,8 @@ mod tests {
 
     fn get_active_regex_count(regex_manager: &RegexManager) -> i32 {
         regex_manager
-            .get_debug_regex_data()
-            .iter()
-            .fold(0, |acc, x| if x.regex.is_some() { acc + 1 } else { acc })
+            .get_debug_regex_data().iter().filter(|x| x.regex.is_some())
+            .count() as i32
     }
 
     #[test]

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -193,7 +193,7 @@ impl Optimization for UnionDomainGroup {
 #[cfg(test)]
 mod optimization_tests_pattern_group {
     use super::*;
-    use crate::filters::network::RegexManager;
+    use crate::filters::regex_manager::RegexManager;
     use crate::lists;
     use crate::request::Request;
     use regex::RegexSet;

--- a/tests/legacy_harness.rs
+++ b/tests/legacy_harness.rs
@@ -2,6 +2,7 @@ mod legacy_test_filters {
     use adblock::filters::network::NetworkFilter;
     use adblock::filters::network::NetworkMatchable;
     use adblock::filters::network::NetworkFilterMask;
+    use adblock::filters::network::RegexManager;
     use adblock::request::Request;
 
     fn test_filter<'a>(
@@ -37,7 +38,7 @@ mod legacy_test_filters {
 
         for to_block in blocked {
             assert!(
-                filter.matches(&Request::from_url(&to_block).unwrap()),
+                filter.matches(&Request::from_url(&to_block).unwrap(), &mut RegexManager::default()),
                 "Expected filter {} to match {}",
                 raw_filter,
                 &to_block
@@ -46,7 +47,7 @@ mod legacy_test_filters {
 
         for to_pass in not_blocked {
             assert!(
-                !filter.matches(&Request::from_url(&to_pass).unwrap()),
+                !filter.matches(&Request::from_url(&to_pass).unwrap(), &mut RegexManager::default()),
                 "Expected filter {} to pass {}",
                 raw_filter,
                 &to_pass
@@ -292,7 +293,7 @@ mod legacy_test_filters {
         // explicit, separate testcase construction of the "script" option as it is not the deafult
         let filter = NetworkFilter::parse("||googlesyndication.com/safeframe/$third-party,script", true, Default::default()).unwrap();
         let request = Request::from_urls("http://tpc.googlesyndication.com/safeframe/1-0-2/html/container.html#xpc=sf-gdn-exp-2&p=http%3A//slashdot.org;", "", "script").unwrap();
-        assert!(filter.matches(&request));
+        assert!(filter.matches(&request, &mut RegexManager::default()));
     }
 }
 

--- a/tests/legacy_harness.rs
+++ b/tests/legacy_harness.rs
@@ -2,7 +2,7 @@ mod legacy_test_filters {
     use adblock::filters::network::NetworkFilter;
     use adblock::filters::network::NetworkMatchable;
     use adblock::filters::network::NetworkFilterMask;
-    use adblock::filters::network::RegexManager;
+    use adblock::filters::regex_manager::RegexManager;
     use adblock::request::Request;
 
     fn test_filter<'a>(

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -1,4 +1,4 @@
-use adblock::filters::network::RegexManager;
+use adblock::filters::regex_manager::RegexManager;
 use adblock::request::Request;
 use adblock::filters::network::NetworkFilter;
 use adblock::filters::network::NetworkMatchable;

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -1,3 +1,4 @@
+use adblock::filters::network::RegexManager;
 use adblock::request::Request;
 use adblock::filters::network::NetworkFilter;
 use adblock::filters::network::NetworkMatchable;
@@ -69,7 +70,7 @@ fn check_filter_matching() {
             // The dataset has cases where URL is set to just "http://" or "https://", which we do not support
             if request_res.is_ok() {
                 let request = request_res.unwrap();
-                assert!(network_filter.matches(&request), "Expected {} to match {} at {}, typed {}", filter, req.url, req.sourceUrl, req.r#type);
+                assert!(network_filter.matches(&request, &mut RegexManager::default()), "Expected {} to match {} at {}, typed {}", filter, req.url, req.sourceUrl, req.r#type);
                 requests_checked += 1;
             }
         }
@@ -106,7 +107,7 @@ fn check_engine_matching() {
             } else {
                 assert!(result.matched, "Expected {} to match {} at {}, typed {}", filter, req.url, req.sourceUrl, req.r#type);
             }
-            
+
             if network_filter.is_redirect() {
                 assert!(result.redirect.is_some(), "Expected {} to trigger redirect rule {}", req.url, filter);
                 let resource = result.redirect.unwrap();


### PR DESCRIPTION
For https://github.com/brave/brave-browser/issues/26892

The idea is to use global regular expression storage instead of individual ones.
This allows to challenge the long-term regexp memory consumption problem in the next PRs.
A new `RegexManager` is in charge of matching/spawning/deleting regex instances. `NetworkFilter` is enforced to match using `RegexManager`.

Plans:
* track the last regex usage and drop the instance it after a few time;
* use less effective, but more memory-saving algorithms for some of the reg exps until it becomes a hot path;

Note:
* Using a standard hasher for u64 instead of AHasher results in 3% performance drop.. Not sure AHasher is the best option. I am open to other suggestions.
* Replacing a standard hasher in other places could also give a perf boost, worst trying.
* `get_debug_info()` method is supposed to be exposed to something like `brave://adblock-internals`.