### PR TITLE
Fix WASM builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
       - name: Cargo build 'adblock' package
         run: cargo build --all-features --all-targets
 
+      - name: Cargo build 'adblock' package (wasm32)
+        if: matrix.os == 'ubuntu-latest'
+        run: rustup target add wasm32-unknown-unknown && cargo build --target wasm32-unknown-unknown
+
       - name: Cargo build 'native' package
         run: |
           # Install npm packages

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -151,8 +151,12 @@ impl Blocker {
 
     #[cfg(feature = "unsync-regex-caching")]
     fn borrow_regex_manager(&self) -> std::cell::RefMut<RegexManager> {
+        #[allow(unused_mut)]
         let mut manager = self.regex_manager.borrow_mut();
+
+        #[cfg(not(target_arch = "wasm32"))]
         manager.update_time();
+
         manager
     }
 

--- a/src/regex_manager.rs
+++ b/src/regex_manager.rs
@@ -8,9 +8,21 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 #[cfg(test)]
+#[cfg(not(target_arch = "wasm32"))]
 use mock_instant::Instant;
 #[cfg(not(test))]
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Clone, Copy)]
+pub struct Instant;
+#[cfg(target_arch = "wasm32")]
+impl Instant {
+    pub fn now() -> Self {
+        Self
+    }
+}
 
 const DEFAULT_CLEAN_UP_INTERVAL: Duration = Duration::from_secs(30);
 const DEFAULT_DISCARD_UNUSED_TIME: Duration = Duration::from_secs(180);
@@ -109,6 +121,7 @@ impl RegexManager {
         };
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn update_time(&mut self) {
         self.now = Instant::now();
         if !self.discard_policy.cleanup_interval.is_zero()
@@ -119,6 +132,7 @@ impl RegexManager {
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn cleanup(&mut self) {
         let now = self.now;
         for v in self.map.values_mut() {


### PR DESCRIPTION
Disabling regex deletion on WASM targets for now, since `std::time` is not available. Also adding `wasm32-unknown-unknown` target to CI.