### PR TITLE
Add CI steps for `--no-default-features`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Cargo build 'adblock' package
         run: cargo build --all-features --all-targets
 
+      - name: Cargo build 'adblock' package (no default features)
+        run: cargo build --no-default-features --all-targets
+
       - name: Cargo build 'adblock' package (wasm32)
         if: matrix.os == 'ubuntu-latest'
         run: rustup target add wasm32-unknown-unknown && cargo build --target wasm32-unknown-unknown
@@ -64,6 +67,9 @@ jobs:
 
       - name: Cargo test 'adblock' package
         run: cargo test --all-features --tests --no-fail-fast
+
+      - name: Cargo test 'adblock' package (no default features)
+        run: cargo test --no-default-features --tests --no-fail-fast
 
       - name: Run Brave-specific tests
         # Only runs on one runner for a few reasons:


### PR DESCRIPTION
There is a regression where `lifeguard` dependency is being used even though `object-pooling` feature is not enabled. This was not caught by CI because CI builds and test only with `--all-features`.

```
[arni][/…/arni/src/adblock-rust][nodefaultfeatures-ci]% cargo test --no-default-features --tests --no-fail-fast
   Compiling adblock v0.7.2 (/Users/arni/src/adblock-rust)
error[E0433]: failed to resolve: use of undeclared crate or module `lifeguard`
   --> src/blocker.rs:380:25
    |
380 |         request_tokens: lifeguard::Recycled<Vec<u64>>,
    |                         ^^^^^^^^^ use of undeclared crate or module `lifeguard`

warning: unused import: `super::*`
   --> src/url_parser/mod.rs:134:9
    |
134 |     use super::*;
    |         ^^^^^^^^
    |
    = note: `#[warn(unused_imports)]` on by default

For more information about this error, try `rustc --explain E0433`.
error: could not compile `adblock` due to previous error
warning: build failed, waiting for other jobs to finish...
warning: `adblock` (lib test) generated 1 warning
error: could not compile `adblock` due to previous error; 1 warning emitted
```