### PR TITLE
Bump criterion to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,14 +152,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "clap"
-version = "2.34.0"
+name = "ciborium"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "bitflags",
+ "clap_lex",
+ "indexmap",
  "textwrap",
- "unicode-width",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -182,15 +225,16 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
 dependencies = [
+ "anes",
  "atty",
  "cast",
+ "ciborium",
  "clap",
  "criterion-plot",
- "csv",
  "itertools",
  "lazy_static",
  "num-traits",
@@ -199,7 +243,6 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -208,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
@@ -812,6 +855,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
 name = "paste"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1254,16 +1303,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,12 +1415,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "tinytemplate"
@@ -1524,12 +1560,6 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ selectors = { version = "0.23", optional = true }
 serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 csv = "1"
 mock_instant = { version = "0.2", features = ["sync"] }
 serde_json = "1.0"

--- a/benches/bench_cosmetic_matching.rs
+++ b/benches/bench_cosmetic_matching.rs
@@ -6,122 +6,126 @@ use adblock::lists::{parse_filters, FilterFormat};
 use adblock::utils::rules_from_lists;
 
 fn by_hostname(c: &mut Criterion) {
-    c.bench(
-        "cosmetic hostname match",
-        Benchmark::new("easylist", move |b| {
-            let rules =
-                rules_from_lists(&vec!["data/easylist.to/easylist/easylist.txt".to_owned()]);
-            let (_, cosmetic_filters) = parse_filters(&rules, false, FilterFormat::Standard);
-            let cfcache = CosmeticFilterCache::from_rules(cosmetic_filters);
-            b.iter(|| cfcache.hostname_cosmetic_resources("google.com"))
-        })
-        .with_function("many lists", move |b| {
-            let rules = rules_from_lists(&vec![
-                "data/easylist.to/easylist/easylist.txt".to_owned(),
-                "data/easylist.to/easylistgermany/easylistgermany.txt".to_owned(),
-                "data/uBlockOrigin/filters.txt".to_owned(),
-                "data/uBlockOrigin/unbreak.txt".to_owned(),
-            ]);
-            let (_, cosmetic_filters) = parse_filters(&rules, false, FilterFormat::Standard);
-            let cfcache = CosmeticFilterCache::from_rules(cosmetic_filters);
-            b.iter(|| cfcache.hostname_cosmetic_resources("google.com"))
-        })
-        .with_function("complex_hostname", move |b| {
-            let rules = rules_from_lists(&vec![
-                "data/easylist.to/easylist/easylist.txt".to_owned(),
-                "data/easylist.to/easylistgermany/easylistgermany.txt".to_owned(),
-                "data/uBlockOrigin/filters.txt".to_owned(),
-                "data/uBlockOrigin/unbreak.txt".to_owned(),
-            ]);
-            let (_, cosmetic_filters) = parse_filters(&rules, false, FilterFormat::Standard);
-            let cfcache = CosmeticFilterCache::from_rules(cosmetic_filters);
-            b.iter(|| cfcache.hostname_cosmetic_resources("ads.serve.1.domain.google.com"))
-        })
-        .throughput(Throughput::Elements(1))
-        .sample_size(20),
-    );
+    let mut group = c.benchmark_group("cosmetic-hostname-match");
+
+    group.throughput(Throughput::Elements(1));
+    group.sample_size(20);
+
+    group.bench_function("easylist", move |b| {
+        let rules =
+            rules_from_lists(&vec!["data/easylist.to/easylist/easylist.txt".to_owned()]);
+        let (_, cosmetic_filters) = parse_filters(&rules, false, FilterFormat::Standard);
+        let cfcache = CosmeticFilterCache::from_rules(cosmetic_filters);
+        b.iter(|| cfcache.hostname_cosmetic_resources("google.com"))
+    });
+    group.bench_function("many lists", move |b| {
+        let rules = rules_from_lists(&vec![
+            "data/easylist.to/easylist/easylist.txt".to_owned(),
+            "data/easylist.to/easylistgermany/easylistgermany.txt".to_owned(),
+            "data/uBlockOrigin/filters.txt".to_owned(),
+            "data/uBlockOrigin/unbreak.txt".to_owned(),
+        ]);
+        let (_, cosmetic_filters) = parse_filters(&rules, false, FilterFormat::Standard);
+        let cfcache = CosmeticFilterCache::from_rules(cosmetic_filters);
+        b.iter(|| cfcache.hostname_cosmetic_resources("google.com"))
+    });
+    group.bench_function("complex_hostname", move |b| {
+        let rules = rules_from_lists(&vec![
+            "data/easylist.to/easylist/easylist.txt".to_owned(),
+            "data/easylist.to/easylistgermany/easylistgermany.txt".to_owned(),
+            "data/uBlockOrigin/filters.txt".to_owned(),
+            "data/uBlockOrigin/unbreak.txt".to_owned(),
+        ]);
+        let (_, cosmetic_filters) = parse_filters(&rules, false, FilterFormat::Standard);
+        let cfcache = CosmeticFilterCache::from_rules(cosmetic_filters);
+        b.iter(|| cfcache.hostname_cosmetic_resources("ads.serve.1.domain.google.com"))
+    });
+
+    group.finish();
 }
 
 fn by_classes_ids(c: &mut Criterion) {
-    c.bench(
-        "cosmetic class, id match",
-        Benchmark::new("easylist", move |b| {
-            let rules =
-                rules_from_lists(&vec!["data/easylist.to/easylist/easylist.txt".to_owned()]);
-            let (_, cosmetic_filters) = parse_filters(&rules, false, FilterFormat::Standard);
-            let cfcache = CosmeticFilterCache::from_rules(cosmetic_filters);
-            let exceptions = Default::default();
-            b.iter(|| {
-                cfcache.hidden_class_id_selectors(
-                    &vec!["ad".to_owned()][..],
-                    &vec!["ad".to_owned()][..],
-                    &exceptions,
-                )
-            })
+    let mut group = c.benchmark_group("cosmetic-class-id-match");
+
+    group.throughput(Throughput::Elements(1));
+    group.sample_size(20);
+
+    group.bench_function("easylist", move |b| {
+        let rules =
+            rules_from_lists(&vec!["data/easylist.to/easylist/easylist.txt".to_owned()]);
+        let (_, cosmetic_filters) = parse_filters(&rules, false, FilterFormat::Standard);
+        let cfcache = CosmeticFilterCache::from_rules(cosmetic_filters);
+        let exceptions = Default::default();
+        b.iter(|| {
+            cfcache.hidden_class_id_selectors(
+                &vec!["ad".to_owned()][..],
+                &vec!["ad".to_owned()][..],
+                &exceptions,
+            )
         })
-        .with_function("many lists", move |b| {
-            let rules = rules_from_lists(&vec![
-                "data/easylist.to/easylist/easylist.txt".to_owned(),
-                "data/easylist.to/easylistgermany/easylistgermany.txt".to_owned(),
-                "data/uBlockOrigin/filters.txt".to_owned(),
-                "data/uBlockOrigin/unbreak.txt".to_owned(),
-            ]);
-            let (_, cosmetic_filters) = parse_filters(&rules, false, FilterFormat::Standard);
-            let cfcache = CosmeticFilterCache::from_rules(cosmetic_filters);
-            let exceptions = Default::default();
-            b.iter(|| {
-                cfcache.hidden_class_id_selectors(
-                    &vec!["ad".to_owned()][..],
-                    &vec!["ad".to_owned()][..],
-                    &exceptions,
-                )
-            })
+    });
+    group.bench_function("many lists", move |b| {
+        let rules = rules_from_lists(&vec![
+            "data/easylist.to/easylist/easylist.txt".to_owned(),
+            "data/easylist.to/easylistgermany/easylistgermany.txt".to_owned(),
+            "data/uBlockOrigin/filters.txt".to_owned(),
+            "data/uBlockOrigin/unbreak.txt".to_owned(),
+        ]);
+        let (_, cosmetic_filters) = parse_filters(&rules, false, FilterFormat::Standard);
+        let cfcache = CosmeticFilterCache::from_rules(cosmetic_filters);
+        let exceptions = Default::default();
+        b.iter(|| {
+            cfcache.hidden_class_id_selectors(
+                &vec!["ad".to_owned()][..],
+                &vec!["ad".to_owned()][..],
+                &exceptions,
+            )
         })
-        .with_function("many matching classes and ids", move |b| {
-            let rules = rules_from_lists(&vec![
-                "data/easylist.to/easylist/easylist.txt".to_owned(),
-                "data/easylist.to/easylistgermany/easylistgermany.txt".to_owned(),
-                "data/uBlockOrigin/filters.txt".to_owned(),
-                "data/uBlockOrigin/unbreak.txt".to_owned(),
-            ]);
-            let (_, cosmetic_filters) = parse_filters(&rules, false, FilterFormat::Standard);
-            let cfcache = CosmeticFilterCache::from_rules(cosmetic_filters);
-            let exceptions = Default::default();
-            let class_list = vec![
-                "block-bg-advertisement-region-1".to_owned(),
-                "photobox-adbox".to_owned(),
-                "headerad-720".to_owned(),
-                "rscontainer".to_owned(),
-                "rail-article-sponsored".to_owned(),
-                "fbPhotoSnowboxAds".to_owned(),
-                "sidebar_ad_module".to_owned(),
-                "ad-728x90_forum".to_owned(),
-                "commercial-unit-desktop-rhs".to_owned(),
-                "sponsored-editorial".to_owned(),
-                "rr-300x600-ad".to_owned(),
-                "adfoot".to_owned(),
-                "lads".to_owned(),
-            ];
-            let id_list = vec![
-                "footer-adspace".to_owned(),
-                "adsponsored_links_box".to_owned(),
-                "lsadvert-top".to_owned(),
-                "mn".to_owned(),
-                "col-right-ad".to_owned(),
-                "view_ads_bottom_bg_middle".to_owned(),
-                "ad_468x60".to_owned(),
-                "rightAdColumn".to_owned(),
-                "content".to_owned(),
-                "rhs_block".to_owned(),
-                "center_col".to_owned(),
-                "header".to_owned(),
-                "advertisingModule160x600".to_owned(),
-            ];
-            b.iter(|| cfcache.hidden_class_id_selectors(&class_list[..], &id_list[..], &exceptions))
-        })
-        .throughput(Throughput::Elements(1))
-        .sample_size(20),
-    );
+    });
+    group.bench_function("many matching classes and ids", move |b| {
+        let rules = rules_from_lists(&vec![
+            "data/easylist.to/easylist/easylist.txt".to_owned(),
+            "data/easylist.to/easylistgermany/easylistgermany.txt".to_owned(),
+            "data/uBlockOrigin/filters.txt".to_owned(),
+            "data/uBlockOrigin/unbreak.txt".to_owned(),
+        ]);
+        let (_, cosmetic_filters) = parse_filters(&rules, false, FilterFormat::Standard);
+        let cfcache = CosmeticFilterCache::from_rules(cosmetic_filters);
+        let exceptions = Default::default();
+        let class_list = vec![
+            "block-bg-advertisement-region-1".to_owned(),
+            "photobox-adbox".to_owned(),
+            "headerad-720".to_owned(),
+            "rscontainer".to_owned(),
+            "rail-article-sponsored".to_owned(),
+            "fbPhotoSnowboxAds".to_owned(),
+            "sidebar_ad_module".to_owned(),
+            "ad-728x90_forum".to_owned(),
+            "commercial-unit-desktop-rhs".to_owned(),
+            "sponsored-editorial".to_owned(),
+            "rr-300x600-ad".to_owned(),
+            "adfoot".to_owned(),
+            "lads".to_owned(),
+        ];
+        let id_list = vec![
+            "footer-adspace".to_owned(),
+            "adsponsored_links_box".to_owned(),
+            "lsadvert-top".to_owned(),
+            "mn".to_owned(),
+            "col-right-ad".to_owned(),
+            "view_ads_bottom_bg_middle".to_owned(),
+            "ad_468x60".to_owned(),
+            "rightAdColumn".to_owned(),
+            "content".to_owned(),
+            "rhs_block".to_owned(),
+            "center_col".to_owned(),
+            "header".to_owned(),
+            "advertisingModule160x600".to_owned(),
+        ];
+        b.iter(|| cfcache.hidden_class_id_selectors(&class_list[..], &id_list[..], &exceptions))
+    });
+
+    group.finish();
 }
 
 criterion_group!(cosmetic_benches, by_hostname, by_classes_ids,);


### PR DESCRIPTION
Update the criterion benchmarking utility to 0.4 to address audit warnings about the deprecated cbor crate.