### PR TITLE
Forbid content blocking rules with non-ASCII characters

### DIFF
--- a/src/content_blocking.rs
+++ b/src/content_blocking.rs
@@ -270,7 +270,7 @@ impl TryFrom<NetworkFilter> for CbRuleEquivalent {
 
     fn try_from(v: NetworkFilter) -> Result<Self, Self::Error> {
         static SPECIAL_CHARS: Lazy<Regex> =
-            Lazy::new(|| Regex::new(r##"([.+?^${}()|\[\]])"##).unwrap());
+            Lazy::new(|| Regex::new(r##"([.+?^${}()|\[\]\\])"##).unwrap());
         static REPLACE_WILDCARDS: Lazy<Regex> = Lazy::new(|| Regex::new(r##"\*"##).unwrap());
         static TRAILING_SEPARATOR: Lazy<Regex> = Lazy::new(|| Regex::new(r##"\^$"##).unwrap());
         if let Some(raw_line) = &v.raw_line {
@@ -1254,6 +1254,21 @@ mod ab2cb_tests {
         }]"####
             )
             .expect("content blocking rule under test could not be deserialized")
+        );
+    }
+
+    #[test]
+    fn escape_literal_backslashes() {
+        test_from_abp(
+            r#"||gamer.no/?module=Tumedia\DFProxy\Modules^"#,
+            r####"[{
+            "action": {
+                "type": "block"
+            },
+            "trigger": {
+                "url-filter": "^[^:]+:(//)?([^/]+\\.)?gamer\\.no/\\?module=tumedia\\\\dfproxy\\\\modules"
+            }
+        }]"####,
         );
     }
 }


### PR DESCRIPTION
It might be possible to correctly convert the failing examples here at some point, but in the meantime this safeguard is important to ensure that the rulesets can be loaded.

(closes #272)