### PR TITLE
Expose cosmetic filtering methods to JS bindings

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -22,7 +22,7 @@ class Engine {
         this.boxed = blocker.Engine_constructor(filter_set.boxed, ...args);
     }
 }
-forwardClassMethods(Engine, ['check', 'serializeRaw', 'serializeCompressed', 'deserialize', 'enableTag', 'useResources', 'tagExists', 'clearTags', 'addResource', 'getResource']);
+forwardClassMethods(Engine, ['check', 'urlCosmeticResources', 'hiddenClassIdSelectors', 'serializeRaw', 'serializeCompressed', 'deserialize', 'enableTag', 'useResources', 'tagExists', 'clearTags', 'addResource', 'getResource']);
 
 exports.FilterFormat = blocker.FilterFormat;
 exports.FilterSet = FilterSet;


### PR DESCRIPTION
Closes #290 (cc @eggplants)

I'd still like to experiment with making `exceptions` an opaque struct to avoid serialization/deserialization overhead, but this should otherwise be functional if you'd like to start testing it.

```js
const urlCosmeticResources = engine.urlCosmeticResources('https://youtube.com');
const hiddenClassIdSelectors = engine.hiddenClassIdSelectors(['ad'], [], urlCosmeticResources.exceptions);
```