### PR TITLE
Fix excessive memory usage for Rust 1.76

### DIFF
--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -800,6 +800,7 @@ impl NetworkFilterList {
             };
 
             optimized.append(&mut unoptimizable);
+            optimized.shrink_to_fit();
             optimized_map.insert(key, optimized);
         }
 


### PR DESCRIPTION
For cr121 we started to use 1.76 rust with a in-place iteration issue that results in excessive memory consumption.
`rustc 1.76.0-dev (df0295f07175acc7325ce3ca4152eb05752af1f2-3-llvmorg-18-init-12938-geb1d5065 chromium)`

This PR fixes the most critical code path that reduces the memory to about the original size.