### PR TITLE
Follow up for setup perf CI

### DIFF
--- a/.github/workflows/perf-ci.yml
+++ b/.github/workflows/perf-ci.yml
@@ -48,3 +48,5 @@ jobs:
           comment-on-alert: true
           fail-on-alert: true
           comment-always: true
+          # Upload results only for master
+          auto-push: ${{ github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
We need to explicitly set `auto-push:true` for `master`.
Checked on my personal fork, works well
Follow up for https://github.com/brave/adblock-rust/pull/417
