### PR TITLE
Using the replace_all function to replace arguments in JS template

### DIFF
--- a/src/resources/resource_storage.rs
+++ b/src/resources/resource_storage.rs
@@ -405,7 +405,7 @@ fn patch_template_scriptlet(
         .enumerate()
         .for_each(|(i, arg)| {
             template = TEMPLATE_ARGUMENT_RE[i]
-                .replace(&template, arg.as_ref().replace('$', "$$"))
+                .replace_all(&template, arg.as_ref().replace('$', "$$"))
                 .to_string();
         });
     template


### PR DESCRIPTION
I tried using a relatively new version of the scriptlets.js file from the uBlock repository. In the new version, the argument templates of some functions may have more than one placeholder. like the following code

```
/// set-constant.js
/// alias set.js
(function() {
    const chain = '{{1}}';
    if ( chain === '{{1}}' || chain === '' ) { return; }
    let cValue = '{{2}}';
    const trappedProp = (( ) => {
```

However, when I use adblock-rust, the code returned by the engine after the replacement template is as follows:

```
(function() {
    const chain = 'ytInitialPlayerResponse.adSlots';
    if ( chain === '{{1}}' || chain === '' ) { return; }
    let cValue = 'undefined';
    const trappedProp = (( ) => {
```

It can be seen that only the first `{{1}}` was replaced, but the second one was not. The reason is that the current version uses `replace` instead of `replace_all`, and this PR fixes the issue.