### PR TITLE
add brave-list-deserialize perf test

### DIFF
--- a/benches/bench_rules.rs
+++ b/benches/bench_rules.rs
@@ -2,6 +2,7 @@ use criterion::*;
 use once_cell::sync::Lazy;
 
 use adblock::blocker::{Blocker, BlockerOptions};
+use adblock::Engine;
 
 #[path = "../tests/test_utils.rs"]
 mod test_utils;
@@ -100,10 +101,19 @@ fn blocker_new(c: &mut Criterion) {
     ])
     .collect();
     let brave_list_rules: Vec<_> = rules_from_lists(&["data/brave/brave-main-list.txt"]).collect();
+    let engine = Engine::from_rules(&brave_list_rules, Default::default());
+    let engine_serialized = engine.serialize().unwrap();
 
     group.bench_function("el+ep", move |b| b.iter(|| get_blocker(&easylist_rules)));
     group.bench_function("brave-list", move |b| {
         b.iter(|| get_blocker(&brave_list_rules))
+    });
+    group.bench_function("brave-list-deserialize", move |b| {
+        b.iter(|| {
+            let mut engine = Engine::default();
+            engine.deserialize(&engine_serialized).unwrap();
+            engine
+        })
     });
 
     group.finish();


### PR DESCRIPTION
The PR adds a benchmark to measure loading from serialized data (the content of a .dat file)