### PR TITLE
Improve perf CI

### DIFF
--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Performance benchmarking script
+# Usage: ./scripts/run-benchmarks.sh
+
+set -e
+
+echo "Running network filter matching benchmark..."
+cargo bench --bench bench_matching rule-match-browserlike/brave-list -- --output-format bencher
+
+echo "Running first request matching delay benchmark..."
+cargo bench --bench bench_matching rule-match-first-request -- --output-format bencher
+
+echo "Running startup speed benchmark..."
+cargo bench --bench bench_rules blocker_new/brave-list -- --output-format bencher
+
+echo "Running memory usage benchmark..."
+cargo bench --bench bench_memory memory-usage -- --output-format bencher

--- a/.github/workflows/perf-ci.yml
+++ b/.github/workflows/perf-ci.yml
@@ -22,20 +22,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout PR
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Bench network filter matching
-        run: cargo bench --bench bench_matching rule-match-browserlike/brave-list -- --output-format bencher | tee -a output.txt
-
-      - name: Bench first request matching delay
-        run: cargo bench --bench bench_matching rule-match-first-request -- --output-format bencher | tee -a output.txt
-
-      - name: Bench startup speed
-        run: cargo bench --bench bench_rules blocker_new/brave-list -- --output-format bencher | tee -a output.txt
-
-      - name: Bench memory usage
-        run: cargo bench --bench bench_memory -- --output-format bencher | tee -a output.txt
+      - name: Run benchmarks
+        run: |
+          ./.github/scripts/run-benchmarks.sh | tee -a output.txt
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
@@ -44,7 +36,7 @@ jobs:
           tool: 'cargo'
           output-file-path: output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          alert-threshold: '130%' # fails on +30% regression
+          alert-threshold: '110%' # fails on +10% regression
           comment-on-alert: true
           fail-on-alert: true
           comment-always: true

--- a/benches/bench_matching.rs
+++ b/benches/bench_matching.rs
@@ -212,7 +212,7 @@ fn rule_match_browserlike_comparable(c: &mut Criterion) {
     let requests_len = requests.len() as u64;
 
     group.throughput(Throughput::Elements(requests_len));
-    group.sample_size(20);
+    group.sample_size(10);
 
     fn requests_parsed(requests: &[TestRequest]) -> Vec<(String, String, String, String, bool)> {
         requests


### PR DESCRIPTION
The PR:
* ~~Runs `cargo bench` for `master` to use it as a more reliable reference.~~ (need to merge `.github/scripts/run-benchmarks.sh first`)
* create a .sh file to launch the benchmarks 
* Set alert-threshold to 10%
* Limit the number of samples to 10 (speed up the CI)