### PR TITLE
Don't count file memory in benches

### DIFF
--- a/benches/bench_memory.rs
+++ b/benches/bench_memory.rs
@@ -149,9 +149,10 @@ fn bench_memory_usage(c: &mut Criterion) {
                 ALLOCATOR.reset();
                 let rules = rules_from_lists(&["data/brave/brave-main-list.txt"]);
                 let mut engine = Engine::from_rules(rules, Default::default());
-                let resource_json =
+                let mut resource_json =
                     std::fs::read_to_string("data/brave/brave-resources.json").unwrap();
-                let resource_list: Vec<Resource> = serde_json::from_str(&resource_json).unwrap();
+                let resource_list: Vec<Resource> =
+                    serde_json::from_str(&std::mem::take(&mut resource_json)).unwrap();
                 engine.use_resources(resource_list);
 
                 if run_requests {


### PR DESCRIPTION
It turns out that resources takes only 1.2MB, not 2MB. The incorrect numbers are originated from holding a file content too.