### PR TITLE
Update `selectors` crate to v0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "mock_instant",
  "once_cell",
  "percent-encoding",
+ "precomputed-hash",
  "regex",
  "reqwest",
  "rmp-serde",
@@ -339,14 +340,14 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.31.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b3df4f93e5fbbe73ec01ec8d3f68bba73107993a5b1e7519273c32db9b0d5be"
+checksum = "b7c66d1cd8ed61bf80b38432613a7a2f09401ab8d0501110655f8b341484a3e3"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.8.0",
+ "phf",
  "smallvec",
 ]
 
@@ -564,17 +565,6 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1142,82 +1132,52 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phf"
-version = "0.8.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared 0.8.0",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "phf"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
-dependencies = [
- "phf_shared 0.10.0",
+ "phf_shared",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.10.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.8.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared 0.8.0",
- "rand 0.7.3",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
-dependencies = [
- "phf_shared 0.10.0",
+ "phf_shared",
  "rand 0.8.5",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.8.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fde18ff429ffc8fe78e2bf7f8b7a5a5a6e2a8b58bc5a9ac69198bbda9189c"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator 0.8.0",
- "phf_shared 0.8.0",
- "proc-macro-hack",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
- "syn 1.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.8.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
@@ -1273,12 +1233,6 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -1376,26 +1330,10 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
- "rand_pcg",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -1405,28 +1343,8 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1441,21 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.11",
-]
 
 [[package]]
 name = "rand_core"
@@ -1464,24 +1370,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1705,9 +1593,9 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "selectors"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
+checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
 dependencies = [
  "bitflags",
  "cssparser",
@@ -1715,7 +1603,7 @@ dependencies = [
  "fxhash",
  "log",
  "new_debug_unreachable",
- "phf 0.10.1",
+ "phf",
  "phf_codegen",
  "precomputed-hash",
  "servo_arc",
@@ -1789,9 +1677,9 @@ dependencies = [
 
 [[package]]
 name = "servo_arc"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d036d71a959e00c77a63538b90a6c2390969f9772b096ea837205c6bd0491a44"
+checksum = "204ea332803bd95a0b60388590d59cf6468ec9becf626e2451f1d26a1d972de4"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -1817,9 +1705,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siphasher"
-version = "0.3.10"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -2149,12 +2037,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.10.1"
 dependencies = [
  "addr",
  "base64",
- "bitflags 2.9.0",
+ "bitflags",
  "criterion",
  "cssparser",
  "csv",
@@ -132,12 +132,6 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
@@ -254,12 +248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,29 +339,25 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.29.6"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93d03419cb5950ccfd3daf3ff1c7a36ace64609a1a8746d493df1ca0afde0fa"
+checksum = "5b3df4f93e5fbbe73ec01ec8d3f68bba73107993a5b1e7519273c32db9b0d5be"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "matches",
- "phf",
- "proc-macro2",
- "quote",
+ "phf 0.8.0",
  "smallvec",
- "syn 1.0.99",
 ]
 
 [[package]]
 name = "cssparser-macros"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfae75de57f2b2e85e8768c3ea840fd159c8f33e2b6522c7835b7abac81be16e"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 1.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -403,10 +387,8 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
- "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
  "syn 1.0.99",
 ]
 
@@ -457,7 +439,7 @@ version = "25.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1045398c1bfd89168b5fd3f1fc11f6e70b34f6f66300c87d44d3de849463abf1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "rustc_version",
 ]
 
@@ -1007,12 +989,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,10 +1077,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "nodrop"
-version = "0.1.14"
+name = "new_debug_unreachable"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "num-traits"
@@ -1171,18 +1147,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.8.0",
  "proc-macro-hack",
 ]
 
 [[package]]
-name = "phf_codegen"
-version = "0.8.0"
+name = "phf"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
 ]
 
 [[package]]
@@ -1191,8 +1176,18 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.8.0",
  "rand 0.7.3",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1201,8 +1196,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6fde18ff429ffc8fe78e2bf7f8b7a5a5a6e2a8b58bc5a9ac69198bbda9189c"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.8.0",
+ "phf_shared 0.8.0",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -1214,6 +1209,15 @@ name = "phf_shared"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
  "siphasher",
 ]
@@ -1386,6 +1390,17 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
@@ -1406,6 +1421,16 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
@@ -1421,6 +1446,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
  "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.11",
 ]
 
 [[package]]
@@ -1671,16 +1705,17 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "selectors"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
+checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "cssparser",
  "derive_more",
  "fxhash",
  "log",
- "phf",
+ "new_debug_unreachable",
+ "phf 0.10.1",
  "phf_codegen",
  "precomputed-hash",
  "servo_arc",
@@ -1754,11 +1789,10 @@ dependencies = [
 
 [[package]]
 name = "servo_arc"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52aa42f8fdf0fed91e5ce7f23d8138441002fa31dca008acf47e6fd4721f741"
+checksum = "d036d71a959e00c77a63538b90a6c2390969f9772b096ea837205c6bd0491a44"
 dependencies = [
- "nodrop",
  "stable_deref_trait",
 ]
 
@@ -1998,7 +2032,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -2346,7 +2380,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ seahash = "4.1.0"
 memchr = "2.4"
 base64 = "0.22"
 rmp-serde = "0.15"
-cssparser = { version = "0.29", optional = true }
-selectors = { version = "0.24", optional = true }
+cssparser = { version = "0.31", optional = true }
+selectors = { version = "0.25", optional = true }
 thiserror = "1.0"
 flatbuffers = { version = "25.2.10" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,9 @@ seahash = "4.1.0"
 memchr = "2.4"
 base64 = "0.22"
 rmp-serde = "0.15"
-cssparser = { version = "0.31", optional = true }
-selectors = { version = "0.25", optional = true }
+cssparser = { version = "0.34", optional = true }
+selectors = { version = "0.26", optional = true }
+precomputed-hash = "0.1"
 thiserror = "1.0"
 flatbuffers = { version = "25.2.10" }
 

--- a/src/filters/cosmetic.rs
+++ b/src/filters/cosmetic.rs
@@ -606,6 +606,7 @@ mod css_validation {
     use super::{CosmeticFilterError, CosmeticFilterOperator};
     use core::fmt::{Result as FmtResult, Write};
     use cssparser::{CowRcStr, ParseError, Parser, ParserInput, SourceLocation, ToCss, Token};
+    use precomputed_hash::PrecomputedHash;
     use selectors::parser::SelectorParseErrorKind;
 
     /// Returns a validated canonical CSS selector for the given input, or nothing if one can't be
@@ -680,7 +681,7 @@ mod css_validation {
         }
 
         if let Some(prelude) = prelude {
-            if !prelude.0.iter().any(has_procedural_operator) {
+            if !prelude.slice().iter().any(has_procedural_operator) {
                 // There are no procedural filters, so all selectors use standard CSS.
                 // It's ok to return that as a "single" selector.
                 return Ok(vec![CosmeticFilterOperator::CssSelector(
@@ -688,13 +689,13 @@ mod css_validation {
                 )]);
             }
 
-            if prelude.0.len() != 1 {
+            if prelude.slice().len() != 1 {
                 // Procedural filters don't work well with multiple selectors
                 return Err(CosmeticFilterError::ProceduralFilterWithMultipleSelectors);
             }
 
             // Safe; early return if length is not 1
-            let selector = prelude.0.into_iter().next().unwrap();
+            let selector = prelude.slice().iter().next().unwrap();
 
             /// Shim for items returned by `selectors::parser::SelectorIter`. Sequences and
             /// components iterate in opposite directions, but we want to process them in a
@@ -907,6 +908,7 @@ mod css_validation {
             &self,
             name: CowRcStr<'i>,
             arguments: &mut Parser<'i, 't>,
+            _after_part: bool,
         ) -> Result<
             <Self::Impl as selectors::parser::SelectorImpl>::NonTSPseudoClass,
             ParseError<'i, Self::Error>,
@@ -1006,13 +1008,22 @@ mod css_validation {
         type ExtraMatchingData<'a> = ();
         type AttrValue = CssString;
         type Identifier = CssIdent;
-        type LocalName = CssString;
+        type LocalName = CssIdent;
         type NamespaceUrl = DummyValue;
         type NamespacePrefix = DummyValue;
         type BorrowedNamespaceUrl = DummyValue;
-        type BorrowedLocalName = CssString;
+        type BorrowedLocalName = CssIdent;
         type NonTSPseudoClass = NonTSPseudoClass;
         type PseudoElement = PseudoElement;
+    }
+
+    /// Simple implementation of [PrecomputedHash] that just uses the default hasher for its
+    /// argument.
+    fn precomputed_hash_impl<H: std::hash::Hash>(this: &H) -> u32 {
+        use std::hash::{DefaultHasher, Hasher};
+        let mut hasher = DefaultHasher::new();
+        this.hash(&mut hasher);
+        hasher.finish() as u32
     }
 
     /// Serialized using `CssStringWriter`.
@@ -1021,13 +1032,24 @@ mod css_validation {
 
     impl ToCss for CssString {
         fn to_css<W: Write>(&self, dest: &mut W) -> core::fmt::Result {
-            cssparser::CssStringWriter::new(dest).write_str(&self.0)
+            dest.write_str("\"")?;
+            {
+                let mut dest = cssparser::CssStringWriter::new(dest);
+                dest.write_str(&self.0)?;
+            }
+            dest.write_str("\"")
         }
     }
 
     impl<'a> From<&'a str> for CssString {
         fn from(s: &'a str) -> Self {
             CssString(s.to_string())
+        }
+    }
+
+    impl PrecomputedHash for CssString {
+        fn precomputed_hash(&self) -> u32 {
+            precomputed_hash_impl(&self.0)
         }
     }
 
@@ -1047,6 +1069,12 @@ mod css_validation {
         }
     }
 
+    impl PrecomputedHash for CssIdent {
+        fn precomputed_hash(&self) -> u32 {
+            precomputed_hash_impl(&self.0)
+        }
+    }
+
     /// For performance, individual fields of parsed selectors are discarded. Instead, they are
     /// parsed into a `DummyValue` with no fields.
     #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -1061,6 +1089,12 @@ mod css_validation {
     impl<'a> From<&'a str> for DummyValue {
         fn from(s: &'a str) -> Self {
             DummyValue(s.to_string())
+        }
+    }
+
+    impl PrecomputedHash for DummyValue {
+        fn precomputed_hash(&self) -> u32 {
+            precomputed_hash_impl(&self.0)
         }
     }
 

--- a/src/filters/cosmetic.rs
+++ b/src/filters/cosmetic.rs
@@ -636,12 +636,10 @@ mod css_validation {
         let mock_stylesheet = format!("{}{{mock-stylesheet-marker}}", selector);
         let mut pi = ParserInput::new(&mock_stylesheet);
         let mut parser = Parser::new(&mut pi);
-        let mut rule_list_parser = cssparser::RuleListParser::new_for_stylesheet(
-            &mut parser,
-            QualifiedRuleParserImpl {
-                accept_abp_selectors,
-            },
-        );
+        let mut parser_impl = QualifiedRuleParserImpl {
+            accept_abp_selectors,
+        };
+        let mut rule_list_parser = cssparser::StyleSheetParser::new(&mut parser, &mut parser_impl);
 
         let prelude = rule_list_parser.next().and_then(|r| r.ok());
 
@@ -792,6 +790,7 @@ mod css_validation {
                     accept_abp_selectors: self.accept_abp_selectors,
                 },
                 input,
+                selectors::parser::ParseRelative::No,
             )
             .map_err(|_| ParseError {
                 kind: cssparser::ParseErrorKind::Custom(()),
@@ -1004,7 +1003,7 @@ mod css_validation {
     struct SelectorImpl;
 
     impl selectors::parser::SelectorImpl for SelectorImpl {
-        type ExtraMatchingData = ();
+        type ExtraMatchingData<'a> = ();
         type AttrValue = CssString;
         type Identifier = CssIdent;
         type LocalName = CssString;

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -219,7 +219,7 @@ mod tests {
         let data = engine.serialize().unwrap();
 
         let expected_hash = if cfg!(feature = "css-validation") {
-            7254547691107602751
+            6556399856993017327
         } else {
             4130628479730907288
         };

--- a/tests/unit/filters/cosmetic.rs
+++ b/tests/unit/filters/cosmetic.rs
@@ -635,6 +635,60 @@ mod parse_tests {
         );
     }
 
+    #[test]
+    fn escaped_selectors() {
+        check_parse_result(
+            r#"temp-mail.io##.fixed.bottom-0.\[\@media\(max-width\:1350px\)\]\:hidden"#,
+            CosmeticFilterBreakdown {
+                selector: SelectorType::PlainCss(
+                    r#".fixed.bottom-0.\[\@media\(max-width\:1350px\)\]\:hidden"#.to_string(),
+                ),
+                hostnames: Some(vec![2102614015710080174]),
+                ..Default::default()
+            },
+        );
+        check_parse_result(
+            r#"pinloker.com,sekilastekno.com###main:has(a[\@click="scroll"][target="_blank"]) .entry-content > figure, h3, h4, ol, p, ul"#,
+            CosmeticFilterBreakdown {
+                selector: SelectorType::PlainCss(r#"#main:has(a[\@click="scroll"][target="_blank"]) .entry-content > figure, h3, h4, ol, p, ul"#.to_string()),
+                hostnames: Some(vec![6774884157174391526, 8625775575346486664]),
+                ..Default::default()
+            }
+        );
+
+        // NOTE: the following `selector` fields are actually invalid selectors, and should keep
+        // the `\` escape characters from the original rules.
+        check_parse_result(
+            r#"pinloker.com,sekilastekno.com##.separator > a[\@click="scroll"][target="_blank"]"#,
+            CosmeticFilterBreakdown {
+                selector: SelectorType::PlainCss(
+                    r#".separator > a[@click="scroll"][target="_blank"]"#.to_string(),
+                ),
+                hostnames: Some(vec![6774884157174391526, 8625775575346486664]),
+                ..Default::default()
+            },
+        );
+        check_parse_result(
+            r#"senpai-stream.net##div[wire\:click="watching"]:style(display: flex !important;)"#,
+            CosmeticFilterBreakdown {
+                selector: SelectorType::PlainCss(r#"div[wire:click="watching"]"#.to_string()),
+                action: Some(CosmeticFilterAction::Style(
+                    "display: flex !important;".to_string(),
+                )),
+                hostnames: Some(vec![12306889736704683473]),
+                ..Default::default()
+            },
+        );
+        check_parse_result(
+            r#"presearch.com##div[\:class*="AdClass"]"#,
+            CosmeticFilterBreakdown {
+                selector: SelectorType::PlainCss(r#"div[:class*="AdClass"]"#.to_string()),
+                hostnames: Some(vec![15231640029204839219]),
+                ..Default::default()
+            },
+        );
+    }
+
     /// As of writing, these procedural filters with multiple comma-separated selectors aren't
     /// fully supported by uBO. Here, they are treated as parsing errors.
     #[test]

--- a/tests/unit/filters/cosmetic.rs
+++ b/tests/unit/filters/cosmetic.rs
@@ -655,14 +655,11 @@ mod parse_tests {
                 ..Default::default()
             }
         );
-
-        // NOTE: the following `selector` fields are actually invalid selectors, and should keep
-        // the `\` escape characters from the original rules.
         check_parse_result(
             r#"pinloker.com,sekilastekno.com##.separator > a[\@click="scroll"][target="_blank"]"#,
             CosmeticFilterBreakdown {
                 selector: SelectorType::PlainCss(
-                    r#".separator > a[@click="scroll"][target="_blank"]"#.to_string(),
+                    r#".separator > a[\@click="scroll"][target="_blank"]"#.to_string(),
                 ),
                 hostnames: Some(vec![6774884157174391526, 8625775575346486664]),
                 ..Default::default()
@@ -671,7 +668,7 @@ mod parse_tests {
         check_parse_result(
             r#"senpai-stream.net##div[wire\:click="watching"]:style(display: flex !important;)"#,
             CosmeticFilterBreakdown {
-                selector: SelectorType::PlainCss(r#"div[wire:click="watching"]"#.to_string()),
+                selector: SelectorType::PlainCss(r#"div[wire\:click="watching"]"#.to_string()),
                 action: Some(CosmeticFilterAction::Style(
                     "display: flex !important;".to_string(),
                 )),
@@ -682,7 +679,7 @@ mod parse_tests {
         check_parse_result(
             r#"presearch.com##div[\:class*="AdClass"]"#,
             CosmeticFilterBreakdown {
-                selector: SelectorType::PlainCss(r#"div[:class*="AdClass"]"#.to_string()),
+                selector: SelectorType::PlainCss(r#"div[\:class*="AdClass"]"#.to_string()),
                 hostnames: Some(vec![15231640029204839219]),
                 ..Default::default()
             },


### PR DESCRIPTION
The purpose of this update is to align the `selectors` version with what is currently used for other dependencies in Brave Browser, however this actually fixes a subtle issue relating to escaping special characters that occurs in 3 filter rules from our default lists. Tests added and updated to reflect the fix.