### PR TITLE
Pin rust toolchain to 1.90

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.90"
 components = ["clippy", "rustfmt" ]


### PR DESCRIPTION
Rust toolchain should be updated by a PR (in a combination with fixing new errors/linter issues)

Tested with 1.89 pinned on a custom branch:
<img width="929" height="581" alt="image" src="https://github.com/user-attachments/assets/a0cedfa9-0422-4f05-9e74-7fd119643f70" />
 