### PR TITLE
Add removeparam filters to the serialized data format

### DIFF
--- a/src/data_format/storage.rs
+++ b/src/data_format/storage.rs
@@ -243,6 +243,9 @@ pub(crate) struct SerializeFormat<'a> {
     procedural_action: &'a HashMap<Hash, Vec<String>>,
     #[serde(serialize_with = "stabilize_hashmap_serialization")]
     procedural_action_exception: &'a HashMap<Hash, Vec<String>>,
+
+    #[serde(serialize_with = "serialize_network_filter_list")]
+    removeparam: &'a NetworkFilterList,
 }
 
 impl SerializeFormat<'_> {
@@ -301,6 +304,9 @@ pub(crate) struct DeserializeFormat {
     procedural_action: HashMap<Hash, Vec<String>>,
     #[serde(default)]
     procedural_action_exception: HashMap<Hash, Vec<String>>,
+
+    #[serde(default)]
+    removeparam: NetworkFilterListDeserializeFmt,
 }
 
 impl DeserializeFormat {
@@ -341,6 +347,8 @@ impl<'a> From<(&'a Blocker, &'a CosmeticFilterCache)> for SerializeFormat<'a> {
 
             procedural_action: &cfc.specific_rules.procedural_action.0,
             procedural_action_exception: &cfc.specific_rules.procedural_action_exception.0,
+
+            removeparam: &blocker.removeparam,
         }
     }
 }
@@ -360,7 +368,7 @@ impl TryFrom<DeserializeFormat> for (Blocker, CosmeticFilterCache) {
                 exceptions: v.exceptions.try_into()?,
                 importants: v.importants.try_into()?,
                 redirects: v.redirects.try_into()?,
-                removeparam: NetworkFilterList::default(),
+                removeparam: v.removeparam.try_into()?,
                 filters: v.filters.try_into()?,
                 generic_hide: v.generic_hide.try_into()?,
 

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -183,7 +183,7 @@ mod tests {
     fn deserialization_generate_simple() {
         let mut engine = Engine::from_rules(["ad-banner"], Default::default());
         let data = engine.serialize().unwrap();
-        const EXPECTED_HASH: u64 = 5723845290597955159;
+        const EXPECTED_HASH: u64 = 9023363977439833140;
         assert_eq!(hash(&data), EXPECTED_HASH, "{}", HASH_MISMATCH_MSG);
         engine.deserialize(&data).unwrap();
     }
@@ -193,7 +193,7 @@ mod tests {
         let mut engine = Engine::from_rules(["ad-banner$tag=abc"], Default::default());
         engine.use_tags(&["abc"]);
         let data = engine.serialize().unwrap();
-        const EXPECTED_HASH: u64 = 9626816743810307798;
+        const EXPECTED_HASH: u64 = 17490165506820084756;
         assert_eq!(hash(&data), EXPECTED_HASH, "{}", HASH_MISMATCH_MSG);
         engine.deserialize(&data).unwrap();
     }
@@ -219,9 +219,9 @@ mod tests {
         let data = engine.serialize().unwrap();
 
         let expected_hash = if cfg!(feature = "css-validation") {
-            14270179196454678892
+            11154262451234023377
         } else {
-            8787095256768277705
+            48716029470216845
         };
 
         assert_eq!(hash(&data), expected_hash, "{}", HASH_MISMATCH_MSG);


### PR DESCRIPTION
closes #524 

(This is already fixed in the 0.11.x branch; this is just a fix for the 0.10.x series)