### PR TITLE
Enable cosmetic filters in some benches

### DIFF
--- a/benches/bench_matching.rs
+++ b/benches/bench_matching.rs
@@ -35,10 +35,11 @@ fn load_requests() -> Vec<TestRequest> {
 }
 
 fn get_engine(rules: impl IntoIterator<Item = impl AsRef<str>>) -> Engine {
-    let (network_filters, _) = adblock::lists::parse_filters(rules, false, Default::default());
+    let (network_filters, cosmetic_filters) =
+        adblock::lists::parse_filters(rules, false, Default::default());
 
     Engine::from_filter_set(
-        FilterSet::new_with_rules(network_filters, vec![], false),
+        FilterSet::new_with_rules(network_filters, cosmetic_filters, false),
         true,
     )
 }

--- a/benches/bench_rules.rs
+++ b/benches/bench_rules.rs
@@ -79,10 +79,11 @@ fn list_parse(c: &mut Criterion) {
 }
 
 fn get_engine(rules: impl IntoIterator<Item = impl AsRef<str>>) -> Engine {
-    let (network_filters, _) = adblock::lists::parse_filters(rules, false, Default::default());
+    let (network_filters, cosmetic_filters) =
+        adblock::lists::parse_filters(rules, false, Default::default());
 
     Engine::from_filter_set(
-        FilterSet::new_with_rules(network_filters, vec![], false),
+        FilterSet::new_with_rules(network_filters, cosmetic_filters, false),
         true,
     )
 }


### PR DESCRIPTION
For https://github.com/brave/brave-browser/issues/50463

For my machine this updates `bench_rules/blocker_new/brave-list` from `159.18 ms` to more realistic `186.04 ms`.
Although, for CI is only +9%