### PR TITLE
Speed up cosmetic filters matching

### DIFF
--- a/src/cosmetic_filter_cache.rs
+++ b/src/cosmetic_filter_cache.rs
@@ -19,6 +19,7 @@ use crate::flatbuffers::containers::flat_map::FlatMapView;
 use crate::flatbuffers::containers::flat_multimap::FlatMultiMapView;
 use crate::flatbuffers::containers::hash_map::HashMapStringView;
 use crate::flatbuffers::containers::hash_set::HashSetView;
+use crate::flatbuffers::unsafe_tools::fb_vector_to_slice;
 use crate::resources::{PermissionMask, ResourceStorage};
 
 use crate::utils::Hash;
@@ -246,15 +247,15 @@ impl CosmeticFilterCache {
 
         let cosmetic_filters = self.filter_data_context.memory.root().cosmetic_filters();
         let hostname_rules_view = FlatMapView::new(
-            cosmetic_filters.hostname_index(),
+            fb_vector_to_slice(cosmetic_filters.hostname_index()),
             cosmetic_filters.hostname_values(),
         );
         let hostname_hide_view = FlatMultiMapView::new(
-            cosmetic_filters.hostname_hide_index(),
+            fb_vector_to_slice(cosmetic_filters.hostname_hide_index()),
             cosmetic_filters.hostname_hide_values(),
         );
         let hostname_inject_script_view = FlatMultiMapView::new(
-            cosmetic_filters.hostname_inject_script_index(),
+            fb_vector_to_slice(cosmetic_filters.hostname_inject_script_index()),
             cosmetic_filters.hostname_inject_script_values(),
         );
 


### PR DESCRIPTION
For https://github.com/brave/brave-browser/issues/50463

The PRs speeds up matching of u64 flat maps by using `fb_vector_to_slice()`. This allows to use more optimal binary_search (a build it impl that bypasses some unneeded range checks).

```
url_cosmetic_resources/brave-list
                        time:   [189.73 µs 191.20 µs 193.89 µs]
                 change:
                        time:   [-18.766% -11.801% -4.9190%] (p = 0.00 < 0.05)
                        Performance has improved.
```