### PR TITLE
Vec::append() => Vec::extend()

### DIFF
--- a/js/src/lib.rs
+++ b/js/src/lib.rs
@@ -351,8 +351,8 @@ fn ublock_resources(mut cx: FunctionContext) -> JsResult<JsValue> {
     );
     if let Some(scriptlets_path) = scriptlets_path {
         #[allow(deprecated)]
-        resources.append(
-            &mut adblock::resources::resource_assembler::assemble_scriptlet_resources(&Path::new(
+        resources.extend(
+            adblock::resources::resource_assembler::assemble_scriptlet_resources(&Path::new(
                 &scriptlets_path,
             )),
         );

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -900,10 +900,10 @@ impl NetworkFilter {
                         (self.is_plain() || self.is_regex()) && !self.is_right_anchor();
                     let skip_first_token = self.is_right_anchor();
 
-                    let mut filter_tokens =
+                    let filter_tokens =
                         utils::tokenize_filter(f, skip_first_token, skip_last_token);
 
-                    tokens.append(&mut filter_tokens);
+                    tokens.extend(filter_tokens);
                 }
             }
             FilterPart::AnyOf(_) => (), // across AnyOf set of filters no single token is guaranteed to match to a request
@@ -913,16 +913,16 @@ impl NetworkFilter {
         // Append tokens from hostname, if any
         if !self.mask.contains(NetworkFilterMask::IS_HOSTNAME_REGEX) {
             if let Some(hostname) = self.hostname.as_ref() {
-                let mut hostname_tokens = utils::tokenize(hostname);
-                tokens.append(&mut hostname_tokens);
+                let hostname_tokens = utils::tokenize(hostname);
+                tokens.extend(hostname_tokens);
             }
         }
 
         if tokens.is_empty() && self.mask.contains(NetworkFilterMask::IS_REMOVEPARAM) {
             if let Some(removeparam) = &self.modifier_option {
                 if VALID_PARAM.is_match(removeparam) {
-                    let mut param_tokens = utils::tokenize(&removeparam.to_ascii_lowercase());
-                    tokens.append(&mut param_tokens);
+                    let param_tokens = utils::tokenize(&removeparam.to_ascii_lowercase());
+                    tokens.extend(param_tokens);
                 }
             }
         }

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -259,10 +259,10 @@ impl FilterSet {
         filters: impl IntoIterator<Item = impl AsRef<str>>,
         opts: ParseOptions,
     ) -> FilterListMetadata {
-        let (metadata, mut parsed_network_filters, mut parsed_cosmetic_filters) =
+        let (metadata, parsed_network_filters, parsed_cosmetic_filters) =
             parse_filters_with_metadata(filters, self.debug, opts);
-        self.network_filters.append(&mut parsed_network_filters);
-        self.cosmetic_filters.append(&mut parsed_cosmetic_filters);
+        self.network_filters.extend(parsed_network_filters);
+        self.cosmetic_filters.extend(parsed_cosmetic_filters);
         metadata
     }
 
@@ -337,7 +337,7 @@ impl FilterSet {
             }
         });
 
-        other_rules.append(&mut ignore_previous_rules);
+        other_rules.extend(ignore_previous_rules);
 
         if add_fp_document_exception {
             other_rules.push(content_blocking::ignore_previous_fp_documents());

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -24,16 +24,16 @@ pub fn optimize(filters: Vec<NetworkFilter>) -> Vec<NetworkFilter> {
 
     /*
     let union_domain_group = UnionDomainGroup {};
-    let (mut fused, unfused) = apply_optimisation(&union_domain_group, filters);
-    optimized.append(&mut fused);
+    let (fused, unfused) = apply_optimisation(&union_domain_group, filters);
+    optimized.extend(fused);
     */
 
     let simple_pattern_group = SimplePatternGroup {};
-    let (mut fused, mut unfused) = apply_optimisation(&simple_pattern_group, filters);
-    optimized.append(&mut fused);
+    let (fused, unfused) = apply_optimisation(&simple_pattern_group, filters);
+    optimized.extend(fused);
 
     // Append whatever is still left unfused
-    optimized.append(&mut unfused);
+    optimized.extend(unfused);
 
     // Re-sort the list, now that the order has been perturbed
     optimized.sort_by_key(|f| f.id);


### PR DESCRIPTION
For https://github.com/brave/brave-browser/issues/50463

The PR optimizes the peak memory usage by 5%.
`append()` doesn't drop the capacity of vec, it just calls `set_len(0)`