### PR TITLE
Build cosmetic filters first to optimize peak memory usage

### DIFF
--- a/src/data_format/mod.rs
+++ b/src/data_format/mod.rs
@@ -17,7 +17,7 @@ const ADBLOCK_RUST_DAT_MAGIC: [u8; 4] = [0xd1, 0xd9, 0x3a, 0xaf];
 
 /// The version of the data format.
 /// If the data format version is incremented, the data is considered as incompatible.
-const ADBLOCK_RUST_DAT_VERSION: u8 = 3;
+const ADBLOCK_RUST_DAT_VERSION: u8 = 4;
 
 /// The total length of the header prefix (magic + version + seahash)
 const HEADER_PREFIX_LENGTH: usize = 4 + 1 + 8;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -326,10 +326,10 @@ fn make_flatbuffer(
     optimize: bool,
 ) -> VerifiedFlatbufferMemory {
     let mut builder = EngineFlatBuilder::default();
-    let network_rules_builder = NetworkRulesBuilder::from_rules(network_filters, optimize);
-    let network_rules = FlatSerialize::serialize(network_rules_builder, &mut builder);
     let cosmetic_rules = CosmeticFilterCacheBuilder::from_rules(cosmetic_filters, &mut builder);
     let cosmetic_rules = FlatSerialize::serialize(cosmetic_rules, &mut builder);
+    let network_rules_builder = NetworkRulesBuilder::from_rules(network_filters, optimize);
+    let network_rules = FlatSerialize::serialize(network_rules_builder, &mut builder);
     builder.finish(network_rules, cosmetic_rules)
 }
 

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -183,7 +183,7 @@ mod tests {
     fn deserialization_generate_simple() {
         let mut engine = Engine::from_rules(["ad-banner"], Default::default());
         let data = engine.serialize().to_vec();
-        const EXPECTED_HASH: u64 = 10945714988765761881;
+        const EXPECTED_HASH: u64 = 17160288148100955881;
         assert_eq!(hash(&data), EXPECTED_HASH, "{HASH_MISMATCH_MSG}");
         engine.deserialize(&data).unwrap();
     }
@@ -193,7 +193,7 @@ mod tests {
         let mut engine = Engine::from_rules(["ad-banner$tag=abc"], Default::default());
         engine.use_tags(&["abc"]);
         let data = engine.serialize().to_vec();
-        const EXPECTED_HASH: u64 = 4608037684406751718;
+        const EXPECTED_HASH: u64 = 11923093095299951113;
         assert_eq!(hash(&data), EXPECTED_HASH, "{HASH_MISMATCH_MSG}");
         engine.deserialize(&data).unwrap();
     }
@@ -237,9 +237,9 @@ mod tests {
             );
         }
         let expected_hash: u64 = if cfg!(feature = "css-validation") {
-            9439492009815519037
+            5747051769866886432
         } else {
-            14803842039735157685
+            4816395107441601860
         };
 
         assert_eq!(hash(&data), expected_hash, "{HASH_MISMATCH_MSG}");


### PR DESCRIPTION
For https://github.com/brave/brave-browser/issues/50463