### PR TITLE
[perf] tokenize some regexp patterns

### DIFF
--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -311,6 +311,7 @@ pub enum FilterPart {
     AnyOf(Vec<String>),
 }
 
+#[derive(Debug, PartialEq)]
 pub enum FilterTokens {
     Empty,
     OptDomains(Vec<Hash>),
@@ -928,6 +929,12 @@ impl NetworkFilter {
         if !self.mask.contains(NetworkFilterMask::IS_HOSTNAME_REGEX) {
             if let Some(hostname) = self.hostname.as_ref() {
                 utils::tokenize_to(hostname, &mut tokens);
+            }
+        } else if let Some(hostname) = self.hostname.as_ref() {
+            // Find last dot to tokenize the prefix
+            let last_dot_pos = hostname.rfind('.');
+            if let Some(last_dot_pos) = last_dot_pos {
+                utils::tokenize_to(&hostname[..last_dot_pos], &mut tokens);
             }
         }
 

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -237,9 +237,9 @@ mod tests {
             );
         }
         let expected_hash: u64 = if cfg!(feature = "css-validation") {
-            9439492009815519037
+            15545091389304905433
         } else {
-            14803842039735157685
+            543362704487480180
         };
 
         assert_eq!(hash(&data), expected_hash, "{HASH_MISMATCH_MSG}");

--- a/tests/unit/filters/network.rs
+++ b/tests/unit/filters/network.rs
@@ -1186,4 +1186,17 @@ mod parse_tests {
         defaults.opt_domains = Some(vec![utils::fast_hash("auth.wi-fi.ru")]);
         assert_eq!(defaults, NetworkFilterBreakdown::from(&filter));
     }
+
+    #[test]
+    fn test_simple_pattern_tokenization() {
+        let rule = "||some.primewire.c*/sw$script,1p";
+        let filter = NetworkFilter::parse(rule, true, ParseOptions::default()).unwrap();
+        assert_eq!(
+            filter.get_tokens_optimized(),
+            FilterTokens::Other(vec![
+                utils::fast_hash("some"),
+                utils::fast_hash("primewire")
+            ])
+        );
+    }
 }


### PR DESCRIPTION
The PR tokenizes some common regex filters like `||dlscord.*$all` (with token `dlscord`). This reduces the number of filers that always checked (stored with token = `0`) that improves the filter matching performance.

`-13%` on my machine:
```
rule-match-browserlike/brave-list
master:  time:    [1.5573 s 1.5734 s 1.5927 s]
this PR:  time:   [1.3547 s 1.3618 s 1.3694 s]
```