### PR TITLE
Fix processing bad_filter in into_content_blocking

### DIFF
--- a/src/content_blocking.rs
+++ b/src/content_blocking.rs
@@ -316,9 +316,10 @@ impl TryFrom<NetworkFilter> for CbRuleEquivalent {
             if v.mask.contains(NetworkFilterMask::GENERIC_HIDE) {
                 return Err(CbRuleCreationFailure::NetworkGenerichideUnsupported);
             }
-            if v.mask.contains(NetworkFilterMask::BAD_FILTER) {
-                return Err(CbRuleCreationFailure::NetworkBadFilterUnsupported);
-            }
+            debug_assert!(
+                !v.mask.contains(NetworkFilterMask::BAD_FILTER),
+                "BAD_FILTER should be filtered out"
+            );
             if v.is_csp() {
                 return Err(CbRuleCreationFailure::NetworkCspUnsupported);
             }


### PR DESCRIPTION
The PR adds support of BAD_FILTER for iOS `into_content_blocking`. This is a step toward simplifying the building pipeline. In one of the next step `into_content_blocking` will be moved to `Engine` to use the flatbuffer representation were we process BAD_FILTER during serialization.