### PR TITLE
Fix no hostname case

### DIFF
--- a/src/filters/network_matchers.rs
+++ b/src/filters/network_matchers.rs
@@ -446,6 +446,9 @@ pub fn check_included_domains_mapped(
             }) {
                 return false;
             }
+        } else {
+            // If there are domain restrictions but no source hostname, we can't apply the rule
+            return false;
         }
     }
     true
@@ -485,6 +488,10 @@ pub fn check_excluded_domains_mapped(
             }) {
                 return false;
             }
+        } else {
+            // If there are domain restrictions but no source hostname
+            // (i.e. about:blank), apply the rule anyway.
+            return true;
         }
     }
 

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -199,5 +199,5 @@ fn check_rule_matching_browserlike() {
     let (blocked, passes) = bench_rule_matching_browserlike(&engine, &requests);
     let msg = "The number of blocked/passed requests has changed. ".to_string()
         + "If this is expected, update the expected values in the test.";
-    assert_eq!((blocked, passes), (101701, 141244), "{msg}");
+    assert_eq!((blocked, passes), (106860, 136085), "{msg}");
 }


### PR DESCRIPTION
The PR addresses matching issues that makes the behavior unstable: the result depends on the order we checked the tokens.