### PR TITLE
update flatbuffers to 25.9.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,9 +444,9 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "flatbuffers"
-version = "25.2.10"
+version = "25.9.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1045398c1bfd89168b5fd3f1fc11f6e70b34f6f66300c87d44d3de849463abf1"
+checksum = "09b6620799e7340ebd9968d2e0708eb82cf1971e9a16821e2091b6d6e475eed5"
 dependencies = [
  "bitflags",
  "rustc_version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ cssparser = { version = "0.34", optional = true }
 selectors = { version = "0.26", optional = true }
 precomputed-hash = "0.1"
 thiserror = "1.0"
-flatbuffers = { version = "25.2.10" }
+flatbuffers = { version = "25.9.23" }
 
 [dev-dependencies]
 criterion = "=0.5.1"

--- a/src/flatbuffers/fb_network_filter_generated.rs
+++ b/src/flatbuffers/fb_network_filter_generated.rs
@@ -29,7 +29,7 @@ pub mod fb {
         #[inline]
         unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
             Self {
-                _tab: flatbuffers::Table::new(buf, loc),
+                _tab: unsafe { flatbuffers::Table::new(buf, loc) },
             }
         }
     }
@@ -441,7 +441,7 @@ pub mod fb {
         #[inline]
         unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
             Self {
-                _tab: flatbuffers::Table::new(buf, loc),
+                _tab: unsafe { flatbuffers::Table::new(buf, loc) },
             }
         }
     }
@@ -672,7 +672,7 @@ pub mod fb {
         #[inline]
         unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
             Self {
-                _tab: flatbuffers::Table::new(buf, loc),
+                _tab: unsafe { flatbuffers::Table::new(buf, loc) },
             }
         }
     }
@@ -999,7 +999,7 @@ pub mod fb {
         #[inline]
         unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
             Self {
-                _tab: flatbuffers::Table::new(buf, loc),
+                _tab: unsafe { flatbuffers::Table::new(buf, loc) },
             }
         }
     }
@@ -1158,7 +1158,7 @@ pub mod fb {
         #[inline]
         unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
             Self {
-                _tab: flatbuffers::Table::new(buf, loc),
+                _tab: unsafe { flatbuffers::Table::new(buf, loc) },
             }
         }
     }
@@ -2065,7 +2065,7 @@ pub mod fb {
         #[inline]
         unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
             Self {
-                _tab: flatbuffers::Table::new(buf, loc),
+                _tab: unsafe { flatbuffers::Table::new(buf, loc) },
             }
         }
     }
@@ -2383,14 +2383,14 @@ pub mod fb {
     /// # Safety
     /// Callers must trust the given bytes do indeed contain a valid `Engine`.
     pub unsafe fn root_as_engine_unchecked(buf: &[u8]) -> Engine {
-        flatbuffers::root_unchecked::<Engine>(buf)
+        unsafe { flatbuffers::root_unchecked::<Engine>(buf) }
     }
     #[inline]
     /// Assumes, without verification, that a buffer of bytes contains a size prefixed Engine and returns it.
     /// # Safety
     /// Callers must trust the given bytes do indeed contain a valid size prefixed `Engine`.
     pub unsafe fn size_prefixed_root_as_engine_unchecked(buf: &[u8]) -> Engine {
-        flatbuffers::size_prefixed_root_unchecked::<Engine>(buf)
+        unsafe { flatbuffers::size_prefixed_root_unchecked::<Engine>(buf) }
     }
     #[inline]
     pub fn finish_engine_buffer<'a, 'b, A: flatbuffers::Allocator + 'a>(


### PR DESCRIPTION
Chromium already uses 25.9.23:
https://source.chromium.org/chromium/chromium/src/+/main:third_party/flatbuffers/src/rust/flatbuffers/Cargo.toml;l=3;bpv=1