### PR TITLE
update Rust to 1.92

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91"
+channel = "1.92"
 components = ["clippy", "rustfmt" ]


### PR DESCRIPTION
Rust 1.92 was released here:
https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/