### PR TITLE
Replace once_cell:: to std::sync::*

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,6 @@ dependencies = [
  "itertools 0.13.0",
  "memchr",
  "mock_instant",
- "once_cell",
  "percent-encoding",
  "precomputed-hash",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ exclude = [
 addr = { version = "0.15", default-features = false, features = ["psl"], optional = true }
 url = "2.5"
 percent-encoding = "2.1"
-once_cell = "1.8"
 regex = "1.12.2"
 bitflags = { version = "2.10.0", features = ["serde"] }
 itertools = "0.13"

--- a/benches/bench_rules.rs
+++ b/benches/bench_rules.rs
@@ -1,5 +1,5 @@
 use criterion::*;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 use adblock::{Engine, FilterSet};
 
@@ -7,8 +7,8 @@ use adblock::{Engine, FilterSet};
 mod test_utils;
 use test_utils::rules_from_lists;
 
-static DEFAULT_LISTS: Lazy<Vec<String>> =
-    Lazy::new(|| rules_from_lists(&["data/easylist.to/easylist/easylist.txt"]).collect());
+static DEFAULT_LISTS: LazyLock<Vec<String>> =
+    LazyLock::new(|| rules_from_lists(&["data/easylist.to/easylist/easylist.txt"]).collect());
 
 fn bench_string_hashing(filters: &Vec<String>) -> adblock::utils::Hash {
     let mut dummy: adblock::utils::Hash = 0;

--- a/src/content_blocking.rs
+++ b/src/content_blocking.rs
@@ -5,9 +5,9 @@ use crate::filters::network::{NetworkFilter, NetworkFilterMask, NetworkFilterMas
 use crate::lists::ParsedFilter;
 
 use memchr::{memchr as find_char, memmem};
-use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
 
 use std::collections::HashSet;
 use std::convert::{TryFrom, TryInto};
@@ -305,10 +305,12 @@ impl TryFrom<NetworkFilter> for CbRuleEquivalent {
     type Error = CbRuleCreationFailure;
 
     fn try_from(v: NetworkFilter) -> Result<Self, Self::Error> {
-        static SPECIAL_CHARS: Lazy<Regex> =
-            Lazy::new(|| Regex::new(r##"([.+?^${}()|\[\]\\])"##).unwrap());
-        static REPLACE_WILDCARDS: Lazy<Regex> = Lazy::new(|| Regex::new(r##"\*"##).unwrap());
-        static TRAILING_SEPARATOR: Lazy<Regex> = Lazy::new(|| Regex::new(r##"\^$"##).unwrap());
+        static SPECIAL_CHARS: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r##"([.+?^${}()|\[\]\\])"##).unwrap());
+        static REPLACE_WILDCARDS: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r##"\*"##).unwrap());
+        static TRAILING_SEPARATOR: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r##"\^$"##).unwrap());
         if let Some(raw_line) = &v.raw_line {
             if v.is_redirect() {
                 return Err(CbRuleCreationFailure::NetworkRedirectUnsupported);

--- a/src/cosmetic_filter_utils.rs
+++ b/src/cosmetic_filter_utils.rs
@@ -9,14 +9,15 @@ use memchr::memchr as find_char;
 /// This should only be called once `selector` has been verified to start with either a "#" or "."
 /// character.
 pub(crate) fn key_from_selector(selector: &str) -> Option<String> {
-    use once_cell::sync::Lazy;
     use regex::Regex;
+    use std::sync::LazyLock;
 
-    static RE_PLAIN_SELECTOR: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[#.][\w\\-]+").unwrap());
-    static RE_PLAIN_SELECTOR_ESCAPED: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"^[#.](?:\\[0-9A-Fa-f]+ |\\.|\w|-)+").unwrap());
-    static RE_ESCAPE_SEQUENCE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"\\([0-9A-Fa-f]+ |.)").unwrap());
+    static RE_PLAIN_SELECTOR: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^[#.][\w\\-]+").unwrap());
+    static RE_PLAIN_SELECTOR_ESCAPED: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^[#.](?:\\[0-9A-Fa-f]+ |\\.|\w|-)+").unwrap());
+    static RE_ESCAPE_SEQUENCE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\\([0-9A-Fa-f]+ |.)").unwrap());
 
     // If there are no escape characters in the selector, just take the first class or id token.
     let mat = RE_PLAIN_SELECTOR.find(selector);

--- a/src/filters/abstract_network.rs
+++ b/src/filters/abstract_network.rs
@@ -2,11 +2,11 @@ use memchr::memrchr as find_char_reverse;
 
 use super::network::NetworkFilterError;
 
-use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::LazyLock;
 
 /// For now, only support `$removeparam` with simple alphanumeric/dash/underscore patterns.
-static VALID_PARAM: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[a-zA-Z0-9_\-]+$").unwrap());
+static VALID_PARAM: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9_\-]+$").unwrap());
 
 #[derive(Clone, Copy)]
 pub(crate) enum NetworkFilterLeftAnchor {

--- a/src/filters/cosmetic.rs
+++ b/src/filters/cosmetic.rs
@@ -621,10 +621,10 @@ mod css_validation {
         selector: &str,
         accept_abp_selectors: bool,
     ) -> Result<Vec<CosmeticFilterOperator>, CosmeticFilterError> {
-        use once_cell::sync::Lazy;
         use regex::Regex;
-        static RE_SIMPLE_SELECTOR: Lazy<Regex> =
-            Lazy::new(|| Regex::new(r"^[#.]?[A-Za-z_][\w-]*$").unwrap());
+        use std::sync::LazyLock;
+        static RE_SIMPLE_SELECTOR: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^[#.]?[A-Za-z_][\w-]*$").unwrap());
 
         if RE_SIMPLE_SELECTOR.is_match(selector) {
             return Ok(vec![CosmeticFilterOperator::CssSelector(

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -2,9 +2,9 @@
 //! modification.
 
 use memchr::memchr as find_char;
-use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
 use thiserror::Error;
 
 use std::fmt;
@@ -18,7 +18,7 @@ use crate::request;
 use crate::utils::{self, Hash, TokensBuffer};
 
 /// For now, only support `$removeparam` with simple alphanumeric/dash/underscore patterns.
-static VALID_PARAM: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[a-zA-Z0-9_\-]+$").unwrap());
+static VALID_PARAM: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9_\-]+$").unwrap());
 
 #[non_exhaustive]
 #[derive(Debug, Error, PartialEq, Clone)]
@@ -641,7 +641,7 @@ impl NetworkFilter {
                 // and then the pattern.
                 // TODO - this could be made more efficient if we could match between two
                 // indices. Once again, we have to do more work than is really needed.
-                static SEPARATOR: Lazy<Regex> = Lazy::new(|| Regex::new("[/^*]").unwrap());
+                static SEPARATOR: LazyLock<Regex> = LazyLock::new(|| Regex::new("[/^*]").unwrap());
                 if let Some(first_separator) = SEPARATOR.find(pattern) {
                     let first_separator_start = first_separator.start();
                     // NOTE: `first_separator` shall never be -1 here since `IS_REGEX` is true.
@@ -825,8 +825,8 @@ impl NetworkFilter {
     /// emulate the behavior of hosts-style blocking.
     pub fn parse_hosts_style(hostname: &str, debug: bool) -> Result<Self, NetworkFilterError> {
         // Make sure the hostname doesn't contain any invalid characters
-        static INVALID_CHARS: Lazy<Regex> =
-            Lazy::new(|| Regex::new("[/^*!?$&(){}\\[\\]+=~`\\s|@,'\"><:;]").unwrap());
+        static INVALID_CHARS: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new("[/^*!?$&(){}\\[\\]+=~`\\s|@,'\"><:;]").unwrap());
         if INVALID_CHARS.is_match(hostname) {
             return Err(NetworkFilterError::FilterParseError);
         }

--- a/src/regex_manager.rs
+++ b/src/regex_manager.rs
@@ -8,6 +8,7 @@ use regex::{
     bytes::Regex as BytesRegex, bytes::RegexBuilder as BytesRegexBuilder,
     bytes::RegexSet as BytesRegexSet, bytes::RegexSetBuilder as BytesRegexSetBuilder, Regex,
 };
+use std::sync::LazyLock;
 
 use std::collections::HashMap;
 use std::fmt;
@@ -173,16 +174,15 @@ pub(crate) fn compile_regex<'a, I>(
 where
     I: Iterator<Item = &'a str> + ExactSizeIterator,
 {
-    use once_cell::sync::Lazy;
     // Escape special regex characters: |.$+?{}()[]\
-    static SPECIAL_RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"([\|\.\$\+\?\{\}\(\)\[\]])").unwrap());
+    static SPECIAL_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"([\|\.\$\+\?\{\}\(\)\[\]])").unwrap());
     // * can match anything
-    static WILDCARD_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\*").unwrap());
+    static WILDCARD_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\*").unwrap());
     // ^ can match any separator or the end of the pattern
-    static ANCHOR_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\^(.)").unwrap());
+    static ANCHOR_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\^(.)").unwrap());
     // ^ can match any separator or the end of the pattern
-    static ANCHOR_RE_EOL: Lazy<Regex> = Lazy::new(|| Regex::new(r"\^$").unwrap());
+    static ANCHOR_RE_EOL: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\^$").unwrap());
 
     let mut escaped_patterns = Vec::with_capacity(filters.len());
     for filter_str in filters {

--- a/src/resources/resource_assembler.rs
+++ b/src/resources/resource_assembler.rs
@@ -4,14 +4,15 @@
 use crate::resources::{MimeType, Resource, ResourceType};
 use base64::{engine::Engine as _, prelude::BASE64_STANDARD};
 use memchr::memmem;
-use once_cell::sync::Lazy;
 use regex::Regex;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
+use std::sync::LazyLock;
 
-static TOP_COMMENT_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r#"^/\*[\S\s]+?\n\*/\s*"#).unwrap());
-static NON_EMPTY_LINE_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r#"\S"#).unwrap());
+static TOP_COMMENT_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"^/\*[\S\s]+?\n\*/\s*"#).unwrap());
+static NON_EMPTY_LINE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"\S"#).unwrap());
 
 /// Represents a single entry of the `Map` from uBlock Origin's `redirect-resources.js`.
 struct ResourceProperties {
@@ -60,14 +61,14 @@ type JsResourceEntry = (String, JsResourceProperties);
 
 const REDIRECTABLE_RESOURCES_DECLARATION: &str = "export default new Map([";
 //  ]);
-static MAP_END_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r#"^\s*\]\s*\)"#).unwrap());
+static MAP_END_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"^\s*\]\s*\)"#).unwrap());
 
-static TRAILING_COMMA_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r#",([\],\}])"#).unwrap());
-static UNQUOTED_FIELD_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r#"([\{,])([a-zA-Z][a-zA-Z0-9_]*):"#).unwrap());
+static TRAILING_COMMA_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#",([\],\}])"#).unwrap());
+static UNQUOTED_FIELD_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"([\{,])([a-zA-Z][a-zA-Z0-9_]*):"#).unwrap());
 // Avoid matching a starting `/*` inside a string
-static TRAILING_BLOCK_COMMENT_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r#"\s*/\*[^'"]*\*/\s*$"#).unwrap());
+static TRAILING_BLOCK_COMMENT_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"\s*/\*[^'"]*\*/\s*$"#).unwrap());
 
 /// Reads data from a a file in the format of uBlock Origin's `redirect-resources.js` file to
 /// determine the files in the `web_accessible_resources` directory, as well as any of their

--- a/src/resources/resource_storage.rs
+++ b/src/resources/resource_storage.rs
@@ -3,8 +3,8 @@
 use std::collections::HashMap;
 
 use base64::{engine::Engine as _, prelude::BASE64_STANDARD};
-use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::LazyLock;
 use thiserror::Error;
 
 use super::{PermissionMask, Resource, ResourceType};
@@ -260,8 +260,8 @@ fn stringify_arg<const QUOTED: bool>(arg: &str) -> String {
 /// Gets the function name from a JS function definition
 fn extract_function_name(fn_def: &str) -> Option<&str> {
     // This is not bulletproof, but should be robust against most issues.
-    static FUNCTION_NAME_RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r#"^function\s+([^\(\)\{\}\s]+)\s*\("#).unwrap());
+    static FUNCTION_NAME_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#"^function\s+([^\(\)\{\}\s]+)\s*\("#).unwrap());
 
     FUNCTION_NAME_RE.captures(fn_def).map(|captures| {
         // capture 1 is always present in the above regex if any match was made
@@ -486,16 +486,16 @@ impl From<std::string::FromUtf8Error> for ScriptletResourceError {
     }
 }
 
-static TEMPLATE_ARGUMENT_RE: [Lazy<Regex>; 9] = [
-    Lazy::new(|| template_argument_regex(1)),
-    Lazy::new(|| template_argument_regex(2)),
-    Lazy::new(|| template_argument_regex(3)),
-    Lazy::new(|| template_argument_regex(4)),
-    Lazy::new(|| template_argument_regex(5)),
-    Lazy::new(|| template_argument_regex(6)),
-    Lazy::new(|| template_argument_regex(7)),
-    Lazy::new(|| template_argument_regex(8)),
-    Lazy::new(|| template_argument_regex(9)),
+static TEMPLATE_ARGUMENT_RE: [LazyLock<Regex>; 9] = [
+    LazyLock::new(|| template_argument_regex(1)),
+    LazyLock::new(|| template_argument_regex(2)),
+    LazyLock::new(|| template_argument_regex(3)),
+    LazyLock::new(|| template_argument_regex(4)),
+    LazyLock::new(|| template_argument_regex(5)),
+    LazyLock::new(|| template_argument_regex(6)),
+    LazyLock::new(|| template_argument_regex(7)),
+    LazyLock::new(|| template_argument_regex(8)),
+    LazyLock::new(|| template_argument_regex(9)),
 ];
 
 fn template_argument_regex(i: usize) -> Regex {

--- a/src/url_parser/mod.rs
+++ b/src/url_parser/mod.rs
@@ -5,8 +5,7 @@ mod parser;
 // mod parser_regex;
 
 #[cfg(not(feature = "embedded-domain-resolver"))]
-static DOMAIN_RESOLVER: once_cell::sync::OnceCell<Box<dyn ResolvesDomain>> =
-    once_cell::sync::OnceCell::new();
+static DOMAIN_RESOLVER: std::sync::OnceLock<Box<dyn ResolvesDomain>> = std::sync::OnceLock::new();
 
 /// Sets the library's domain resolver implementation.
 ///


### PR DESCRIPTION
The PR replaces usages of `once_cell` crate to the standard `std::sync::` primitives