### PR TITLE
Replace panics in parsing/resource assembly with typed errors

### DIFF
--- a/benches/bench_redirect_performance.rs
+++ b/benches/bench_redirect_performance.rs
@@ -99,12 +99,14 @@ fn get_resources_for_filters(#[allow(unused)] filters: &[NetworkFilter]) -> Vec<
         let mut resource_data = assemble_web_accessible_resources(
             Path::new("data/test/fake-uBO-files/web_accessible_resources"),
             Path::new("data/test/fake-uBO-files/redirect-resources.js"),
-        );
+        )
+        .expect("assemble redirect resources");
         #[allow(deprecated)]
         resource_data.append(
             &mut adblock::resources::resource_assembler::assemble_scriptlet_resources(Path::new(
                 "data/test/fake-uBO-files/scriptlets.js",
-            )),
+            ))
+            .expect("assemble scriptlets"),
         );
         resource_data
     }

--- a/src/filters/abstract_network.rs
+++ b/src/filters/abstract_network.rs
@@ -163,6 +163,7 @@ fn parse_filter_options(raw_options: &str) -> Result<Vec<NetworkFilterOption>, N
 
         // Check for options: option=value1|value2
         let mut option_and_values = maybe_negated_option.splitn(2, '=');
+        // SAFETY: splitn(2, _) always returns at least 1 element.
         let (option, value) = (
             option_and_values.next().unwrap(),
             option_and_values.next().unwrap_or_default(),

--- a/src/filters/network_matchers.rs
+++ b/src/filters/network_matchers.rs
@@ -201,7 +201,9 @@ where
                 false
             }
         })
-        .unwrap_or_else(|| unreachable!()) // no match if filter has no hostname - should be unreachable
+        // SAFETY: This function is only called from check_pattern() when
+        // mask.is_hostname_anchor() is true, which guarantees hostname is Some.
+        .unwrap_or_else(|| unreachable!())
 }
 
 // ||pattern|
@@ -236,7 +238,9 @@ where
                 false
             }
         })
-        .unwrap_or_else(|| unreachable!()) // no match if filter has no hostname - should be unreachable
+        // SAFETY: This function is only called from check_pattern() when
+        // mask.is_hostname_anchor() is true, which guarantees hostname is Some.
+        .unwrap_or_else(|| unreachable!())
 }
 
 // |||pattern|
@@ -276,7 +280,9 @@ where
                 false
             }
         })
-        .unwrap_or_else(|| unreachable!()) // no match if filter has no hostname - should be unreachable
+        // SAFETY: This function is only called from check_pattern() when
+        // mask.is_hostname_anchor() is true, which guarantees hostname is Some.
+        .unwrap_or_else(|| unreachable!())
 }
 
 // ||pattern + left-anchor => This means that a plain pattern needs to appear
@@ -313,7 +319,9 @@ where
                 false
             }
         })
-        .unwrap_or_else(|| unreachable!()) // no match if filter has no hostname - should be unreachable
+        // SAFETY: This function is only called from check_pattern() when
+        // mask.is_hostname_anchor() is true, which guarantees hostname is Some.
+        .unwrap_or_else(|| unreachable!())
 }
 
 // ||pattern
@@ -347,7 +355,9 @@ where
                 false
             }
         })
-        .unwrap_or_else(|| unreachable!()) // no match if filter has no hostname - should be unreachable
+        // SAFETY: This function is only called from check_pattern() when
+        // mask.is_hostname_anchor() is true, which guarantees hostname is Some.
+        .unwrap_or_else(|| unreachable!())
 }
 
 /// Efficiently checks if a certain network filter matches against a network

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -310,6 +310,7 @@ impl FilterSet {
             if bad_filter_ids.contains(&filter.get_id()) || filter.is_badfilter() {
                 return;
             }
+            // SAFETY: self.debug verified earlier; debug mode guarantees raw_line is Some.
             let original_rule = *filter
                 .raw_line
                 .clone()
@@ -331,6 +332,7 @@ impl FilterSet {
         let add_fp_document_exception = !filters_used.is_empty();
 
         self.cosmetic_filters.into_iter().for_each(|filter| {
+            // SAFETY: self.debug verified earlier; debug mode guarantees raw_line is Some.
             let original_rule = *filter
                 .raw_line
                 .clone()

--- a/src/resources/resource_storage.rs
+++ b/src/resources/resource_storage.rs
@@ -336,8 +336,8 @@ impl ResourceStorage {
         filter_permission: PermissionMask,
         required_deps: &mut Vec<ResourceImpl>,
     ) -> Result<String, ScriptletResourceError> {
-        // `unwrap` is safe because these are guaranteed valid at filter parsing.
-        let scriptlet_args = parse_scriptlet_args(scriptlet_args).unwrap();
+        let scriptlet_args = parse_scriptlet_args(scriptlet_args)
+            .ok_or(ScriptletResourceError::InvalidScriptletArgs)?;
 
         if scriptlet_args.is_empty() {
             return Err(ScriptletResourceError::MissingScriptletName);
@@ -472,6 +472,8 @@ pub enum ScriptletResourceError {
     ContentTypeNotInjectable,
     #[error("filter rule is not authorized to inject the intended scriptlet")]
     InsufficientPermissions,
+    #[error("scriptlet arguments were malformed")]
+    InvalidScriptletArgs,
 }
 
 impl From<base64::DecodeError> for ScriptletResourceError {

--- a/src/url_parser/parser.rs
+++ b/src/url_parser/parser.rs
@@ -186,15 +186,22 @@ simple_enum_error! {
     // HostParseError => "internal host parse error",
     RelativeUrlWithoutBase => "relative URL without a base",
     // RelativeUrlWithCannotBeABaseBase => "relative URL with a cannot-be-a-base base",
-    // SetHostOnCannotBeABaseUrl => "a cannot-be-a-base URL doesn’t have a host to set",
+    // SetHostOnCannotBeABaseUrl => "a cannot-be-a-base URL doesn't have a host to set",
     // Overflow => "URLs more than 4 GB are not supported",
     FileUrlNotSupported => "file URLs are not supported",
     ExpectedMoreChars => "Expected more characters",
+    FormattingError => "internal formatting error",
 }
 
 impl From<idna::Errors> for ParseError {
     fn from(_: idna::Errors) -> ParseError {
         ParseError::IdnaError
+    }
+}
+
+impl From<fmt::Error> for ParseError {
+    fn from(_: fmt::Error) -> ParseError {
+        ParseError::FormattingError
     }
 }
 
@@ -529,10 +536,10 @@ impl Parser {
         }
 
         if host_str.is_ascii() {
-            write!(&mut self.serialization, "{host_str}").unwrap();
+            write!(&mut self.serialization, "{host_str}")?;
         } else {
             let encoded = idna::domain_to_ascii(host_str)?;
-            write!(&mut self.serialization, "{encoded}").unwrap();
+            write!(&mut self.serialization, "{encoded}")?;
         }
 
         let host_end = self.serialization.len();

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -234,7 +234,8 @@ fn check_live_redirects() {
     let redirect_engine_path =
         std::path::Path::new("data/test/fake-uBO-files/redirect-resources.js");
     let war_dir = std::path::Path::new("data/test/fake-uBO-files/web_accessible_resources");
-    let resources = assemble_web_accessible_resources(war_dir, redirect_engine_path);
+    let resources = assemble_web_accessible_resources(war_dir, redirect_engine_path)
+        .expect("assemble resources");
 
     engine.use_resources(resources);
     {

--- a/tests/ublock-coverage.rs
+++ b/tests/ublock-coverage.rs
@@ -94,7 +94,8 @@ fn check_specific_rules() {
         let resources = adblock::resources::resource_assembler::assemble_web_accessible_resources(
             Path::new("data/test/fake-uBO-files/web_accessible_resources"),
             Path::new("data/test/fake-uBO-files/redirect-resources.js"),
-        );
+        )
+        .expect("assemble resources");
         engine.use_resources(resources);
 
         let request = Request::new(

--- a/tests/unit/resources/resource_assembler.rs
+++ b/tests/unit/resources/resource_assembler.rs
@@ -8,7 +8,8 @@ mod tests {
             Path::new("data/test/fake-uBO-files/web_accessible_resources");
         let redirect_resources_path = Path::new("data/test/fake-uBO-files/redirect-resources.js");
         let resources =
-            assemble_web_accessible_resources(web_accessible_resource_dir, redirect_resources_path);
+            assemble_web_accessible_resources(web_accessible_resource_dir, redirect_resources_path)
+                .expect("assemble resources");
 
         let expected_resource_names = vec![
             "1x1.gif",
@@ -108,7 +109,7 @@ mod tests {
     fn test_scriptlet_resource_assembly2() {
         let scriptlets_path = Path::new("data/test/fake-uBO-files/scriptlets2.js");
         #[allow(deprecated)]
-        let resources = assemble_scriptlet_resources(scriptlets_path);
+        let resources = assemble_scriptlet_resources(scriptlets_path).expect("assemble scriptlets");
 
         let expected_resource_names = vec![
             "abort-current-inline-script.js",
@@ -205,7 +206,7 @@ mod tests {
     fn test_scriptlet_resource_assembly() {
         let scriptlets_path = Path::new("data/test/fake-uBO-files/scriptlets.js");
         #[allow(deprecated)]
-        let resources = assemble_scriptlet_resources(scriptlets_path);
+        let resources = assemble_scriptlet_resources(scriptlets_path).expect("assemble scriptlets");
 
         let expected_resource_names = vec![
             "abort-current-inline-script.js",


### PR DESCRIPTION
Closes #432.

Replaced some panics in methods returning `Result` with a typed error for more descriptive error handling and added comments explaining unwrap/expect safety in others.