### PR TITLE
Enable css-validation feature by default to fix :has-text() selector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,8 +92,8 @@ harness = false
 
 [features]
 # If disabling default features, consider explicitly re-enabling the
-# "embedded-domain-resolver" feature.
-default = ["embedded-domain-resolver", "full-regex-handling", "single-thread"]
+# "embedded-domain-resolver" and "css-validation" features.
+default = ["embedded-domain-resolver", "full-regex-handling", "single-thread", "css-validation"]
 full-regex-handling = []
 single-thread = [] # disables `Send` and `Sync` on `Engine`.
 debug-info = []


### PR DESCRIPTION
The :has-text() selector and other procedural operators were not working because the css-validation feature was not enabled by default. Without this feature, all selectors are treated as plain CSS instead of being properly parsed to extract procedural operators.

This fix enables css-validation as a default feature, allowing :has-text() and other procedural selectors to work correctly.

Fixes #537