### PR TITLE
Fix attribute filters with quoted attribute names

### DIFF
--- a/src/filters/cosmetic.rs
+++ b/src/filters/cosmetic.rs
@@ -632,9 +632,16 @@ mod css_validation {
             )]);
         }
 
+        // Normalize ABP-style quoted attribute names to standard CSS
+        // Transform ["attribute-name"] to [attribute-name]
+        static RE_QUOTED_ATTR: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r#"\["([^"]+)"([*^$|~]?=)"#).unwrap()
+        });
+        let normalized_selector = RE_QUOTED_ATTR.replace_all(selector, "[$1$2");
+
         // Use `mock-stylesheet-marker` where uBO uses `color: red` since we have control over the
         // parsing logic within the block.
-        let mock_stylesheet = format!("{selector}{{mock-stylesheet-marker}}");
+        let mock_stylesheet = format!("{}{{mock-stylesheet-marker}}", normalized_selector);
         let mut pi = ParserInput::new(&mock_stylesheet);
         let mut parser = Parser::new(&mut pi);
         let mut parser_impl = QualifiedRuleParserImpl {


### PR DESCRIPTION
ABP-style attribute selectors use quoted attribute names like:
  div["data-apiary-widget-name"*="value"]

This is not valid CSS syntax. Standard CSS requires:
  div[data-apiary-widget-name*="value"]

The fix normalizes ABP syntax to standard CSS by removing quotes around attribute names before CSS validation. This allows filters from Adblock Plus to work correctly in adblock-rust.

Fixes #438