### PR TITLE
Fix scriptlet argument parsing for JavaScript expressions

### DIFF
--- a/src/data_format/mod.rs
+++ b/src/data_format/mod.rs
@@ -17,7 +17,7 @@ const ADBLOCK_RUST_DAT_MAGIC: [u8; 4] = [0xd1, 0xd9, 0x3a, 0xaf];
 
 /// The version of the data format.
 /// If the data format version is incremented, the data is considered as incompatible.
-const ADBLOCK_RUST_DAT_VERSION: u8 = 3;
+const ADBLOCK_RUST_DAT_VERSION: u8 = 4;
 
 /// The total length of the header prefix (magic + version + seahash)
 const HEADER_PREFIX_LENGTH: usize = 4 + 1 + 8;

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -183,7 +183,7 @@ mod tests {
     fn deserialization_generate_simple() {
         let mut engine = Engine::from_rules(["ad-banner"], Default::default());
         let data = engine.serialize().to_vec();
-        const EXPECTED_HASH: u64 = 10945714988765761881;
+        const EXPECTED_HASH: u64 = 4588487935723956783;
         assert_eq!(hash(&data), EXPECTED_HASH, "{HASH_MISMATCH_MSG}");
         engine.deserialize(&data).unwrap();
     }
@@ -193,7 +193,7 @@ mod tests {
         let mut engine = Engine::from_rules(["ad-banner$tag=abc"], Default::default());
         engine.use_tags(&["abc"]);
         let data = engine.serialize().to_vec();
-        const EXPECTED_HASH: u64 = 4608037684406751718;
+        const EXPECTED_HASH: u64 = 7781508779107365248;
         assert_eq!(hash(&data), EXPECTED_HASH, "{HASH_MISMATCH_MSG}");
         engine.deserialize(&data).unwrap();
     }
@@ -237,9 +237,9 @@ mod tests {
             );
         }
         let expected_hash: u64 = if cfg!(feature = "css-validation") {
-            7671576097086431151
+            2776615937181389450
         } else {
-            7220740598028920672
+            16106018527136154885
         };
 
         assert_eq!(hash(&data), expected_hash, "{HASH_MISMATCH_MSG}");


### PR DESCRIPTION
Fixes #398 - Allow scriptlet arguments containing JavaScript expressions that start with quoted strings but are not fully quoted. For example:
- "test"!==undefined
- "value"||something

The parser now falls back to comma-separated parsing when it detects an operator after a closing quote, treating the entire expression as a single unquoted argument. Malformed quoted arguments (like unmatched quotes or quotes followed by alphanumeric characters) are still properly rejected.

This change increments ADBLOCK_RUST_DAT_VERSION to 4 as it affects which filters are considered valid and thus changes serialization.