### PR TITLE
update Rust to 1.93

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.92"
+channel = "1.93"
 components = ["clippy", "rustfmt" ]


### PR DESCRIPTION
Rust 1.93 released:
https://blog.rust-lang.org/2026/01/22/Rust-1.93.0/