### PR TITLE
Change perf CI runner to ubuntu-latest-4-cores-public

### DIFF
--- a/.github/workflows/perf-ci.yml
+++ b/.github/workflows/perf-ci.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   benchmark:
     name: Performance benchmarking
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest-4-cores-public
 
     steps:
       - name: Checkout PR


### PR DESCRIPTION
This PR will move the benchmark jobs to a [runner group](https://docs.github.com/en/actions/how-tos/manage-runners/larger-runners/manage-larger-runners), in the assumption that dedicated Azure VMs might be less oversubscribed than the public runner pool.