### PR TITLE
deduplicate URL normalization for network rules

### DIFF
--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -753,20 +753,19 @@ impl NetworkFilter {
 
         let hostname_decoded = hostname
             .map(|host| {
-                let hostname_normalised = if mask.contains(NetworkFilterMask::IS_HOSTNAME_ANCHOR) {
-                    host.trim_start_matches("www.")
+                let hostname =
+                    idna::domain_to_ascii_cow(host.as_bytes(), idna::AsciiDenyList::EMPTY)
+                        .map_err(|_| NetworkFilterError::PunycodeError)?;
+                let hostname_normalized = if mask.contains(NetworkFilterMask::IS_HOSTNAME_ANCHOR) {
+                    if let Some(stripped) = hostname.strip_prefix("www.") {
+                        std::borrow::Cow::from(stripped)
+                    } else {
+                        hostname
+                    }
                 } else {
-                    &host
+                    hostname
                 };
-
-                let lowercase = hostname_normalised.to_lowercase();
-                let hostname = if lowercase.is_ascii() {
-                    lowercase
-                } else {
-                    idna::domain_to_ascii(&lowercase)
-                        .map_err(|_| NetworkFilterError::PunycodeError)?
-                };
-                Ok(hostname)
+                Ok(hostname_normalized.to_string())
             })
             .transpose();
 
@@ -839,22 +838,9 @@ impl NetworkFilter {
             return Err(NetworkFilterError::FilterParseError);
         }
 
-        // Normalize the hostname to punycode and parse it as a `||hostname^` rule.
-        let normalized_host = hostname.to_lowercase();
-        let normalized_host = normalized_host.trim_start_matches("www.");
-
-        let mut hostname = "||".to_string();
-        if normalized_host.is_ascii() {
-            hostname.push_str(normalized_host);
-        } else {
-            hostname.push_str(
-                &idna::domain_to_ascii(normalized_host)
-                    .map_err(|_| NetworkFilterError::PunycodeError)?,
-            );
-        }
-        hostname.push('^');
-
-        NetworkFilter::parse(&hostname, debug, Default::default())
+        // Parse it as a `||hostname^` rule.
+        let rule = format!("||{hostname}^");
+        NetworkFilter::parse(&rule, debug, Default::default())
     }
 
     pub fn get_id_without_badfilter(&self) -> Hash {

--- a/tests/unit/filters/network.rs
+++ b/tests/unit/filters/network.rs
@@ -986,7 +986,7 @@ mod parse_tests {
         {
             let filter = NetworkFilter::parse_hosts_style("www.example.com", true).unwrap();
             assert!(filter.raw_line.is_some());
-            assert_eq!(*filter.raw_line.clone().unwrap(), "||example.com^");
+            assert_eq!(*filter.raw_line.clone().unwrap(), "||www.example.com^");
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some("example.com".to_string());
             defaults.is_plain = true;
@@ -1006,6 +1006,66 @@ mod parse_tests {
             defaults.is_right_anchor = true;
             defaults.from_document = true;
             assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
+        }
+        // Uppercase hostname
+        {
+            let filter = NetworkFilter::parse_hosts_style("Example.COM", true).unwrap();
+            assert!(filter.raw_line.is_some());
+            assert_eq!(*filter.raw_line.clone().unwrap(), "||Example.COM^");
+            let mut defaults = default_network_filter_breakdown();
+            defaults.hostname = Some("example.com".to_string());
+            defaults.is_plain = true;
+            defaults.is_hostname_anchor = true;
+            defaults.is_right_anchor = true;
+            defaults.from_document = true;
+            assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
+        }
+        // Mixed-case with www prefix
+        {
+            let filter = NetworkFilter::parse_hosts_style("WWW.Example.COM", true).unwrap();
+            assert!(filter.raw_line.is_some());
+            assert_eq!(*filter.raw_line.clone().unwrap(), "||WWW.Example.COM^");
+            let mut defaults = default_network_filter_breakdown();
+            defaults.hostname = Some("example.com".to_string());
+            defaults.is_plain = true;
+            defaults.is_hostname_anchor = true;
+            defaults.is_right_anchor = true;
+            defaults.from_document = true;
+            assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
+        }
+        // Non-ASCII / punycode hostname
+        {
+            let filter = NetworkFilter::parse_hosts_style("münchen.de", true).unwrap();
+            assert!(filter.raw_line.is_some());
+            assert_eq!(*filter.raw_line.clone().unwrap(), "||münchen.de^");
+            let mut defaults = default_network_filter_breakdown();
+            defaults.hostname = Some("xn--mnchen-3ya.de".to_string());
+            defaults.is_plain = true;
+            defaults.is_hostname_anchor = true;
+            defaults.is_right_anchor = true;
+            defaults.from_document = true;
+            assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
+        }
+        // Non-ASCII with www prefix
+        {
+            let filter = NetworkFilter::parse_hosts_style("www.münchen.de", true).unwrap();
+            assert!(filter.raw_line.is_some());
+            assert_eq!(*filter.raw_line.clone().unwrap(), "||www.münchen.de^");
+            let mut defaults = default_network_filter_breakdown();
+            defaults.hostname = Some("xn--mnchen-3ya.de".to_string());
+            defaults.is_plain = true;
+            defaults.is_hostname_anchor = true;
+            defaults.is_right_anchor = true;
+            defaults.from_document = true;
+            assert_eq!(defaults, NetworkFilterBreakdown::from(&filter))
+        }
+        // Equivalence between parse_hosts_style and manually constructing the parse input
+        {
+            let hosts_filter = NetworkFilter::parse_hosts_style("Example.COM", true).unwrap();
+            let parse_filter =
+                NetworkFilter::parse("||example.com^", true, Default::default()).unwrap();
+            assert_eq!(hosts_filter.hostname, parse_filter.hostname);
+            assert_eq!(hosts_filter.mask, parse_filter.mask);
         }
     }
 


### PR DESCRIPTION
`www`-stripping, punycode, and lowercasing are all already done in `NetworkFilter::parse`, so there's no reason to have them in `parse_hosts_style` which delegates to `NetworkFilter::parse` internally.