### PR TITLE
chore: #617 migrate to domain_to_ascii_cow

### DIFF
--- a/src/content_blocking.rs
+++ b/src/content_blocking.rs
@@ -4,7 +4,6 @@ use crate::filters::cosmetic::CosmeticFilter;
 use crate::filters::network::{NetworkFilter, NetworkFilterMask, NetworkFilterMaskHelper};
 use crate::lists::ParsedFilter;
 
-use idna::AsciiDenyList;
 use memchr::{memchr as find_char, memmem};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -465,7 +464,7 @@ impl TryFrom<NetworkFilter> for CbRuleEquivalent {
                     } else {
                         // The network filter has already parsed successfully, so this should be
                         // safe
-                        idna::domain_to_ascii_cow(&lowercase.as_bytes(), AsciiDenyList::EMPTY)
+                        idna::domain_to_ascii_cow(&lowercase.as_bytes(), idna::AsciiDenyList::EMPTY)
                             .unwrap()
                             .to_string()
                     };
@@ -619,16 +618,18 @@ impl TryFrom<CosmeticFilter> for CbRule {
                         any_unsupported = true
                     }
                     LocationType::Hostname => {
-                        if let Ok(encoded) =
-                            idna::domain_to_ascii_cow(location.as_bytes(), AsciiDenyList::EMPTY)
-                        {
+                        if let Ok(encoded) = idna::domain_to_ascii_cow(
+                            location.as_bytes(),
+                            idna::AsciiDenyList::EMPTY,
+                        ) {
                             hostnames_vec.push(encoded.to_string());
                         }
                     }
                     LocationType::NotHostname => {
-                        if let Ok(encoded) =
-                            idna::domain_to_ascii_cow(location.as_bytes(), AsciiDenyList::EMPTY)
-                        {
+                        if let Ok(encoded) = idna::domain_to_ascii_cow(
+                            location.as_bytes(),
+                            idna::AsciiDenyList::EMPTY,
+                        ) {
                             not_hostnames_vec.push(encoded.to_string());
                         }
                     }

--- a/src/content_blocking.rs
+++ b/src/content_blocking.rs
@@ -4,6 +4,7 @@ use crate::filters::cosmetic::CosmeticFilter;
 use crate::filters::network::{NetworkFilter, NetworkFilterMask, NetworkFilterMaskHelper};
 use crate::lists::ParsedFilter;
 
+use idna::AsciiDenyList;
 use memchr::{memchr as find_char, memmem};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -464,7 +465,9 @@ impl TryFrom<NetworkFilter> for CbRuleEquivalent {
                     } else {
                         // The network filter has already parsed successfully, so this should be
                         // safe
-                        idna::domain_to_ascii(&lowercase).unwrap()
+                        idna::domain_to_ascii_cow(&lowercase.as_bytes(), AsciiDenyList::EMPTY)
+                            .unwrap()
+                            .to_string()
                     };
 
                     collection.push(format!("*{normalized_domain}"));
@@ -616,13 +619,17 @@ impl TryFrom<CosmeticFilter> for CbRule {
                         any_unsupported = true
                     }
                     LocationType::Hostname => {
-                        if let Ok(encoded) = idna::domain_to_ascii(location) {
-                            hostnames_vec.push(encoded);
+                        if let Ok(encoded) =
+                            idna::domain_to_ascii_cow(location.as_bytes(), AsciiDenyList::EMPTY)
+                        {
+                            hostnames_vec.push(encoded.to_string());
                         }
                     }
                     LocationType::NotHostname => {
-                        if let Ok(encoded) = idna::domain_to_ascii(location) {
-                            not_hostnames_vec.push(encoded);
+                        if let Ok(encoded) =
+                            idna::domain_to_ascii_cow(location.as_bytes(), AsciiDenyList::EMPTY)
+                        {
+                            not_hostnames_vec.push(encoded.to_string());
                         }
                     }
                 },

--- a/src/filters/cosmetic.rs
+++ b/src/filters/cosmetic.rs
@@ -1,7 +1,6 @@
 //! Filters that take effect at a page-content level, including CSS selector-based filtering and
 //! content script injection.
 
-use idna::AsciiDenyList;
 use memchr::{memchr as find_char, memmem, memrchr as find_char_reverse};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -229,7 +228,7 @@ impl CosmeticFilter {
             if location.is_ascii() {
                 hostname.push_str(location);
             } else {
-                match idna::domain_to_ascii_cow(location.as_bytes(), AsciiDenyList::EMPTY) {
+                match idna::domain_to_ascii_cow(location.as_bytes(), idna::AsciiDenyList::EMPTY) {
                     Ok(x) if !x.is_empty() => hostname.push_str(&x),
                     _ => return Err(CosmeticFilterError::PunycodeError),
                 }

--- a/src/filters/cosmetic.rs
+++ b/src/filters/cosmetic.rs
@@ -1,6 +1,7 @@
 //! Filters that take effect at a page-content level, including CSS selector-based filtering and
 //! content script injection.
 
+use idna::AsciiDenyList;
 use memchr::{memchr as find_char, memmem, memrchr as find_char_reverse};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -228,7 +229,7 @@ impl CosmeticFilter {
             if location.is_ascii() {
                 hostname.push_str(location);
             } else {
-                match idna::domain_to_ascii(location) {
+                match idna::domain_to_ascii_cow(location.as_bytes(), AsciiDenyList::EMPTY) {
                     Ok(x) if !x.is_empty() => hostname.push_str(&x),
                     _ => return Err(CosmeticFilterError::PunycodeError),
                 }

--- a/src/url_parser/parser.rs
+++ b/src/url_parser/parser.rs
@@ -9,7 +9,6 @@
 use std::error::Error;
 use std::fmt::{self, Formatter, Write};
 
-use idna::AsciiDenyList;
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use std::ops::{Range, RangeFrom, RangeTo};
 
@@ -532,7 +531,8 @@ impl Parser {
         if host_str.is_ascii() {
             write!(&mut self.serialization, "{host_str}").unwrap();
         } else {
-            let encoded = idna::domain_to_ascii_cow(host_str.as_bytes(), AsciiDenyList::EMPTY)?;
+            let encoded =
+                idna::domain_to_ascii_cow(host_str.as_bytes(), idna::AsciiDenyList::EMPTY)?;
             write!(&mut self.serialization, "{encoded}").unwrap();
         }
 

--- a/src/url_parser/parser.rs
+++ b/src/url_parser/parser.rs
@@ -9,6 +9,7 @@
 use std::error::Error;
 use std::fmt::{self, Formatter, Write};
 
+use idna::AsciiDenyList;
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use std::ops::{Range, RangeFrom, RangeTo};
 
@@ -531,7 +532,7 @@ impl Parser {
         if host_str.is_ascii() {
             write!(&mut self.serialization, "{host_str}").unwrap();
         } else {
-            let encoded = idna::domain_to_ascii(host_str)?;
+            let encoded = idna::domain_to_ascii_cow(host_str.as_bytes(), AsciiDenyList::EMPTY)?;
             write!(&mut self.serialization, "{encoded}").unwrap();
         }
 


### PR DESCRIPTION
Resolves #617 

Replaces `idna::domain_to_ascii` with `idna::domain_to_ascii_cow`, providing the empty deny list to preserve existing functionality.