### PR TITLE
forbid `url(` in cosmetic filter styles case-insensitively

### DIFF
--- a/src/filters/cosmetic.rs
+++ b/src/filters/cosmetic.rs
@@ -830,13 +830,22 @@ mod css_validation {
     }
 
     pub fn is_valid_css_style(style: &str) -> bool {
+        use regex::{Regex, RegexBuilder};
+        use std::sync::LazyLock;
+        static RE_URL_DIRECTIVE: LazyLock<Regex> = LazyLock::new(|| {
+            RegexBuilder::new(r"url\(")
+                .case_insensitive(true)
+                .build()
+                .unwrap()
+        });
+
         if style.contains('\\') {
             return false;
         }
-        if style.contains("url(") {
+        if style.contains("/*") {
             return false;
         }
-        if style.contains("/*") {
+        if RE_URL_DIRECTIVE.is_match(style) {
             return false;
         }
         true

--- a/tests/unit/filters/cosmetic.rs
+++ b/tests/unit/filters/cosmetic.rs
@@ -1251,4 +1251,16 @@ mod css_validation_tests {
             )])
         );
     }
+
+    #[test]
+    fn bad_style_inputs() {
+        assert!(is_valid_css_style(r#"background: red"#));
+        assert!(is_valid_css_style(r#"display: flex"#));
+        assert!(is_valid_css_style(r#"float: left; font-weight: bold"#));
+        assert!(!is_valid_css_style(r#"/* opening comment"#));
+        assert!(!is_valid_css_style(r#"\\75\\72\\6c\\28"#));
+        assert!(!is_valid_css_style(r#"background: url(https://evil.com)"#));
+        assert!(!is_valid_css_style(r#"background: UrL(https://evil.com)"#));
+        assert!(!is_valid_css_style(r#"URL(https://evil.com)"#));
+    }
 }


### PR DESCRIPTION
https://hackerone.com/reports/3711765

`example.com##h1:style(background: UrL(hxxps://tracker.com/pixel))` is valid CSS too