### PR TITLE
Use custom formatters for memory usage benchmarks

### DIFF
--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -15,7 +15,7 @@ echo "Running startup speed benchmark..."
 cargo bench --bench bench_rules blocker_new/brave-list -- --output-format bencher
 
 echo "Running memory usage benchmark..."
-cargo bench --bench bench_memory memory-usage -- --output-format bencher
+cargo bench --bench bench_memory memory-usage -- --output-format bencher --noplot
 
 echo "Running cosmetic matching benchmark..."
 cargo bench --bench bench_cosmetic_matching -- --output-format bencher

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,25 +348,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -365,12 +373,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -735,12 +743,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,21 +983,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1256,6 +1247,16 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ thiserror = "1.0"
 flatbuffers = { version = "25.12.19" }
 
 [dev-dependencies]
-criterion = "=0.5.1"
+criterion = "=0.8.2"
 csv = "=1.3.0"
 mock_instant = { version = "=0.5.1" }
 reqwest = "=0.13.3"

--- a/benches/bench_memory.rs
+++ b/benches/bench_memory.rs
@@ -6,7 +6,7 @@
 use criterion::*;
 use serde::{Deserialize, Serialize};
 use std::alloc::{GlobalAlloc, Layout, System};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use adblock::request::Request;
 use adblock::resources::Resource;
@@ -21,6 +21,7 @@ use test_utils::rules_from_lists;
 static ALLOCATOR: MemoryTracker = MemoryTracker::new();
 
 struct MemoryTracker {
+    frozen: AtomicBool,
     allocated: AtomicUsize,
     max_allocated: AtomicUsize,
     allocations_count: AtomicUsize,
@@ -30,6 +31,7 @@ struct MemoryTracker {
 impl MemoryTracker {
     const fn new() -> Self {
         Self {
+            frozen: AtomicBool::new(false),
             allocated: AtomicUsize::new(0),
             max_allocated: AtomicUsize::new(0),
             allocations_count: AtomicUsize::new(0),
@@ -49,7 +51,12 @@ impl MemoryTracker {
         self.allocations_count.load(Ordering::SeqCst)
     }
 
+    fn freeze(&self) {
+        self.frozen.store(true, Ordering::SeqCst);
+    }
+
     fn reset(&self) {
+        self.frozen.store(false, Ordering::SeqCst);
         self.allocated.store(0, Ordering::SeqCst);
         self.max_allocated.store(0, Ordering::SeqCst);
         self.allocations_count.store(0, Ordering::SeqCst);
@@ -74,7 +81,7 @@ impl MemoryTracker {
 unsafe impl GlobalAlloc for MemoryTracker {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let ret = self.internal.alloc(layout);
-        if !ret.is_null() {
+        if !ret.is_null() && !self.frozen.load(Ordering::SeqCst) {
             self.allocations_count.fetch_add(1, Ordering::SeqCst);
             self.allocated.fetch_add(layout.size(), Ordering::SeqCst);
             self.update_max_allocated(self.current_usage());
@@ -84,12 +91,14 @@ unsafe impl GlobalAlloc for MemoryTracker {
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         self.internal.dealloc(ptr, layout);
-        self.allocated.fetch_sub(layout.size(), Ordering::SeqCst);
+        if !self.frozen.load(Ordering::SeqCst) {
+            self.allocated.fetch_sub(layout.size(), Ordering::SeqCst);
+        }
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
         let ret = self.internal.realloc(ptr, layout, new_size);
-        if !ret.is_null() {
+        if !ret.is_null() && !self.frozen.load(Ordering::SeqCst) {
             self.allocations_count.fetch_add(1, Ordering::SeqCst);
             self.allocated.fetch_sub(layout.size(), Ordering::SeqCst);
             self.allocated.fetch_add(new_size, Ordering::SeqCst);
@@ -100,7 +109,7 @@ unsafe impl GlobalAlloc for MemoryTracker {
 
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
         let ret = self.internal.alloc_zeroed(layout);
-        if !ret.is_null() {
+        if !ret.is_null() && !self.frozen.load(Ordering::SeqCst) {
             self.allocations_count.fetch_add(1, Ordering::SeqCst);
             self.allocated.fetch_add(layout.size(), Ordering::SeqCst);
             self.update_max_allocated(self.current_usage());
@@ -133,66 +142,182 @@ fn load_requests() -> Vec<TestRequest> {
     reqs
 }
 
-fn bench_memory_usage(c: &mut Criterion) {
-    let mut group = c.benchmark_group("memory-usage");
-    group.sample_size(10);
-    group.measurement_time(std::time::Duration::from_secs(1));
+impl MemoryAllocated {
+    fn metric(&self) -> usize {
+        match self {
+            Self::Current => ALLOCATOR.current_usage(),
+            Self::Max => ALLOCATOR.max_usage(),
+            Self::AllocCount => ALLOCATOR.allocations_count(),
+        }
+    }
+}
 
-    let mut noise = 0;
+/// Measurement of allocated memory
+enum MemoryAllocated {
+    Current,
+    Max,
+    AllocCount,
+}
+impl criterion::measurement::Measurement for MemoryAllocated {
+    type Intermediate = usize;
+    type Value = usize;
+
+    fn start(&self) -> Self::Intermediate {
+        ALLOCATOR.reset();
+        0
+    }
+    fn end(&self, _i: Self::Intermediate) -> Self::Value {
+        self.metric()
+    }
+    fn add(&self, v1: &Self::Value, v2: &Self::Value) -> Self::Value {
+        *v1 + *v2
+    }
+    fn zero(&self) -> Self::Value {
+        0
+    }
+    fn to_f64(&self, val: &Self::Value) -> f64 {
+        *val as f64
+    }
+    fn formatter(&self) -> &dyn criterion::measurement::ValueFormatter {
+        match self {
+            Self::Current | Self::Max => &MemoryFormatter,
+            Self::AllocCount => &RawUnitsFormatter,
+        }
+    }
+}
+
+/// Just prints a number directly without units.
+struct RawUnitsFormatter;
+impl criterion::measurement::ValueFormatter for RawUnitsFormatter {
+    fn scale_values(&self, _typ: f64, _values: &mut [f64]) -> &'static str {
+        ""
+    }
+
+    fn scale_throughputs(&self, _typ: f64, _tp: &Throughput, _values: &mut [f64]) -> &'static str {
+        unimplemented!()
+    }
+
+    fn scale_for_machines(&self, _values: &mut [f64]) -> &'static str {
+        ""
+    }
+}
+
+/// Prints the number formatted as a quantity of bytes
+struct MemoryFormatter;
+impl criterion::measurement::ValueFormatter for MemoryFormatter {
+    fn scale_values(&self, bytes: f64, values: &mut [f64]) -> &'static str {
+        let (factor, unit) = if bytes < 1024f64.powi(1) {
+            (1024f64.powi(0), "B")
+        } else if bytes < 1024f64.powi(2) {
+            (1024f64.powi(-1), "KB")
+        } else if bytes < 1024f64.powi(3) {
+            (1024f64.powi(-2), "MB")
+        } else {
+            (1024f64.powi(-3), "GB")
+        };
+
+        for val in values {
+            *val *= factor;
+        }
+
+        unit
+    }
+    fn scale_throughputs(
+        &self,
+        _typical_value: f64,
+        _tp: &Throughput,
+        _values: &mut [f64],
+    ) -> &'static str {
+        unimplemented!()
+    }
+    fn scale_for_machines(&self, _values: &mut [f64]) -> &'static str {
+        // no scale needed
+        "B"
+    }
+}
+
+fn bench_cb(run_requests: &[&TestRequest], b: &mut Bencher<MemoryAllocated>) {
+    b.iter(|| {
+        ALLOCATOR.reset();
+        let rules = rules_from_lists(&["data/brave/brave-main-list.txt"]);
+        let mut engine = Engine::from_rules(rules, Default::default());
+        let resource_json = std::fs::read_to_string("data/brave/brave-resources.json").unwrap();
+        let resource_list: Vec<Resource> = serde_json::from_str(&resource_json).unwrap();
+        std::mem::drop(resource_json);
+        engine.use_resources(resource_list);
+
+        if run_requests.len() > 0 {
+            ALLOCATOR.reset(); // disregard previous allocations
+            for request in run_requests {
+                std::hint::black_box(engine.check_network_request(&((*request).into())));
+            }
+        }
+
+        // Prevent engine from being optimized
+        std::hint::black_box(&engine);
+
+        ALLOCATOR.freeze();
+    });
+}
+
+fn bench_current_memory_usage(c: &mut Criterion<MemoryAllocated>) {
     let all_requests = load_requests();
     let first_1000_requests: Vec<_> = all_requests.iter().take(1000).collect();
 
-    let mut cb = |metric: fn() -> usize, run_requests: bool, b: &mut Bencher| {
-        let mut result = 0;
-        b.iter_custom(|iters| {
-            for _ in 0..iters {
-                ALLOCATOR.reset();
-                let rules = rules_from_lists(&["data/brave/brave-main-list.txt"]);
-                let mut engine = Engine::from_rules(rules, Default::default());
-                let resource_json =
-                    std::fs::read_to_string("data/brave/brave-resources.json").unwrap();
-                let resource_list: Vec<Resource> = serde_json::from_str(&resource_json).unwrap();
-                std::mem::drop(resource_json);
-                engine.use_resources(resource_list);
-
-                if run_requests {
-                    ALLOCATOR.reset();
-                    for request in first_1000_requests.clone() {
-                        std::hint::black_box(engine.check_network_request(&request.into()));
-                    }
-                }
-
-                noise += 1; // add some noise to make criterion happy
-                result += metric() + noise;
-
-                // Prevent engine from being optimized
-                std::hint::black_box(&engine);
-            }
-
-            // Return the memory usage as a Duration
-            std::time::Duration::from_nanos(result as u64)
+    let mut group = c.benchmark_group("memory-usage-final");
+    group
+        .bench_function("brave-list-initial", |b| bench_cb(&[], b))
+        .bench_function("brave-list-1000-requests", |b| {
+            bench_cb(&first_1000_requests, b)
         });
-    };
-
-    group.bench_function("brave-list-initial", |b| {
-        cb(|| ALLOCATOR.current_usage(), false, b)
-    });
-    group.bench_function("brave-list-initial/max", |b| {
-        cb(|| ALLOCATOR.max_usage(), false, b)
-    });
-    group.bench_function("brave-list-initial/alloc-count", |b| {
-        cb(|| ALLOCATOR.allocations_count(), false, b)
-    });
-
-    group.bench_function("brave-list-1000-requests", |b| {
-        cb(|| ALLOCATOR.current_usage(), true, b)
-    });
-    group.bench_function("brave-list-1000-requests/alloc-count", |b| {
-        cb(|| ALLOCATOR.allocations_count(), true, b)
-    });
-
     group.finish();
 }
 
-criterion_group!(benches, bench_memory_usage);
-criterion_main!(benches);
+fn bench_max_memory_usage(c: &mut Criterion<MemoryAllocated>) {
+    let mut group = c.benchmark_group("memory-usage-max");
+    group.bench_function("brave-list-initial/max", |b| bench_cb(&[], b));
+    group.finish();
+}
+
+fn bench_allocation_count(c: &mut Criterion<MemoryAllocated>) {
+    let all_requests = load_requests();
+    let first_1000_requests: Vec<_> = all_requests.iter().take(1000).collect();
+
+    let mut group = c.benchmark_group("memory-usage-alloc-count");
+    group
+        .bench_function("brave-list-initial/alloc-count", |b| bench_cb(&[], b))
+        .bench_function("brave-list-1000-requests/alloc-count", |b| {
+            bench_cb(&first_1000_requests, b)
+        });
+    group.finish();
+}
+
+fn current_memory_usage_config() -> Criterion<MemoryAllocated> {
+    Criterion::default()
+        .sample_size(10)
+        .measurement_time(std::time::Duration::from_secs(1))
+        .with_measurement(MemoryAllocated::Current)
+}
+
+fn max_memory_usage_config() -> Criterion<MemoryAllocated> {
+    Criterion::default()
+        .sample_size(10)
+        .measurement_time(std::time::Duration::from_secs(1))
+        .with_measurement(MemoryAllocated::Max)
+}
+
+fn allocations_count_config() -> Criterion<MemoryAllocated> {
+    Criterion::default()
+        .sample_size(10)
+        .measurement_time(std::time::Duration::from_secs(1))
+        .with_measurement(MemoryAllocated::AllocCount)
+}
+
+criterion_group!(name = current_memory_usage_benches; config = current_memory_usage_config(); targets = bench_current_memory_usage);
+criterion_group!(name = max_memory_usage_benches; config = max_memory_usage_config(); targets = bench_max_memory_usage);
+criterion_group!(name = allocation_count_benches; config = allocations_count_config(); targets = bench_allocation_count);
+criterion_main!(
+    current_memory_usage_benches,
+    max_memory_usage_benches,
+    allocation_count_benches
+);

--- a/benches/bench_memory.rs
+++ b/benches/bench_memory.rs
@@ -158,7 +158,7 @@ fn bench_memory_usage(c: &mut Criterion) {
                 if run_requests {
                     ALLOCATOR.reset();
                     for request in first_1000_requests.clone() {
-                        criterion::black_box(engine.check_network_request(&request.into()));
+                        std::hint::black_box(engine.check_network_request(&request.into()));
                     }
                 }
 
@@ -166,7 +166,7 @@ fn bench_memory_usage(c: &mut Criterion) {
                 result += metric() + noise;
 
                 // Prevent engine from being optimized
-                criterion::black_box(&engine);
+                std::hint::black_box(&engine);
             }
 
             // Return the memory usage as a Duration

--- a/benches/bench_regex.rs
+++ b/benches/bench_regex.rs
@@ -17,7 +17,7 @@ fn bench_simple_regexes(c: &mut Criterion) {
     group.bench_function("list", move |b| {
         b.iter(|| {
             for rule in rules.iter() {
-                criterion::black_box(rule.is_match(pattern));
+                std::hint::black_box(rule.is_match(pattern));
             }
         })
     });


### PR DESCRIPTION
`cargo bench memory-usage -- --noplot`

```
memory-usage-final/brave-list-initial
                        time:   [10.140 MB 10.140 MB 10.140 MB]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

memory-usage-final/brave-list-1000-requests
                        time:   [2.2093 MB 2.2093 MB 2.2093 MB]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

memory-usage-max/brave-list-initial/max
                        time:   [59.081 MB 59.081 MB 59.081 MB]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

memory-usage-alloc-count/brave-list-initial/alloc-count
                        time:   [969555  969555  969555 ]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.

memory-usage-alloc-count/brave-list-1000-requests/alloc-count
                        time:   [ 69980   69980   69980 ]
                        change: [+0.0000% +0.0000% +0.0000%] (p = NaN > 0.05)
                        No change in performance detected.
```