### PR TITLE
[perf] Set mask default to optimize memory usage (0.13.x)

### DIFF
--- a/src/flatbuffers/fb_network_filter.fbs
+++ b/src/flatbuffers/fb_network_filter.fbs
@@ -7,7 +7,10 @@
 namespace fb;
 
 table NetworkFilter {
-  mask: uint32;  // NetworkFilterMask (network.rs)
+  // NetworkFilterMask (network.rs).
+  // Default = DEFAULT_OPTIONS | IS_HOSTNAME_ANCHOR | IS_RIGHT_ANCHOR | FROM_DOCUMENT
+  // (the most common mask, covering ~50% of filters).
+  mask: uint32 = 540221439;  // 0x20331FFF
 
   /// These arrays contain sorted (ascending) indices in the |unique_domains_hashes|
   /// instead of the hashes themselves. This approach saves memory, as there

--- a/src/flatbuffers/fb_network_filter_generated.rs
+++ b/src/flatbuffers/fb_network_filter_generated.rs
@@ -114,7 +114,7 @@ pub mod fb {
             // which contains a valid value in this slot
             unsafe {
                 self._tab
-                    .get::<u32>(NetworkFilter::VT_MASK, Some(0))
+                    .get::<u32>(NetworkFilter::VT_MASK, Some(540221439))
                     .unwrap()
             }
         }
@@ -262,7 +262,7 @@ pub mod fb {
         #[inline]
         fn default() -> Self {
             NetworkFilterArgs {
-                mask: 0,
+                mask: 540221439,
                 opt_domains: None,
                 opt_not_domains: None,
                 patterns: None,
@@ -281,7 +281,8 @@ pub mod fb {
     impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> NetworkFilterBuilder<'a, 'b, A> {
         #[inline]
         pub fn add_mask(&mut self, mask: u32) {
-            self.fbb_.push_slot::<u32>(NetworkFilter::VT_MASK, mask, 0);
+            self.fbb_
+                .push_slot::<u32>(NetworkFilter::VT_MASK, mask, 540221439);
         }
         #[inline]
         pub fn add_opt_domains(
@@ -387,7 +388,7 @@ pub mod fb {
     impl Default for NetworkFilterT {
         fn default() -> Self {
             Self {
-                mask: 0,
+                mask: 540221439,
                 opt_domains: None,
                 opt_not_domains: None,
                 patterns: None,

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -221,8 +221,8 @@ mod tests {
         #[cfg(feature = "debug-info")]
         {
             let debug_info = engine.get_debug_info();
-            let low_bound = 9_000_000;
-            let high_bound = 9_500_000;
+            let low_bound = 8_700_000;
+            let high_bound = 9_200_000;
             assert!(
                 debug_info.flatbuffer_size >= low_bound,
                 "Expected size >= {} bytes, got {}",
@@ -237,9 +237,9 @@ mod tests {
             );
         }
         let expected_hash: u64 = if cfg!(feature = "css-validation") {
-            11452175769852090292
+            1278886013448413771
         } else {
-            9645570723907119088
+            6460458707531433656
         };
 
         assert_eq!(hash(&data), expected_hash, "{HASH_MISMATCH_MSG}");


### PR DESCRIPTION
The PR adjusts `mask` default value to consume less memory.
Flatbuffer builder doesn't serialize the mask if it's equal to the default.
The current default covers about 50% of the network rules and saves 200KB+ of memory. 

Note: it's a breaking DAT change and the dat version should be increased (was already done in 0.13.x).