### PR TITLE
Refactor is bad filter (0.13.x)

### DIFF
--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -211,7 +211,7 @@ impl Blocker {
             }
             None => None,
             // If matched an important filter, exceptions don't atter
-            Some(f) if f.is_important() => None,
+            Some(f) if f.filter_mask.is_important() => None,
             Some(_) => self
                 .exceptions()
                 .check(request, &self.tags_enabled, &mut regex_manager),
@@ -227,7 +227,7 @@ impl Blocker {
         let redirect_resource = {
             let mut exceptions = vec![];
             for redirect_filter in redirect_filters.iter() {
-                if redirect_filter.is_exception() {
+                if redirect_filter.filter_mask.is_exception() {
                     if let Some(redirect) = redirect_filter.modifier_option.as_ref() {
                         exceptions.push(redirect);
                     }
@@ -235,7 +235,7 @@ impl Blocker {
             }
             let mut resource_and_priority = None;
             for redirect_filter in redirect_filters.iter() {
-                if !redirect_filter.is_exception() {
+                if !redirect_filter.filter_mask.is_exception() {
                     if let Some(redirect) = redirect_filter.modifier_option.as_ref() {
                         if !exceptions.contains(&redirect) {
                             // parse redirect + priority
@@ -278,7 +278,7 @@ impl Blocker {
         let important = filter.is_some()
             && filter
                 .as_ref()
-                .map(|f| f.is_important())
+                .map(|f| f.filter_mask.is_important())
                 .unwrap_or_else(|| false);
 
         let rewritten_url = if important {
@@ -410,8 +410,8 @@ impl Blocker {
         let mut enabled_directives: HashSet<&str> = HashSet::new();
 
         for filter in filters.iter() {
-            if filter.is_exception() {
-                if filter.is_csp() {
+            if filter.filter_mask.is_exception() {
+                if filter.filter_mask.is_csp() {
                     if let Some(csp_directive) = &filter.modifier_option {
                         disabled_directives.insert(csp_directive);
                     } else {
@@ -420,7 +420,7 @@ impl Blocker {
                         return None;
                     }
                 }
-            } else if filter.is_csp() {
+            } else if filter.filter_mask.is_csp() {
                 if let Some(csp_directive) = &filter.modifier_option {
                     enabled_directives.insert(csp_directive);
                 }

--- a/src/content_blocking.rs
+++ b/src/content_blocking.rs
@@ -1,7 +1,9 @@
 //! Transforms filter rules into content blocking syntax used on iOS and MacOS.
 
 use crate::filters::cosmetic::CosmeticFilter;
-use crate::filters::network::{NetworkFilter, NetworkFilterMask, NetworkFilterMaskHelper};
+use crate::filters::network::{
+    NetworkFilter, NetworkFilterFeaturesMask, NetworkFilterMask, NetworkFilterMaskHelper,
+};
 use crate::lists::ParsedFilter;
 
 use memchr::{memchr as find_char, memmem};
@@ -319,7 +321,8 @@ impl TryFrom<NetworkFilter> for CbRuleEquivalent {
                 return Err(CbRuleCreationFailure::NetworkGenerichideUnsupported);
             }
             debug_assert!(
-                !v.mask.contains(NetworkFilterMask::BAD_FILTER),
+                !v.features_mask
+                    .contains(NetworkFilterFeaturesMask::BAD_FILTER),
                 "BAD_FILTER should be filtered out"
             );
             if v.is_csp() {

--- a/src/filters/fb_network_builder.rs
+++ b/src/filters/fb_network_builder.rs
@@ -228,7 +228,7 @@ impl NetworkRulesBuilder {
         // Collect badfilter ids in advance.
         for filter in network_filters.iter() {
             if filter.is_badfilter() {
-                badfilter_ids.insert(filter.get_id_without_badfilter());
+                badfilter_ids.insert(filter.get_id());
             }
         }
 

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -21,6 +21,9 @@ use crate::utils::{self, Hash, TokensBuffer};
 static VALID_PARAM: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9_\-]+$").unwrap());
 
 bitflags::bitflags! {
+  /// Features that are properties used to classify the filter, but not stored
+  /// in the flatbuffer serialized format. For that reason, not available
+  /// for FlatNetworkFilter (use NetworkFilterMask instead).
   #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Default)]
   pub struct NetworkFilterFeaturesMask: u32 {
     const BAD_FILTER = 1 << 0;
@@ -107,7 +110,6 @@ bitflags::bitflags! {
         const THIRD_PARTY = 1 << 16;
         const FIRST_PARTY = 1 << 17;
         const IS_REDIRECT = 1 << 26;
-        const UNUSED_BAD_FILTER = 1 << 27;
         const GENERIC_HIDE = 1 << 30;
 
         // Full document rules are not implied by negated types.
@@ -930,7 +932,7 @@ impl NetworkFilter {
     }
 
     pub fn is_badfilter(&self) -> bool {
-        self.features_mask.bits() & NetworkFilterFeaturesMask::BAD_FILTER.bits() != 0
+        self.features_mask.contains(NetworkFilterFeaturesMask::BAD_FILTER)
     }
 
     #[cfg(test)]

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -20,6 +20,13 @@ use crate::utils::{self, Hash, TokensBuffer};
 /// For now, only support `$removeparam` with simple alphanumeric/dash/underscore patterns.
 static VALID_PARAM: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9_\-]+$").unwrap());
 
+bitflags::bitflags! {
+  #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Default)]
+  pub struct NetworkFilterFeaturesMask: u32 {
+    const BAD_FILTER = 1 << 0;
+  }
+}
+
 #[non_exhaustive]
 #[derive(Debug, Error, PartialEq, Clone)]
 pub enum NetworkFilterError {
@@ -100,7 +107,7 @@ bitflags::bitflags! {
         const THIRD_PARTY = 1 << 16;
         const FIRST_PARTY = 1 << 17;
         const IS_REDIRECT = 1 << 26;
-        const BAD_FILTER = 1 << 27;
+        const UNUSED_BAD_FILTER = 1 << 27;
         const GENERIC_HIDE = 1 << 30;
 
         // Full document rules are not implied by negated types.
@@ -199,11 +206,6 @@ pub trait NetworkFilterMaskHelper {
     #[inline]
     fn also_block_redirect(&self) -> bool {
         self.has_flag(NetworkFilterMask::ALSO_BLOCK_REDIRECT)
-    }
-
-    #[inline]
-    fn is_badfilter(&self) -> bool {
-        self.has_flag(NetworkFilterMask::BAD_FILTER)
     }
 
     #[inline]
@@ -379,6 +381,7 @@ impl FilterPart {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkFilter {
     pub mask: NetworkFilterMask,
+    pub features_mask: NetworkFilterFeaturesMask,
     pub filter: FilterPart,
     pub opt_domains: Option<Vec<Hash>>,
     pub opt_not_domains: Option<Vec<Hash>>,
@@ -445,6 +448,7 @@ impl NetworkFilter {
             | NetworkFilterMask::FIRST_PARTY
             | NetworkFilterMask::FROM_HTTPS
             | NetworkFilterMask::FROM_HTTP;
+        let mut features_mask: NetworkFilterFeaturesMask = Default::default();
 
         // Temporary masks for positive (e.g.: $script) and negative (e.g.: $~script)
         // content type options.
@@ -504,7 +508,9 @@ impl NetworkFilter {
                             opt_not_domains = Some(opt_not_domains_array);
                         }
                     }
-                    NetworkFilterOption::Badfilter => mask.set(NetworkFilterMask::BAD_FILTER, true),
+                    NetworkFilterOption::Badfilter => {
+                        features_mask.set(NetworkFilterFeaturesMask::BAD_FILTER, true)
+                    }
                     NetworkFilterOption::Important => {
                         mask.set(NetworkFilterMask::IS_IMPORTANT, true)
                     }
@@ -798,6 +804,7 @@ impl NetworkFilter {
             },
             hostname: hostname_decoded?,
             mask,
+            features_mask,
             opt_domains,
             opt_not_domains,
             tag,
@@ -832,19 +839,6 @@ impl NetworkFilter {
         // Parse it as a `||hostname^` rule.
         let rule = format!("||{hostname}^");
         NetworkFilter::parse(&rule, debug, Default::default())
-    }
-
-    pub fn get_id_without_badfilter(&self) -> Hash {
-        let mut mask = self.mask;
-        mask.set(NetworkFilterMask::BAD_FILTER, false);
-        compute_filter_id(
-            self.modifier_option.as_deref(),
-            mask,
-            self.filter.string_view().as_deref(),
-            self.hostname.as_deref(),
-            self.opt_domains.as_ref(),
-            self.opt_not_domains.as_ref(),
-        )
     }
 
     pub fn get_id(&self) -> Hash {
@@ -933,6 +927,10 @@ impl NetworkFilter {
 
             FilterTokens::Other(tokens_buffer.as_slice())
         }
+    }
+
+    pub fn is_badfilter(&self) -> bool {
+        self.features_mask.bits() & NetworkFilterFeaturesMask::BAD_FILTER.bits() != 0
     }
 
     #[cfg(test)]

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -932,7 +932,8 @@ impl NetworkFilter {
     }
 
     pub fn is_badfilter(&self) -> bool {
-        self.features_mask.contains(NetworkFilterFeaturesMask::BAD_FILTER)
+        self.features_mask
+            .contains(NetworkFilterFeaturesMask::BAD_FILTER)
     }
 
     #[cfg(test)]

--- a/src/filters/network_matchers.rs
+++ b/src/filters/network_matchers.rs
@@ -404,10 +404,6 @@ where
 
 #[inline]
 pub fn check_options(mask: NetworkFilterMask, request: &request::Request) -> bool {
-    // Bad filter never matches
-    if mask.is_badfilter() {
-        return false;
-    }
     // We first discard requests based on type, protocol and party. This is really
     // cheap and should be done first.
     if !mask.check_cpt_allowed(&request.request_type)

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -285,7 +285,6 @@ impl FilterSet {
         self,
     ) -> Result<(Vec<crate::content_blocking::CbRule>, Vec<String>), ()> {
         use crate::content_blocking;
-        use crate::filters::network::NetworkFilterMaskHelper;
         use std::collections::HashSet;
 
         if !self.debug {
@@ -296,7 +295,7 @@ impl FilterSet {
         let mut bad_filter_ids = HashSet::new();
         for filter in self.network_filters.iter() {
             if filter.is_badfilter() {
-                bad_filter_ids.insert(filter.get_id_without_badfilter());
+                bad_filter_ids.insert(filter.get_id());
             }
         }
 

--- a/src/network_filter_list.rs
+++ b/src/network_filter_list.rs
@@ -7,9 +7,7 @@ use flatbuffers::ForwardsUOffset;
 use crate::filters::fb_network::FlatNetworkFilter;
 use crate::filters::filter_data_context::FilterDataContext;
 use crate::filters::flatbuffer_generated::fb;
-use crate::filters::network::{
-    NetworkFilter, NetworkFilterMask, NetworkFilterMaskHelper, NetworkMatchable,
-};
+use crate::filters::network::{NetworkFilter, NetworkFilterMask, NetworkMatchable};
 use crate::flatbuffers::containers::flat_multimap::FlatMultiMapView;
 use crate::flatbuffers::unsafe_tools::fb_vector_to_slice;
 use crate::regex_manager::RegexManager;
@@ -41,13 +39,6 @@ impl fmt::Display for CheckResult {
         } else {
             write!(f, "{}", self.filter_mask)
         }
-    }
-}
-
-impl NetworkFilterMaskHelper for CheckResult {
-    #[inline]
-    fn has_flag(&self, v: NetworkFilterMask) -> bool {
-        self.filter_mask.contains(v)
     }
 }
 


### PR DESCRIPTION
For https://github.com/brave/adblock-rust/issues/635
The PR:
* removes IS_BADFILTER from NetworkFilterMask
* adds NetworkFilterFeatureMask to store parse-only features
* rids off `get_id_without_badfilter` in favor of `get_id()`
* removes impl NetworkFilterMaskHelper for CheckedResult