### PR TITLE
Refactor more mask items (0.13.x)

### DIFF
--- a/benches/bench_redirect_performance.rs
+++ b/benches/bench_redirect_performance.rs
@@ -2,7 +2,7 @@ use adblock::{Engine, FilterSet};
 use criterion::*;
 use tokio::runtime::Runtime;
 
-use adblock::filters::network::{NetworkFilter, NetworkFilterMask, NetworkFilterMaskHelper};
+use adblock::filters::network::{NetworkFilter, NetworkFilterMask};
 use adblock::request::Request;
 use adblock::resources::Resource;
 

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -411,16 +411,14 @@ impl Blocker {
 
         for filter in filters.iter() {
             if filter.filter_mask.is_exception() {
-                if filter.filter_mask.is_csp() {
-                    if let Some(csp_directive) = &filter.modifier_option {
-                        disabled_directives.insert(csp_directive);
-                    } else {
-                        // Exception filters with empty `csp` options will disable all CSP
-                        // injections for matching pages.
-                        return None;
-                    }
+                if let Some(csp_directive) = &filter.modifier_option {
+                    disabled_directives.insert(csp_directive);
+                } else {
+                    // Exception filters with empty `csp` options will disable all CSP
+                    // injections for matching pages.
+                    return None;
                 }
-            } else if filter.filter_mask.is_csp() {
+            } else {
                 if let Some(csp_directive) = &filter.modifier_option {
                     enabled_directives.insert(csp_directive);
                 }

--- a/src/content_blocking.rs
+++ b/src/content_blocking.rs
@@ -1,9 +1,7 @@
 //! Transforms filter rules into content blocking syntax used on iOS and MacOS.
 
 use crate::filters::cosmetic::CosmeticFilter;
-use crate::filters::network::{
-    NetworkFilter, NetworkFilterFeaturesMask, NetworkFilterMask, NetworkFilterMaskHelper,
-};
+use crate::filters::network::{NetworkFilter, NetworkFilterFeaturesMask, NetworkFilterMask};
 use crate::lists::ParsedFilter;
 
 use memchr::{memchr as find_char, memmem};

--- a/src/content_blocking.rs
+++ b/src/content_blocking.rs
@@ -317,7 +317,7 @@ impl TryFrom<NetworkFilter> for CbRuleEquivalent {
             if v.is_redirect() {
                 return Err(CbRuleCreationFailure::NetworkRedirectUnsupported);
             }
-            if v.mask.contains(NetworkFilterMask::GENERIC_HIDE) {
+            if v.is_generic_hide() {
                 return Err(CbRuleCreationFailure::NetworkGenerichideUnsupported);
             }
             debug_assert!(

--- a/src/data_format/mod.rs
+++ b/src/data_format/mod.rs
@@ -17,7 +17,7 @@ const ADBLOCK_RUST_DAT_MAGIC: [u8; 4] = [0xd1, 0xd9, 0x3a, 0xaf];
 
 /// The version of the data format.
 /// If the data format version is incremented, the data is considered as incompatible.
-const ADBLOCK_RUST_DAT_VERSION: u8 = 3;
+const ADBLOCK_RUST_DAT_VERSION: u8 = 4;
 
 /// The total length of the header prefix (magic + version + seahash)
 const HEADER_PREFIX_LENGTH: usize = 4 + 1 + 8;

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -821,6 +821,7 @@ impl NetworkFilter {
         compute_filter_id(
             self.modifier_option.as_deref(),
             self.mask,
+            self.features_mask,
             self.filter.string_view().as_deref(),
             self.hostname.as_deref(),
             self.opt_domains.as_ref(),
@@ -978,12 +979,17 @@ pub(crate) trait NetworkMatchable {
 fn compute_filter_id(
     modifier_option: Option<&str>,
     mask: NetworkFilterMask,
+    features_mask: NetworkFilterFeaturesMask,
     filter: Option<&str>,
     hostname: Option<&str>,
     opt_domains: Option<&Vec<Hash>>,
     opt_not_domains: Option<&Vec<Hash>>,
 ) -> Hash {
     let mut hash: Hash = (5408 * 33) ^ Hash::from(mask.bits());
+
+    // Exclude BAD_FILTER from the hash
+    let features_mask_bits = features_mask.bits() & !NetworkFilterFeaturesMask::BAD_FILTER.bits();
+    hash = hash.wrapping_mul(33) ^ Hash::from(features_mask_bits);
 
     if let Some(s) = modifier_option {
         let chars = s.chars();

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -28,6 +28,7 @@ bitflags::bitflags! {
   pub struct NetworkFilterFeaturesMask: u32 {
     const BAD_FILTER = 1 << 0;
     const IS_REMOVEPARAM = 1 << 1;
+    const GENERIC_HIDE = 1 << 2;
   }
 }
 
@@ -110,7 +111,6 @@ bitflags::bitflags! {
         const THIRD_PARTY = 1 << 16;
         const FIRST_PARTY = 1 << 17;
         const IS_REDIRECT = 1 << 26;
-        const GENERIC_HIDE = 1 << 30;
 
         // Full document rules are not implied by negated types.
         const FROM_DOCUMENT = 1 << 29;
@@ -203,11 +203,6 @@ pub trait NetworkFilterMaskHelper {
     #[inline]
     fn also_block_redirect(&self) -> bool {
         self.has_flag(NetworkFilterMask::ALSO_BLOCK_REDIRECT)
-    }
-
-    #[inline]
-    fn is_generic_hide(&self) -> bool {
-        self.has_flag(NetworkFilterMask::GENERIC_HIDE)
     }
 
     #[inline]
@@ -543,7 +538,7 @@ impl NetworkFilter {
                         modifier_option = value;
                     }
                     NetworkFilterOption::Generichide => {
-                        mask.set(NetworkFilterMask::GENERIC_HIDE, true)
+                        features_mask.set(NetworkFilterFeaturesMask::GENERIC_HIDE, true)
                     }
                     NetworkFilterOption::Document => {
                         cpt_mask_positive.set(NetworkFilterMask::FROM_DOCUMENT, true)
@@ -763,7 +758,7 @@ impl NetworkFilter {
             })
             .transpose();
 
-        if mask.contains(NetworkFilterMask::GENERIC_HIDE) && !parsed.exception {
+        if features_mask.contains(NetworkFilterFeaturesMask::GENERIC_HIDE) && !parsed.exception {
             return Err(NetworkFilterError::GenericHideWithoutException);
         }
 
@@ -938,6 +933,11 @@ impl NetworkFilter {
     pub fn is_removeparam(&self) -> bool {
         self.features_mask
             .contains(NetworkFilterFeaturesMask::IS_REMOVEPARAM)
+    }
+
+    pub fn is_generic_hide(&self) -> bool {
+        self.features_mask
+            .contains(NetworkFilterFeaturesMask::GENERIC_HIDE)
     }
 
     #[cfg(test)]

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -27,6 +27,7 @@ bitflags::bitflags! {
   #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Default)]
   pub struct NetworkFilterFeaturesMask: u32 {
     const BAD_FILTER = 1 << 0;
+    const IS_REMOVEPARAM = 1 << 1;
   }
 }
 
@@ -106,7 +107,6 @@ bitflags::bitflags! {
         const FROM_HTTPS = 1 << 12;
         const IS_IMPORTANT = 1 << 13;
         const MATCH_CASE = 1 << 14;
-        const IS_REMOVEPARAM = 1 << 15;
         const THIRD_PARTY = 1 << 16;
         const FIRST_PARTY = 1 << 17;
         const IS_REDIRECT = 1 << 26;
@@ -198,11 +198,6 @@ pub trait NetworkFilterMaskHelper {
     #[inline]
     fn is_redirect(&self) -> bool {
         self.has_flag(NetworkFilterMask::IS_REDIRECT)
-    }
-
-    #[inline]
-    fn is_removeparam(&self) -> bool {
-        self.has_flag(NetworkFilterMask::IS_REMOVEPARAM)
     }
 
     #[inline]
@@ -536,7 +531,7 @@ impl NetworkFilter {
                         modifier_option = Some(value);
                     }
                     NetworkFilterOption::Removeparam(value) => {
-                        mask.set(NetworkFilterMask::IS_REMOVEPARAM, true);
+                        features_mask.set(NetworkFilterFeaturesMask::IS_REMOVEPARAM, true);
                         modifier_option = Some(value);
                     }
                     NetworkFilterOption::Csp(value) => {
@@ -587,7 +582,7 @@ impl NetworkFilter {
         // The negated types will be applied later.
         //
         // This doesn't apply to removeparam filters.
-        if !mask.contains(NetworkFilterMask::IS_REMOVEPARAM)
+        if !features_mask.contains(NetworkFilterFeaturesMask::IS_REMOVEPARAM)
             && (cpt_mask_negative & NetworkFilterMask::FROM_NETWORK_TYPES)
                 != NetworkFilterMask::NONE
         {
@@ -596,7 +591,7 @@ impl NetworkFilter {
         // If no positive types were set, then the filter should apply to all network types.
         if (cpt_mask_positive & NetworkFilterMask::FROM_ALL_TYPES).is_empty() {
             // Removeparam is again a special case.
-            if mask.contains(NetworkFilterMask::IS_REMOVEPARAM) {
+            if features_mask.contains(NetworkFilterFeaturesMask::IS_REMOVEPARAM) {
                 mask |= NetworkFilterMask::FROM_DOCUMENT
                     | NetworkFilterMask::FROM_SUBDOCUMENT
                     | NetworkFilterMask::FROM_XMLHTTPREQUEST;
@@ -772,7 +767,7 @@ impl NetworkFilter {
             return Err(NetworkFilterError::GenericHideWithoutException);
         }
 
-        if mask.contains(NetworkFilterMask::IS_REMOVEPARAM) && parsed.exception {
+        if features_mask.contains(NetworkFilterFeaturesMask::IS_REMOVEPARAM) && parsed.exception {
             return Err(NetworkFilterError::RemoveparamWithException);
         }
 
@@ -791,7 +786,7 @@ impl NetworkFilter {
             && mask.contains(NetworkFilterMask::IS_HOSTNAME_ANCHOR)
             && mask.contains(NetworkFilterMask::IS_RIGHT_ANCHOR)
             && !end_url_anchor
-            && !mask.contains(NetworkFilterMask::IS_REMOVEPARAM)
+            && !features_mask.contains(NetworkFilterFeaturesMask::IS_REMOVEPARAM)
         {
             mask |= NetworkFilterMask::FROM_ALL_TYPES;
         }
@@ -901,7 +896,11 @@ impl NetworkFilter {
             }
         }
 
-        if tokens_buffer.is_empty() && self.mask.contains(NetworkFilterMask::IS_REMOVEPARAM) {
+        if tokens_buffer.is_empty()
+            && self
+                .features_mask
+                .contains(NetworkFilterFeaturesMask::IS_REMOVEPARAM)
+        {
             if let Some(removeparam) = &self.modifier_option {
                 if VALID_PARAM.is_match(removeparam) {
                     utils::tokenize_to(&removeparam.to_ascii_lowercase(), tokens_buffer);
@@ -934,6 +933,11 @@ impl NetworkFilter {
     pub fn is_badfilter(&self) -> bool {
         self.features_mask
             .contains(NetworkFilterFeaturesMask::BAD_FILTER)
+    }
+
+    pub fn is_removeparam(&self) -> bool {
+        self.features_mask
+            .contains(NetworkFilterFeaturesMask::IS_REMOVEPARAM)
     }
 
     #[cfg(test)]

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -190,6 +190,11 @@ pub trait NetworkFilterMaskHelper {
     }
 
     #[inline]
+    fn is_important(&self) -> bool {
+        self.has_flag(NetworkFilterMask::IS_IMPORTANT)
+    }
+
+    #[inline]
     fn is_regex(&self) -> bool {
         self.has_flag(NetworkFilterMask::IS_REGEX)
     }

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -30,6 +30,11 @@ bitflags::bitflags! {
     const IS_REMOVEPARAM = 1 << 1;
     const GENERIC_HIDE = 1 << 2;
     const IS_CSP = 1 << 3;
+    const IS_REDIRECT = 1 << 4;
+
+    /// Specifies that a redirect rule should also create a corresponding block rule.
+    /// This is used to avoid returning two separate rules from `NetworkFilter::parse`.
+    const ALSO_BLOCK_REDIRECT = 1 << 5;
   }
 }
 
@@ -111,8 +116,6 @@ bitflags::bitflags! {
         const MATCH_CASE = 1 << 14;
         const THIRD_PARTY = 1 << 16;
         const FIRST_PARTY = 1 << 17;
-        const IS_REDIRECT = 1 << 26;
-
         // Full document rules are not implied by negated types.
         const FROM_DOCUMENT = 1 << 29;
 
@@ -124,10 +127,6 @@ bitflags::bitflags! {
         const IS_EXCEPTION = 1 << 22;
         const IS_COMPLETE_REGEX = 1 << 24;
         const IS_HOSTNAME_REGEX = 1 << 28;
-
-        // Specifies that a redirect rule should also create a corresponding block rule.
-        // This is used to avoid returning two separate rules from `NetworkFilter::parse`.
-        const ALSO_BLOCK_REDIRECT = 1 << 31;
 
         // "Other" network request types
         const UNMATCHED = 1 << 25;
@@ -190,17 +189,6 @@ pub trait NetworkFilterMaskHelper {
         self.has_flag(NetworkFilterMask::MATCH_CASE)
     }
 
-
-    #[inline]
-    fn is_redirect(&self) -> bool {
-        self.has_flag(NetworkFilterMask::IS_REDIRECT)
-    }
-
-    #[inline]
-    fn also_block_redirect(&self) -> bool {
-        self.has_flag(NetworkFilterMask::ALSO_BLOCK_REDIRECT)
-    }
-
     #[inline]
     fn is_regex(&self) -> bool {
         self.has_flag(NetworkFilterMask::IS_REGEX)
@@ -215,7 +203,6 @@ pub trait NetworkFilterMaskHelper {
     fn is_plain(&self) -> bool {
         !self.is_regex()
     }
-
 
     #[inline]
     fn third_party(&self) -> bool {
@@ -509,12 +496,12 @@ impl NetworkFilter {
                     }
                     NetworkFilterOption::Tag(value) => tag = Some(value),
                     NetworkFilterOption::Redirect(value) => {
-                        mask.set(NetworkFilterMask::IS_REDIRECT, true);
-                        mask.set(NetworkFilterMask::ALSO_BLOCK_REDIRECT, true);
+                        features_mask.set(NetworkFilterFeaturesMask::IS_REDIRECT, true);
+                        features_mask.set(NetworkFilterFeaturesMask::ALSO_BLOCK_REDIRECT, true);
                         modifier_option = Some(value);
                     }
                     NetworkFilterOption::RedirectRule(value) => {
-                        mask.set(NetworkFilterMask::IS_REDIRECT, true);
+                        features_mask.set(NetworkFilterFeaturesMask::IS_REDIRECT, true);
                         modifier_option = Some(value);
                     }
                     NetworkFilterOption::Removeparam(value) => {
@@ -935,6 +922,16 @@ impl NetworkFilter {
     pub fn is_csp(&self) -> bool {
         self.features_mask
             .contains(NetworkFilterFeaturesMask::IS_CSP)
+    }
+
+    pub fn is_redirect(&self) -> bool {
+        self.features_mask
+            .contains(NetworkFilterFeaturesMask::IS_REDIRECT)
+    }
+
+    pub fn also_block_redirect(&self) -> bool {
+        self.features_mask
+            .contains(NetworkFilterFeaturesMask::ALSO_BLOCK_REDIRECT)
     }
 
     #[cfg(test)]

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -29,6 +29,7 @@ bitflags::bitflags! {
     const BAD_FILTER = 1 << 0;
     const IS_REMOVEPARAM = 1 << 1;
     const GENERIC_HIDE = 1 << 2;
+    const IS_CSP = 1 << 3;
   }
 }
 
@@ -121,7 +122,6 @@ bitflags::bitflags! {
         const IS_RIGHT_ANCHOR = 1 << 20;
         const IS_HOSTNAME_ANCHOR = 1 << 21;
         const IS_EXCEPTION = 1 << 22;
-        const IS_CSP = 1 << 23;
         const IS_COMPLETE_REGEX = 1 << 24;
         const IS_HOSTNAME_REGEX = 1 << 28;
 
@@ -190,10 +190,6 @@ pub trait NetworkFilterMaskHelper {
         self.has_flag(NetworkFilterMask::MATCH_CASE)
     }
 
-    #[inline]
-    fn is_important(&self) -> bool {
-        self.has_flag(NetworkFilterMask::IS_IMPORTANT)
-    }
 
     #[inline]
     fn is_redirect(&self) -> bool {
@@ -220,10 +216,6 @@ pub trait NetworkFilterMaskHelper {
         !self.is_regex()
     }
 
-    #[inline]
-    fn is_csp(&self) -> bool {
-        self.has_flag(NetworkFilterMask::IS_CSP)
-    }
 
     #[inline]
     fn third_party(&self) -> bool {
@@ -530,10 +522,10 @@ impl NetworkFilter {
                         modifier_option = Some(value);
                     }
                     NetworkFilterOption::Csp(value) => {
-                        mask.set(NetworkFilterMask::IS_CSP, true);
+                        features_mask.set(NetworkFilterFeaturesMask::IS_CSP, true);
                         // CSP rules can never have content types, and should always match against
                         // subdocument and document rules. Rules do not match against document
-                        // requests by default, so this must be explictly added.
+                        // requests by default, so this must be explicitly added.
                         mask.set(NetworkFilterMask::FROM_DOCUMENT, true);
                         modifier_option = value;
                     }
@@ -938,6 +930,11 @@ impl NetworkFilter {
     pub fn is_generic_hide(&self) -> bool {
         self.features_mask
             .contains(NetworkFilterFeaturesMask::GENERIC_HIDE)
+    }
+
+    pub fn is_csp(&self) -> bool {
+        self.features_mask
+            .contains(NetworkFilterFeaturesMask::IS_CSP)
     }
 
     #[cfg(test)]

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -183,7 +183,7 @@ mod tests {
     fn deserialization_generate_simple() {
         let mut engine = Engine::from_rules(["ad-banner"], Default::default());
         let data = engine.serialize().to_vec();
-        const EXPECTED_HASH: u64 = 10945714988765761881;
+        const EXPECTED_HASH: u64 = 4588487935723956783;
         assert_eq!(hash(&data), EXPECTED_HASH, "{HASH_MISMATCH_MSG}");
         engine.deserialize(&data).unwrap();
     }
@@ -193,7 +193,7 @@ mod tests {
         let mut engine = Engine::from_rules(["ad-banner$tag=abc"], Default::default());
         engine.use_tags(&["abc"]);
         let data = engine.serialize().to_vec();
-        const EXPECTED_HASH: u64 = 4608037684406751718;
+        const EXPECTED_HASH: u64 = 7781508779107365248;
         assert_eq!(hash(&data), EXPECTED_HASH, "{HASH_MISMATCH_MSG}");
         engine.deserialize(&data).unwrap();
     }
@@ -237,9 +237,9 @@ mod tests {
             );
         }
         let expected_hash: u64 = if cfg!(feature = "css-validation") {
-            18006544876284176656
+            11452175769852090292
         } else {
-            7678096075090154250
+            9645570723907119088
         };
 
         assert_eq!(hash(&data), expected_hash, "{HASH_MISMATCH_MSG}");


### PR DESCRIPTION
For https://github.com/brave/adblock-rust/issues/635

The PR refactors `NetworkFilterMask` by moving some parse-only bits to `NetworkFilterFeaturesMask`.