### PR TITLE
Simplify string sharing

### DIFF
--- a/src/cosmetic_filter_cache_builder.rs
+++ b/src/cosmetic_filter_cache_builder.rs
@@ -6,7 +6,7 @@ use crate::cosmetic_filter_cache::ProceduralOrActionFilter;
 use crate::cosmetic_filter_utils::SpecificFilterType;
 use crate::cosmetic_filter_utils::{encode_script_with_permission, key_from_selector};
 use crate::filters::cosmetic::{CosmeticFilter, CosmeticFilterMask, CosmeticFilterOperator};
-use crate::filters::fb_builder::{EngineFlatBuilder, ShareableString};
+use crate::filters::fb_builder::EngineFlatBuilder;
 use crate::filters::flatbuffer_generated::fb;
 use crate::flatbuffers::containers::flat_map::FlatMapBuilder;
 use crate::flatbuffers::containers::flat_multimap::FlatMultiMapBuilder;
@@ -27,14 +27,14 @@ use flatbuffers::WIPOffset;
 /// Note: hide and inject_script are now handled separately at the top level
 /// See HostnameSpecificRules declaration for more details.
 #[derive(Default)]
-struct HostnameRule {
-    unhide: Vec<ShareableString>,
-    uninject_script: Vec<ShareableString>,
-    procedural_action: Vec<ShareableString>,
-    procedural_action_exception: Vec<ShareableString>,
+struct HostnameRule<'a> {
+    unhide: Vec<WIPOffset<&'a str>>,
+    uninject_script: Vec<WIPOffset<&'a str>>,
+    procedural_action: Vec<WIPOffset<&'a str>>,
+    procedural_action_exception: Vec<WIPOffset<&'a str>>,
 }
 
-impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for HostnameRule {
+impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for HostnameRule<'a> {
     type Output = WIPOffset<fb::HostnameSpecificRules<'a>>;
 
     fn serialize(
@@ -63,21 +63,21 @@ impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for HostnameRule {
 struct StringVector(Vec<String>);
 
 #[derive(Default)]
-pub(crate) struct CosmeticFilterCacheBuilder {
+pub(crate) struct CosmeticFilterCacheBuilder<'a> {
     simple_class_rules: HashSetBuilder<String>,
     simple_id_rules: HashSetBuilder<String>,
     misc_generic_selectors: HashSet<String>,
     complex_class_rules: HashMapBuilder<String, StringVector>,
     complex_id_rules: HashMapBuilder<String, StringVector>,
 
-    hostname_hide: FlatMultiMapBuilder<Hash, ShareableString>,
-    hostname_inject_script: FlatMultiMapBuilder<Hash, ShareableString>,
+    hostname_hide: FlatMultiMapBuilder<Hash, WIPOffset<&'a str>>,
+    hostname_inject_script: FlatMultiMapBuilder<Hash, WIPOffset<&'a str>>,
 
-    specific_rules: HashMap<Hash, HostnameRule>,
+    specific_rules: HashMap<Hash, HostnameRule<'a>>,
 }
 
-impl CosmeticFilterCacheBuilder {
-    pub fn from_rules(rules: Vec<CosmeticFilter>, builder: &mut EngineFlatBuilder) -> Self {
+impl<'a> CosmeticFilterCacheBuilder<'a> {
+    pub fn from_rules(rules: Vec<CosmeticFilter>, builder: &mut EngineFlatBuilder<'a>) -> Self {
         let mut self_ = Self::default();
 
         for rule in rules {
@@ -87,7 +87,7 @@ impl CosmeticFilterCacheBuilder {
         self_
     }
 
-    pub fn add_filter(&mut self, rule: CosmeticFilter, builder: &mut EngineFlatBuilder) {
+    pub fn add_filter(&mut self, rule: CosmeticFilter, builder: &mut EngineFlatBuilder<'a>) {
         if rule.has_hostname_constraint() {
             if let Some(generic_rule) = rule.hidden_generic_rule() {
                 self.add_generic_filter(generic_rule);
@@ -140,7 +140,7 @@ impl CosmeticFilterCacheBuilder {
         }
     }
 
-    fn store_hostname_rule(&mut self, rule: CosmeticFilter, builder: &mut EngineFlatBuilder) {
+    fn store_hostname_rule(&mut self, rule: CosmeticFilter, builder: &mut EngineFlatBuilder<'a>) {
         use SpecificFilterType::*;
 
         let unhide = rule.mask.contains(CosmeticFilterMask::UNHIDE);
@@ -186,59 +186,59 @@ impl CosmeticFilterCacheBuilder {
         &mut self,
         tokens: impl IntoIterator<Item = Hash>,
         kind: &SpecificFilterType,
-        builder: &mut EngineFlatBuilder,
+        builder: &mut EngineFlatBuilder<'a>,
     ) {
         use SpecificFilterType::*;
 
         match kind {
             // Handle hide and inject_script at top level for better deduplication
             Hide(s) => {
-                let mut shareable_string = None;
+                let mut cached_offset = None;
                 for token in tokens {
-                    let s = shareable_string.get_or_insert_with(|| builder.add_shareable_string(s));
-                    self.hostname_hide.insert(token, s.clone());
+                    let s = cached_offset.get_or_insert_with(|| builder.create_string(s));
+                    self.hostname_hide.insert(token, *s);
                 }
             }
             InjectScript((s, permission)) => {
-                let mut shareable_string = None;
+                let mut cached_offset = None;
                 for token in tokens {
-                    let s = shareable_string.get_or_insert_with(|| {
-                        builder.add_shareable_string(&encode_script_with_permission(s, permission))
+                    let s = cached_offset.get_or_insert_with(|| {
+                        builder.create_string(&encode_script_with_permission(s, permission))
                     });
-                    self.hostname_inject_script.insert(token, s.clone());
+                    self.hostname_inject_script.insert(token, *s);
                 }
             }
             // Handle remaining types through HostnameRule
             Unhide(s) => {
-                let mut shareable_string = None;
+                let mut cached_offset = None;
                 for token in tokens {
-                    let s = shareable_string.get_or_insert_with(|| builder.add_shareable_string(s));
+                    let s = cached_offset.get_or_insert_with(|| builder.create_string(s));
                     let entry = self.specific_rules.entry(token).or_default();
-                    entry.unhide.push(s.clone());
+                    entry.unhide.push(*s);
                 }
             }
             UninjectScript((s, _)) => {
-                let mut shareable_string = None;
+                let mut cached_offset = None;
                 for token in tokens {
-                    let s = shareable_string.get_or_insert_with(|| builder.add_shareable_string(s));
+                    let s = cached_offset.get_or_insert_with(|| builder.create_string(s));
                     let entry = self.specific_rules.entry(token).or_default();
-                    entry.uninject_script.push(s.clone());
+                    entry.uninject_script.push(*s);
                 }
             }
             ProceduralOrAction(s) => {
-                let mut shareable_string = None;
+                let mut cached_offset = None;
                 for token in tokens {
-                    let s = shareable_string.get_or_insert_with(|| builder.add_shareable_string(s));
+                    let s = cached_offset.get_or_insert_with(|| builder.create_string(s));
                     let entry = self.specific_rules.entry(token).or_default();
-                    entry.procedural_action.push(s.clone());
+                    entry.procedural_action.push(*s);
                 }
             }
             ProceduralOrActionException(s) => {
-                let mut shareable_string = None;
+                let mut cached_offset = None;
                 for token in tokens {
-                    let s = shareable_string.get_or_insert_with(|| builder.add_shareable_string(s));
+                    let s = cached_offset.get_or_insert_with(|| builder.create_string(s));
                     let entry = self.specific_rules.entry(token).or_default();
-                    entry.procedural_action_exception.push(s.clone());
+                    entry.procedural_action_exception.push(*s);
                 }
             }
         }
@@ -257,7 +257,7 @@ impl<'a, B: FlatBuilder<'a>> FlatSerialize<'a, B> for StringVector {
     }
 }
 
-impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for CosmeticFilterCacheBuilder {
+impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for CosmeticFilterCacheBuilder<'a> {
     type Output = WIPOffset<fb::CosmeticFilters<'a>>;
 
     fn serialize(

--- a/src/filters/fb_builder.rs
+++ b/src/filters/fb_builder.rs
@@ -5,24 +5,17 @@ use std::collections::HashMap;
 use flatbuffers::WIPOffset;
 
 use crate::filters::fb_network_builder::NetworkFilterListBuilder;
-use crate::flatbuffers::containers::flat_serialize::{FlatBuilder, FlatSerialize, WIPFlatVec};
+use crate::flatbuffers::containers::flat_serialize::{FlatBuilder, WIPFlatVec};
 use crate::flatbuffers::unsafe_tools::VerifiedFlatbufferMemory;
 use crate::utils::Hash;
 
 use super::flat::fb;
-
-#[derive(Clone, Default)]
-pub(crate) struct ShareableString {
-    index: Option<usize>,
-}
 
 #[derive(Default)]
 pub(crate) struct EngineFlatBuilder<'a> {
     fb_builder: flatbuffers::FlatBufferBuilder<'a>,
     unique_domains_hashes: Vec<Hash>,
     unique_domains_hashes_map: HashMap<Hash, u32>,
-    shared_strings: Vec<WIPOffset<&'a str>>,
-    shared_strings_original: Vec<String>,
 }
 
 impl<'a> EngineFlatBuilder<'a> {
@@ -34,15 +27,6 @@ impl<'a> EngineFlatBuilder<'a> {
         self.unique_domains_hashes.push(*h);
         self.unique_domains_hashes_map.insert(*h, index);
         index
-    }
-
-    pub fn add_shareable_string(&mut self, s: &str) -> ShareableString {
-        let wip_offset = self.fb_builder.create_string(s);
-        self.shared_strings.push(wip_offset);
-        self.shared_strings_original.push(s.to_string());
-        ShareableString {
-            index: Some(self.shared_strings.len() - 1),
-        }
     }
 
     pub fn finish(
@@ -72,16 +56,5 @@ impl<'a> FlatBuilder<'a> for EngineFlatBuilder<'a> {
 
     fn raw_builder(&mut self) -> &mut flatbuffers::FlatBufferBuilder<'a> {
         &mut self.fb_builder
-    }
-}
-
-impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for ShareableString {
-    type Output = WIPOffset<&'a str>;
-    fn serialize(value: Self, builder: &mut EngineFlatBuilder<'a>) -> Self::Output {
-        if let Some(index) = value.index {
-            builder.shared_strings[index]
-        } else {
-            builder.raw_builder().create_shared_string("")
-        }
     }
 }

--- a/src/flatbuffers/containers/flat_multimap.rs
+++ b/src/flatbuffers/containers/flat_multimap.rs
@@ -83,9 +83,16 @@ where
     }
 }
 
-#[derive(Default)]
 pub(crate) struct FlatMultiMapBuilder<I, V> {
     entries: Vec<(I, V)>,
+}
+
+impl<I, V> Default for FlatMultiMapBuilder<I, V> {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
 }
 
 impl<I: Ord + std::hash::Hash, V> FlatMultiMapBuilder<I, V> {


### PR DESCRIPTION
The PR removes `ShareableString` in favor of using `WIPOffset<&'a str>>` directly.
This change speeds up the building process and simplifies the code.