### PR TITLE
Bump rust to 1.95

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.94"
+channel = "1.95"
 components = ["clippy", "rustfmt" ]

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -879,15 +879,14 @@ impl NetworkFilter {
 
         // Get tokens from filter
         match &self.filter {
-            FilterPart::Simple(f) => {
-                if !self.is_complete_regex() {
+            FilterPart::Simple(f)
+                if !self.is_complete_regex() => {
                     let skip_last_token =
                         (self.is_plain() || self.is_regex()) && !self.is_right_anchor();
                     let skip_first_token = self.is_right_anchor();
 
                     utils::tokenize_filter_to(f, skip_first_token, skip_last_token, tokens_buffer);
                 }
-            }
             FilterPart::AnyOf(_) => (), // across AnyOf set of filters no single token is guaranteed to match to a request
             _ => (),
         }

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -879,14 +879,13 @@ impl NetworkFilter {
 
         // Get tokens from filter
         match &self.filter {
-            FilterPart::Simple(f)
-                if !self.is_complete_regex() => {
-                    let skip_last_token =
-                        (self.is_plain() || self.is_regex()) && !self.is_right_anchor();
-                    let skip_first_token = self.is_right_anchor();
+            FilterPart::Simple(f) if !self.is_complete_regex() => {
+                let skip_last_token =
+                    (self.is_plain() || self.is_regex()) && !self.is_right_anchor();
+                let skip_first_token = self.is_right_anchor();
 
-                    utils::tokenize_filter_to(f, skip_first_token, skip_last_token, tokens_buffer);
-                }
+                utils::tokenize_filter_to(f, skip_first_token, skip_last_token, tokens_buffer);
+            }
             FilterPart::AnyOf(_) => (), // across AnyOf set of filters no single token is guaranteed to match to a request
             _ => (),
         }

--- a/src/flatbuffers/containers/hash_index.rs
+++ b/src/flatbuffers/containers/hash_index.rs
@@ -188,7 +188,7 @@ impl<I: HashKey, V: Default + Clone> HashIndexBuilder<I, V> {
         self.indexes = vec![I::default(); new_capacity];
         self.values = vec![V::default(); new_capacity];
 
-        for (key, value) in old_indexes.into_iter().zip(old_values.into_iter()) {
+        for (key, value) in old_indexes.into_iter().zip(old_values) {
             if !HashKey::is_empty(&key) {
                 let slot = find_slot(&key, new_capacity, |slot| -> bool {
                     HashKey::is_empty(&self.indexes[slot])


### PR DESCRIPTION
the PR bumps Rust from 1.94 to 1.95 and fixes the related clippy issues.