### PR TITLE
Fix criterion assert

### DIFF
--- a/benches/bench_memory.rs
+++ b/benches/bench_memory.rs
@@ -297,6 +297,7 @@ fn current_memory_usage_config() -> Criterion<MemoryAllocated> {
         .sample_size(10)
         .measurement_time(std::time::Duration::from_secs(1))
         .with_measurement(MemoryAllocated::Current)
+        .without_plots()
 }
 
 fn max_memory_usage_config() -> Criterion<MemoryAllocated> {
@@ -304,6 +305,7 @@ fn max_memory_usage_config() -> Criterion<MemoryAllocated> {
         .sample_size(10)
         .measurement_time(std::time::Duration::from_secs(1))
         .with_measurement(MemoryAllocated::Max)
+        .without_plots()
 }
 
 fn allocations_count_config() -> Criterion<MemoryAllocated> {
@@ -311,6 +313,7 @@ fn allocations_count_config() -> Criterion<MemoryAllocated> {
         .sample_size(10)
         .measurement_time(std::time::Duration::from_secs(1))
         .with_measurement(MemoryAllocated::AllocCount)
+        .without_plots()
 }
 
 criterion_group!(name = current_memory_usage_benches; config = current_memory_usage_config(); targets = bench_current_memory_usage);


### PR DESCRIPTION
```
hread 'main' (6805195) panicked at /Users/mikhail/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/criterion-0.8.2/src/kde.rs:10:66:
index out of bounds: the len is 0 but the index is 0
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::panicking::panic_bounds_check
   3: criterion::plot::plotters_backend::t_test::t_test
   4: <criterion::plot::plotters_backend::PlottersBackend as criterion::plot::Plotter>::t_test
   5: <criterion::html::Html as criterion::report::Report>::measurement_complete
   6: criterion::analysis::common
   7: criterion::benchmark_group::BenchmarkGroup<M>::bench_function
   8: bench_memory::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```