### PR TITLE
refactor: drop redundant intermediate allocations

### DIFF
--- a/js/src/lib.rs
+++ b/js/src/lib.rs
@@ -248,7 +248,7 @@ fn engine_url_cosmetic_resources(mut cx: FunctionContext) -> JsResult<JsValue> {
 fn engine_serialize(mut cx: FunctionContext) -> JsResult<JsArrayBuffer> {
     let this = cx.argument::<JsBox<Engine>>(0)?;
     let serialized = if let Ok(engine) = this.0.lock() {
-        engine.serialize().to_vec()
+        engine.serialize()
     } else {
         cx.throw_error("Failed to acquire lock on engine")?
     };

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -364,7 +364,7 @@ impl Blocker {
                     params
                         .into_iter()
                         .filter(|(_, include)| *include)
-                        .map(|(param, _)| param.to_string()),
+                        .map(|(param, _)| param),
                     "&",
                 );
                 let new_param_str = if p.is_empty() {

--- a/src/cosmetic_filter_utils.rs
+++ b/src/cosmetic_filter_utils.rs
@@ -52,7 +52,7 @@ pub(crate) fn key_from_selector(selector: &str) -> Option<String> {
                 let codepoint = u32::from_str_radix(&capture[..capture.len() - 1], 16).ok()?;
 
                 // Not all u32s are valid Unicode codepoints
-                key += &core::char::from_u32(codepoint)?.to_string();
+                key.push(core::char::from_u32(codepoint)?);
             }
         }
         Some(key + &escaped[beginning..])


### PR DESCRIPTION
## Summary
  Remove unnecessary heap allocations in three independent locations. The most impactful is `engine_serialize`, which was cloning the entire serialized payload before handing it to the JS layer; the other two eliminate redundant intermediate `String`s on code paths that are correct without them.

### `src/blocker.rs` 
Pass `QParam` directly to `itertools::join` instead of mapping through `.to_string()`. `QParam` already implements `Display`, and `itertools::join` formats elements via `Display`, so the per-parameter intermediate `String` was unnecessary. Saves one allocation per query parameter on every removeparam URL rewrite.

### `src/cosmetic_filter_utils.rs`
Replace `key += &char.to_string()` with `key.push(char)` when appending a decoded `\XXXX` escape codepoint. `String::push` writes the char's UTF-8 bytes directly into the existing buffer, removing the per-escape-sequence `String` allocation.

### `js/src/lib.rs` 
`Engine::serialize()` already returns an owned `Vec<u8>` (see `src/engine.rs` and `serialize_dat_file` in `src/data_format/mod.rs`, which builds a fresh `Vec` to prepend the magic+hash header). The extra `.to_vec()` was producing a full duplicate of the entire serialized engine. Remove it and let `JsArrayBuffer::copy_from_slice` do the only required copy (Rust heap → JS heap). The `MutexGuard` is still released at the end of the `if let` arm; this is safe because the returned `Vec<u8>` owns its data.