### PR TITLE
New API for FilterSet & Engine

### DIFF
--- a/benches/bench_cosmetic_matching.rs
+++ b/benches/bench_cosmetic_matching.rs
@@ -7,10 +7,10 @@ mod test_utils;
 pub fn make_engine() -> Engine {
     use adblock::resources::Resource;
 
-    let rules = test_utils::rules_from_lists(&["data/brave/brave-main-list.txt"]);
+    let rules = test_utils::rules_from_lists(["data/brave/brave-main-list.txt"]);
     let resource_json = std::fs::read_to_string("data/brave/brave-resources.json").unwrap();
     let resource_list: Vec<Resource> = serde_json::from_str(&resource_json).unwrap();
-    let mut engine = Engine::from_rules_parametrised(rules, Default::default(), true, true);
+    let mut engine = Engine::from_text_parametrised(rules, Default::default(), true, true);
     engine.use_resources(resource_list);
     engine
 }

--- a/benches/bench_cosmetic_matching.rs
+++ b/benches/bench_cosmetic_matching.rs
@@ -10,7 +10,7 @@ pub fn make_engine() -> Engine {
     let rules = test_utils::rules_from_lists(["data/brave/brave-main-list.txt"]);
     let resource_json = std::fs::read_to_string("data/brave/brave-resources.json").unwrap();
     let resource_list: Vec<Resource> = serde_json::from_str(&resource_json).unwrap();
-    let mut engine = Engine::from_text_parametrised(rules, Default::default(), true, true);
+    let mut engine = Engine::new_with_list_text_parametrised(rules, Default::default(), true, true);
     engine.use_resources(resource_list);
     engine
 }

--- a/benches/bench_matching.rs
+++ b/benches/bench_matching.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use adblock::request::Request;
 use adblock::url_parser::parse_url;
-use adblock::{Engine, FilterSet};
+use adblock::Engine;
 
 #[path = "../tests/test_utils.rs"]
 mod test_utils;
@@ -25,23 +25,13 @@ impl From<&TestRequest> for Request {
 }
 
 fn load_requests() -> Vec<TestRequest> {
-    let requests_str = rules_from_lists(&["data/requests.json"]);
+    let requests_str = rules_from_lists(["data/requests.json"]);
     let reqs: Vec<TestRequest> = requests_str
-        .into_iter()
-        .map(|r| serde_json::from_str(&r))
+        .lines()
+        .map(serde_json::from_str)
         .filter_map(Result::ok)
         .collect();
     reqs
-}
-
-fn get_engine(rules: impl IntoIterator<Item = impl AsRef<str>>) -> Engine {
-    let (network_filters, cosmetic_filters) =
-        adblock::lists::parse_filters(rules, false, Default::default());
-
-    Engine::from_filter_set(
-        FilterSet::new_with_rules(network_filters, cosmetic_filters, false),
-        true,
-    )
 }
 
 fn bench_rule_matching(engine: &Engine, requests: &[TestRequest]) -> (u32, u32) {
@@ -112,21 +102,21 @@ fn rule_match(c: &mut Criterion) {
     group.sample_size(10);
 
     group.bench_function("el+ep", move |b| {
-        let rules = rules_from_lists(&[
+        let rules = rules_from_lists([
             "data/easylist.to/easylist/easylist.txt",
             "data/easylist.to/easylist/easyprivacy.txt",
         ]);
-        let engine = Engine::from_rules(rules, Default::default());
+        let engine = Engine::from_text(rules, Default::default());
         b.iter(|| bench_rule_matching(&engine, &elep_req))
     });
     group.bench_function("easylist", move |b| {
-        let rules = rules_from_lists(&["data/easylist.to/easylist/easylist.txt"]);
-        let engine = Engine::from_rules(rules, Default::default());
+        let rules = rules_from_lists(["data/easylist.to/easylist/easylist.txt"]);
+        let engine = Engine::from_text(rules, Default::default());
         b.iter(|| bench_rule_matching(&engine, &el_req))
     });
     group.bench_function("slimlist", move |b| {
-        let rules = rules_from_lists(&["data/slim-list.txt"]);
-        let engine = Engine::from_rules(rules, Default::default());
+        let rules = rules_from_lists(["data/slim-list.txt"]);
+        let engine = Engine::from_text(rules, Default::default());
         b.iter(|| bench_rule_matching(&engine, &slim_req))
     });
 
@@ -136,7 +126,7 @@ fn rule_match(c: &mut Criterion) {
 fn rule_match_parsed_el(c: &mut Criterion) {
     let mut group = c.benchmark_group("rule-match-parsed");
 
-    let rules = rules_from_lists(&["data/easylist.to/easylist/easylist.txt"]);
+    let rules = rules_from_lists(["data/easylist.to/easylist/easylist.txt"]);
     let requests = load_requests();
     let requests_parsed: Vec<_> = requests
         .into_iter()
@@ -144,7 +134,7 @@ fn rule_match_parsed_el(c: &mut Criterion) {
         .filter_map(Result::ok)
         .collect();
     let requests_len = requests_parsed.len() as u64;
-    let engine = get_engine(rules);
+    let engine = Engine::from_text(rules, Default::default());
 
     group.throughput(Throughput::Elements(requests_len));
     group.sample_size(10);
@@ -159,11 +149,11 @@ fn rule_match_parsed_el(c: &mut Criterion) {
 fn rule_match_parsed_elep_slimlist(c: &mut Criterion) {
     let mut group = c.benchmark_group("rule-match-parsed");
 
-    let full_rules = rules_from_lists(&[
+    let full_rules = rules_from_lists([
         "data/easylist.to/easylist/easylist.txt",
         "data/easylist.to/easylist/easyprivacy.txt",
     ]);
-    let engine = get_engine(full_rules);
+    let engine = Engine::from_text(full_rules, Default::default());
 
     let requests = load_requests();
     let requests_parsed: Vec<_> = requests
@@ -173,8 +163,8 @@ fn rule_match_parsed_elep_slimlist(c: &mut Criterion) {
         .collect();
     let requests_len = requests_parsed.len() as u64;
 
-    let slim_rules = rules_from_lists(&["data/slim-list.txt"]);
-    let slim_engine = get_engine(slim_rules);
+    let slim_rules = rules_from_lists(["data/slim-list.txt"]);
+    let slim_engine = Engine::from_text(slim_rules, Default::default());
 
     let requests_copy = load_requests();
     let requests_parsed_copy: Vec<_> = requests_copy
@@ -245,26 +235,26 @@ fn rule_match_browserlike_comparable(c: &mut Criterion) {
     let requests = requests_parsed(&requests);
 
     group.bench_function("el+ep", |b| {
-        let rules = rules_from_lists(&[
+        let rules = rules_from_lists([
             "data/easylist.to/easylist/easylist.txt",
             "data/easylist.to/easylist/easyprivacy.txt",
         ]);
-        let engine = Engine::from_rules_parametrised(rules, Default::default(), false, true);
+        let engine = Engine::from_text_parametrised(rules, Default::default(), false, true);
         b.iter(|| bench_rule_matching_browserlike(&engine, &requests))
     });
     group.bench_function("el", |b| {
-        let rules = rules_from_lists(&["data/easylist.to/easylist/easylist.txt"]);
-        let engine = Engine::from_rules_parametrised(rules, Default::default(), false, true);
+        let rules = rules_from_lists(["data/easylist.to/easylist/easylist.txt"]);
+        let engine = Engine::from_text_parametrised(rules, Default::default(), false, true);
         b.iter(|| bench_rule_matching_browserlike(&engine, &requests))
     });
     group.bench_function("slimlist", |b| {
-        let rules = rules_from_lists(&["data/slim-list.txt"]);
-        let engine = Engine::from_rules_parametrised(rules, Default::default(), false, true);
+        let rules = rules_from_lists(["data/slim-list.txt"]);
+        let engine = Engine::from_text_parametrised(rules, Default::default(), false, true);
         b.iter(|| bench_rule_matching_browserlike(&engine, &requests))
     });
     group.bench_function("brave-list", |b| {
-        let rules = rules_from_lists(&["data/brave/brave-main-list.txt"]);
-        let engine = Engine::from_rules_parametrised(rules, Default::default(), false, true);
+        let rules = rules_from_lists(["data/brave/brave-main-list.txt"]);
+        let engine = Engine::from_text_parametrised(rules, Default::default(), false, true);
         b.iter(|| bench_rule_matching_browserlike(&engine, &requests))
     });
 
@@ -288,9 +278,8 @@ fn rule_match_first_request(c: &mut Criterion) {
         b.iter_custom(|iters| {
             let mut total_time = std::time::Duration::ZERO;
             for _ in 0..iters {
-                let rules = rules_from_lists(&["data/brave/brave-main-list.txt"]);
-                let engine =
-                    Engine::from_rules_parametrised(rules, Default::default(), false, true);
+                let rules = rules_from_lists(["data/brave/brave-main-list.txt"]);
+                let engine = Engine::from_text_parametrised(rules, Default::default(), false, true);
 
                 // Measure only the matching time, skip setup and destruction
                 let start_time = std::time::Instant::now();

--- a/benches/bench_matching.rs
+++ b/benches/bench_matching.rs
@@ -106,17 +106,17 @@ fn rule_match(c: &mut Criterion) {
             "data/easylist.to/easylist/easylist.txt",
             "data/easylist.to/easylist/easyprivacy.txt",
         ]);
-        let engine = Engine::from_text(rules, Default::default());
+        let engine = Engine::new_with_list_text(rules, Default::default());
         b.iter(|| bench_rule_matching(&engine, &elep_req))
     });
     group.bench_function("easylist", move |b| {
         let rules = rules_from_lists(["data/easylist.to/easylist/easylist.txt"]);
-        let engine = Engine::from_text(rules, Default::default());
+        let engine = Engine::new_with_list_text(rules, Default::default());
         b.iter(|| bench_rule_matching(&engine, &el_req))
     });
     group.bench_function("slimlist", move |b| {
         let rules = rules_from_lists(["data/slim-list.txt"]);
-        let engine = Engine::from_text(rules, Default::default());
+        let engine = Engine::new_with_list_text(rules, Default::default());
         b.iter(|| bench_rule_matching(&engine, &slim_req))
     });
 
@@ -134,7 +134,7 @@ fn rule_match_parsed_el(c: &mut Criterion) {
         .filter_map(Result::ok)
         .collect();
     let requests_len = requests_parsed.len() as u64;
-    let engine = Engine::from_text(rules, Default::default());
+    let engine = Engine::new_with_list_text(rules, Default::default());
 
     group.throughput(Throughput::Elements(requests_len));
     group.sample_size(10);
@@ -153,7 +153,7 @@ fn rule_match_parsed_elep_slimlist(c: &mut Criterion) {
         "data/easylist.to/easylist/easylist.txt",
         "data/easylist.to/easylist/easyprivacy.txt",
     ]);
-    let engine = Engine::from_text(full_rules, Default::default());
+    let engine = Engine::new_with_list_text(full_rules, Default::default());
 
     let requests = load_requests();
     let requests_parsed: Vec<_> = requests
@@ -164,7 +164,7 @@ fn rule_match_parsed_elep_slimlist(c: &mut Criterion) {
     let requests_len = requests_parsed.len() as u64;
 
     let slim_rules = rules_from_lists(["data/slim-list.txt"]);
-    let slim_engine = Engine::from_text(slim_rules, Default::default());
+    let slim_engine = Engine::new_with_list_text(slim_rules, Default::default());
 
     let requests_copy = load_requests();
     let requests_parsed_copy: Vec<_> = requests_copy
@@ -239,22 +239,26 @@ fn rule_match_browserlike_comparable(c: &mut Criterion) {
             "data/easylist.to/easylist/easylist.txt",
             "data/easylist.to/easylist/easyprivacy.txt",
         ]);
-        let engine = Engine::from_text_parametrised(rules, Default::default(), false, true);
+        let engine =
+            Engine::new_with_list_text_parametrised(rules, Default::default(), false, true);
         b.iter(|| bench_rule_matching_browserlike(&engine, &requests))
     });
     group.bench_function("el", |b| {
         let rules = rules_from_lists(["data/easylist.to/easylist/easylist.txt"]);
-        let engine = Engine::from_text_parametrised(rules, Default::default(), false, true);
+        let engine =
+            Engine::new_with_list_text_parametrised(rules, Default::default(), false, true);
         b.iter(|| bench_rule_matching_browserlike(&engine, &requests))
     });
     group.bench_function("slimlist", |b| {
         let rules = rules_from_lists(["data/slim-list.txt"]);
-        let engine = Engine::from_text_parametrised(rules, Default::default(), false, true);
+        let engine =
+            Engine::new_with_list_text_parametrised(rules, Default::default(), false, true);
         b.iter(|| bench_rule_matching_browserlike(&engine, &requests))
     });
     group.bench_function("brave-list", |b| {
         let rules = rules_from_lists(["data/brave/brave-main-list.txt"]);
-        let engine = Engine::from_text_parametrised(rules, Default::default(), false, true);
+        let engine =
+            Engine::new_with_list_text_parametrised(rules, Default::default(), false, true);
         b.iter(|| bench_rule_matching_browserlike(&engine, &requests))
     });
 
@@ -279,7 +283,8 @@ fn rule_match_first_request(c: &mut Criterion) {
             let mut total_time = std::time::Duration::ZERO;
             for _ in 0..iters {
                 let rules = rules_from_lists(["data/brave/brave-main-list.txt"]);
-                let engine = Engine::from_text_parametrised(rules, Default::default(), false, true);
+                let engine =
+                    Engine::new_with_list_text_parametrised(rules, Default::default(), false, true);
 
                 // Measure only the matching time, skip setup and destruction
                 let start_time = std::time::Instant::now();

--- a/benches/bench_memory.rs
+++ b/benches/bench_memory.rs
@@ -148,7 +148,7 @@ fn bench_memory_usage(c: &mut Criterion) {
             for _ in 0..iters {
                 ALLOCATOR.reset();
                 let rules = rules_from_lists(["data/brave/brave-main-list.txt"]);
-                let mut engine = Engine::from_text(rules, Default::default());
+                let mut engine = Engine::new_with_list_text(rules, Default::default());
                 let resource_json =
                     std::fs::read_to_string("data/brave/brave-resources.json").unwrap();
                 let resource_list: Vec<Resource> = serde_json::from_str(&resource_json).unwrap();

--- a/benches/bench_memory.rs
+++ b/benches/bench_memory.rs
@@ -124,10 +124,10 @@ impl From<&TestRequest> for Request {
 }
 
 fn load_requests() -> Vec<TestRequest> {
-    let requests_str = rules_from_lists(&["data/requests.json"]);
+    let requests_str = rules_from_lists(["data/requests.json"]);
     let reqs: Vec<TestRequest> = requests_str
-        .into_iter()
-        .map(|r| serde_json::from_str(&r))
+        .lines()
+        .map(serde_json::from_str)
         .filter_map(Result::ok)
         .collect();
     reqs
@@ -147,8 +147,8 @@ fn bench_memory_usage(c: &mut Criterion) {
         b.iter_custom(|iters| {
             for _ in 0..iters {
                 ALLOCATOR.reset();
-                let rules = rules_from_lists(&["data/brave/brave-main-list.txt"]);
-                let mut engine = Engine::from_rules(rules, Default::default());
+                let rules = rules_from_lists(["data/brave/brave-main-list.txt"]);
+                let mut engine = Engine::from_text(rules, Default::default());
                 let resource_json =
                     std::fs::read_to_string("data/brave/brave-resources.json").unwrap();
                 let resource_list: Vec<Resource> = serde_json::from_str(&resource_json).unwrap();

--- a/benches/bench_redirect_performance.rs
+++ b/benches/bench_redirect_performance.rs
@@ -1,4 +1,4 @@
-use adblock::{Engine, FilterSet};
+use adblock::Engine;
 use criterion::*;
 use tokio::runtime::Runtime;
 
@@ -86,8 +86,7 @@ fn get_redirect_rules() -> Vec<NetworkFilter> {
 
 /// Loads the supplied rules, and the test set of resources, into a Engine
 fn get_preloaded_engine(rules: Vec<NetworkFilter>) -> Engine {
-    let filter_set = FilterSet::new_with_rules(rules, vec![], false);
-    Engine::from_filter_set(filter_set, true /* optimize */)
+    Engine::new_with_parsed_rules(rules, vec![], true)
 }
 
 fn get_resources_for_filters(#[allow(unused)] filters: &[NetworkFilter]) -> Vec<Resource> {

--- a/benches/bench_rules.rs
+++ b/benches/bench_rules.rs
@@ -84,14 +84,14 @@ fn blocker_new(c: &mut Criterion) {
         "data/easylist.to/easylist/easyprivacy.txt",
     ]);
     let brave_list_rules = rules_from_lists(["data/brave/brave-main-list.txt"]);
-    let engine = Engine::from_text(brave_list_rules.clone(), Default::default());
+    let engine = Engine::new_with_list_text(brave_list_rules.clone(), Default::default());
     let engine_serialized = engine.serialize().to_vec();
 
     group.bench_function("el+ep", move |b| {
-        b.iter(|| Engine::from_text(easylist_rules.clone(), Default::default()))
+        b.iter(|| Engine::new_with_list_text(easylist_rules.clone(), Default::default()))
     });
     group.bench_function("brave-list", move |b| {
-        b.iter(|| Engine::from_text(brave_list_rules.clone(), Default::default()))
+        b.iter(|| Engine::new_with_list_text(brave_list_rules.clone(), Default::default()))
     });
     group.bench_function("brave-list-deserialize", move |b| {
         b.iter(|| {

--- a/benches/bench_rules.rs
+++ b/benches/bench_rules.rs
@@ -1,26 +1,26 @@
 use criterion::*;
 use std::sync::LazyLock;
 
-use adblock::{Engine, FilterSet};
+use adblock::Engine;
 
 #[path = "../tests/test_utils.rs"]
 mod test_utils;
 use test_utils::rules_from_lists;
 
-static DEFAULT_LISTS: LazyLock<Vec<String>> =
-    LazyLock::new(|| rules_from_lists(&["data/easylist.to/easylist/easylist.txt"]).collect());
+static DEFAULT_LISTS: LazyLock<String> =
+    LazyLock::new(|| rules_from_lists(["data/easylist.to/easylist/easylist.txt"]));
 
-fn bench_string_hashing(filters: &Vec<String>) -> adblock::utils::Hash {
+fn bench_string_hashing(filters: &str) -> adblock::utils::Hash {
     let mut dummy: adblock::utils::Hash = 0;
-    for filter in filters {
+    for filter in filters.lines() {
         dummy = (dummy + adblock::utils::fast_hash(filter)) % 1000000000;
     }
     dummy
 }
 
-fn bench_string_tokenize(filters: &Vec<String>) -> usize {
+fn bench_string_tokenize(filters: &str) -> usize {
     let mut dummy: usize = 0;
-    for filter in filters {
+    for filter in filters.lines() {
         dummy = (dummy + adblock::utils::tokenize(filter).len()) % 1000000000;
     }
     dummy
@@ -50,15 +50,10 @@ fn string_tokenize(c: &mut Criterion) {
     group.finish();
 }
 
-fn bench_parsing_impl(lists: &Vec<&Vec<String>>) -> usize {
-    let mut dummy = 0;
-
-    for list in lists {
-        let (network_filters, _) = adblock::lists::parse_filters(*list, false, Default::default());
-        dummy += network_filters.len() % 1000000;
-    }
-
-    dummy
+fn bench_parsing_impl(lists: &str) -> usize {
+    let (network_filters, _) =
+        adblock::lists::parse_filters(lists.lines(), false, Default::default());
+    network_filters.len() % 1000000
 }
 
 fn list_parse(c: &mut Criterion) {
@@ -68,24 +63,14 @@ fn list_parse(c: &mut Criterion) {
     group.sample_size(10);
 
     group.bench_function("network filters", |b| {
-        b.iter(|| bench_parsing_impl(&vec![DEFAULT_LISTS.as_ref()]))
+        b.iter(|| bench_parsing_impl(&DEFAULT_LISTS))
     });
 
     group.bench_function("all filters", |b| {
-        b.iter(|| bench_parsing_impl(&vec![DEFAULT_LISTS.as_ref()]))
+        b.iter(|| bench_parsing_impl(&DEFAULT_LISTS))
     });
 
     group.finish();
-}
-
-fn get_engine(rules: impl IntoIterator<Item = impl AsRef<str>>) -> Engine {
-    let (network_filters, cosmetic_filters) =
-        adblock::lists::parse_filters(rules, false, Default::default());
-
-    Engine::from_filter_set(
-        FilterSet::new_with_rules(network_filters, cosmetic_filters, false),
-        true,
-    )
 }
 
 fn blocker_new(c: &mut Criterion) {
@@ -94,18 +79,19 @@ fn blocker_new(c: &mut Criterion) {
     group.throughput(Throughput::Elements(1));
     group.sample_size(10);
 
-    let easylist_rules: Vec<_> = rules_from_lists(&[
+    let easylist_rules = rules_from_lists([
         "data/easylist.to/easylist/easylist.txt",
         "data/easylist.to/easylist/easyprivacy.txt",
-    ])
-    .collect();
-    let brave_list_rules: Vec<_> = rules_from_lists(&["data/brave/brave-main-list.txt"]).collect();
-    let engine = Engine::from_rules(&brave_list_rules, Default::default());
+    ]);
+    let brave_list_rules = rules_from_lists(["data/brave/brave-main-list.txt"]);
+    let engine = Engine::from_text(brave_list_rules.clone(), Default::default());
     let engine_serialized = engine.serialize().to_vec();
 
-    group.bench_function("el+ep", move |b| b.iter(|| get_engine(&easylist_rules)));
+    group.bench_function("el+ep", move |b| {
+        b.iter(|| Engine::from_text(easylist_rules.clone(), Default::default()))
+    });
     group.bench_function("brave-list", move |b| {
-        b.iter(|| get_engine(&brave_list_rules))
+        b.iter(|| Engine::from_text(brave_list_rules.clone(), Default::default()))
     });
     group.bench_function("brave-list-deserialize", move |b| {
         b.iter(|| {

--- a/benches/bench_serialization.rs
+++ b/benches/bench_serialization.rs
@@ -12,24 +12,24 @@ fn serialization(c: &mut Criterion) {
     group.sample_size(20);
 
     group.bench_function("el+ep", move |b| {
-        let full_rules = rules_from_lists(&[
+        let full_rules = rules_from_lists([
             "data/easylist.to/easylist/easylist.txt",
             "data/easylist.to/easylist/easyprivacy.txt",
         ]);
 
-        let engine = Engine::from_rules(full_rules, Default::default());
+        let engine = Engine::from_text(full_rules, Default::default());
         b.iter(|| assert!(!engine.serialize().to_vec().is_empty()))
     });
     group.bench_function("el", move |b| {
-        let full_rules = rules_from_lists(&["data/easylist.to/easylist/easylist.txt"]);
+        let full_rules = rules_from_lists(["data/easylist.to/easylist/easylist.txt"]);
 
-        let engine = Engine::from_rules(full_rules, Default::default());
+        let engine = Engine::from_text(full_rules, Default::default());
         b.iter(|| assert!(!engine.serialize().to_vec().is_empty()))
     });
     group.bench_function("slimlist", move |b| {
-        let full_rules = rules_from_lists(&["data/slim-list.txt"]);
+        let full_rules = rules_from_lists(["data/slim-list.txt"]);
 
-        let engine = Engine::from_rules(full_rules, Default::default());
+        let engine = Engine::from_text(full_rules, Default::default());
         b.iter(|| assert!(!engine.serialize().to_vec().is_empty()))
     });
 
@@ -42,12 +42,12 @@ fn deserialization(c: &mut Criterion) {
     group.sample_size(20);
 
     group.bench_function("el+ep", move |b| {
-        let full_rules = rules_from_lists(&[
+        let full_rules = rules_from_lists([
             "data/easylist.to/easylist/easylist.txt",
             "data/easylist.to/easylist/easyprivacy.txt",
         ]);
 
-        let engine = Engine::from_rules(full_rules, Default::default());
+        let engine = Engine::from_text(full_rules, Default::default());
         let serialized = engine.serialize().to_vec();
 
         b.iter(|| {
@@ -56,9 +56,9 @@ fn deserialization(c: &mut Criterion) {
         })
     });
     group.bench_function("el", move |b| {
-        let full_rules = rules_from_lists(&["data/easylist.to/easylist/easylist.txt"]);
+        let full_rules = rules_from_lists(["data/easylist.to/easylist/easylist.txt"]);
 
-        let engine = Engine::from_rules(full_rules, Default::default());
+        let engine = Engine::from_text(full_rules, Default::default());
         let serialized = engine.serialize().to_vec();
 
         b.iter(|| {
@@ -67,9 +67,9 @@ fn deserialization(c: &mut Criterion) {
         })
     });
     group.bench_function("slimlist", move |b| {
-        let full_rules = rules_from_lists(&["data/slim-list.txt"]);
+        let full_rules = rules_from_lists(["data/slim-list.txt"]);
 
-        let engine = Engine::from_rules(full_rules, Default::default());
+        let engine = Engine::from_text(full_rules, Default::default());
         let serialized = engine.serialize().to_vec();
 
         b.iter(|| {

--- a/benches/bench_serialization.rs
+++ b/benches/bench_serialization.rs
@@ -17,19 +17,19 @@ fn serialization(c: &mut Criterion) {
             "data/easylist.to/easylist/easyprivacy.txt",
         ]);
 
-        let engine = Engine::from_text(full_rules, Default::default());
+        let engine = Engine::new_with_list_text(full_rules, Default::default());
         b.iter(|| assert!(!engine.serialize().to_vec().is_empty()))
     });
     group.bench_function("el", move |b| {
         let full_rules = rules_from_lists(["data/easylist.to/easylist/easylist.txt"]);
 
-        let engine = Engine::from_text(full_rules, Default::default());
+        let engine = Engine::new_with_list_text(full_rules, Default::default());
         b.iter(|| assert!(!engine.serialize().to_vec().is_empty()))
     });
     group.bench_function("slimlist", move |b| {
         let full_rules = rules_from_lists(["data/slim-list.txt"]);
 
-        let engine = Engine::from_text(full_rules, Default::default());
+        let engine = Engine::new_with_list_text(full_rules, Default::default());
         b.iter(|| assert!(!engine.serialize().to_vec().is_empty()))
     });
 
@@ -47,7 +47,7 @@ fn deserialization(c: &mut Criterion) {
             "data/easylist.to/easylist/easyprivacy.txt",
         ]);
 
-        let engine = Engine::from_text(full_rules, Default::default());
+        let engine = Engine::new_with_list_text(full_rules, Default::default());
         let serialized = engine.serialize().to_vec();
 
         b.iter(|| {
@@ -58,7 +58,7 @@ fn deserialization(c: &mut Criterion) {
     group.bench_function("el", move |b| {
         let full_rules = rules_from_lists(["data/easylist.to/easylist/easylist.txt"]);
 
-        let engine = Engine::from_text(full_rules, Default::default());
+        let engine = Engine::new_with_list_text(full_rules, Default::default());
         let serialized = engine.serialize().to_vec();
 
         b.iter(|| {
@@ -69,7 +69,7 @@ fn deserialization(c: &mut Criterion) {
     group.bench_function("slimlist", move |b| {
         let full_rules = rules_from_lists(["data/slim-list.txt"]);
 
-        let engine = Engine::from_text(full_rules, Default::default());
+        let engine = Engine::new_with_list_text(full_rules, Default::default());
         let serialized = engine.serialize().to_vec();
 
         b.iter(|| {

--- a/benches/bench_url.rs
+++ b/benches/bench_url.rs
@@ -18,8 +18,9 @@ struct TestRequest {
 }
 
 fn load_requests() -> Vec<TestRequest> {
-    rules_from_lists(&["data/requests.json"])
-        .map(|r| serde_json::from_str(&r))
+    rules_from_lists(["data/requests.json"])
+        .lines()
+        .map(serde_json::from_str)
         .filter_map(Result::ok)
         .collect::<Vec<_>>()
 }

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -5,16 +5,17 @@ use adblock::{
 };
 
 fn main() {
-    let rules = vec![
-        String::from("-advertisement-icon."),
-        String::from("-advertisement-management/"),
-        String::from("-advertisement."),
-        String::from("-advertisement/script."),
-    ];
+    let rules = [
+        "-advertisement-icon.",
+        "-advertisement-management/",
+        "-advertisement.",
+        "-advertisement/script.",
+    ]
+    .join("\n");
 
     let debug_info = true;
     let mut filter_set = FilterSet::new(debug_info);
-    filter_set.add_filters(&rules, ParseOptions::default());
+    filter_set.add_filter_list(rules, ParseOptions::default());
 
     let engine = Engine::from_filter_set(filter_set, true);
 

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -17,7 +17,7 @@ fn main() {
     let mut filter_set = FilterSet::new(debug_info);
     filter_set.add_filter_list(rules, ParseOptions::default());
 
-    let engine = Engine::from_filter_set(filter_set, true);
+    let engine = Engine::new_with_filter_set(filter_set, true);
 
     let request = Request::new(
         "http://example.com/-advertisement-icon.",

--- a/examples/generate-dat.rs
+++ b/examples/generate-dat.rs
@@ -5,13 +5,14 @@ use std::io::prelude::*;
 
 fn main() {
     // Rules we want to serialize
-    let rules = vec![
+    let rules = [
         String::from("||platform.twitter.com/$tag=twitter-embeds"),
         String::from("@@||platform.twitter.com/$tag=twitter-embeds"),
-    ];
+    ]
+    .join("\n");
 
     // Serialize
-    let mut engine = Engine::from_rules_debug(&rules, Default::default());
+    let mut engine = Engine::from_text(rules, Default::default());
     engine.use_tags(&["twitter-embeds"]);
 
     let request = Request::new(

--- a/examples/generate-dat.rs
+++ b/examples/generate-dat.rs
@@ -12,7 +12,7 @@ fn main() {
     .join("\n");
 
     // Serialize
-    let mut engine = Engine::from_text(rules, Default::default());
+    let mut engine = Engine::new_with_list_text(rules, Default::default());
     engine.use_tags(&["twitter-embeds"]);
 
     let request = Request::new(

--- a/js/example.mjs
+++ b/js/example.mjs
@@ -8,13 +8,13 @@ const filterSet = new adblockRust.FilterSet(debugInfo);
 const easylistFilters = fs.readFileSync(
     dataPath + 'easylist.to/easylist/easylist.txt',
     { encoding: 'utf-8' },
-).split('\n');
+);
 filterSet.addFilters(easylistFilters);
 
 const uboUnbreakFilters = fs.readFileSync(
     dataPath + 'uBlockOrigin/unbreak.txt',
     { encoding: 'utf-8' },
-).split('\n');
+);
 filterSet.addFilters(uboUnbreakFilters);
 
 const resources = adblockRust.uBlockResources(

--- a/js/index.js
+++ b/js/index.js
@@ -15,7 +15,7 @@ class FilterSet {
         this.boxed = blocker.FilterSet_constructor(...args);
     }
 }
-forwardClassMethods(FilterSet, ['addFilters', 'addFilter', 'intoContentBlocking']);
+forwardClassMethods(FilterSet, ['addFilters', 'intoContentBlocking']);
 
 class Engine {
     constructor(filter_set, ...args) {

--- a/js/src/lib.rs
+++ b/js/src/lib.rs
@@ -51,6 +51,31 @@ mod json_ffi {
     }
 }
 
+fn console_warn<'a, C: Context<'a>>(cx: &mut C, message: &str) -> NeonResult<()> {
+    let console: Handle<JsObject> = cx.global().get(cx, "console")?;
+    let warn: Handle<JsFunction> = console.get(cx, "warn")?;
+    let msg = JsString::new(cx, message).upcast::<JsValue>();
+    warn.call(cx, console, [msg])?;
+    Ok(())
+}
+
+/// Accepts a single filter list string, or a deprecated array of list strings (joined with `\n`).
+fn filter_rules_from_js<'a, C: Context<'a>>(
+    cx: &mut C,
+    input: Handle<JsValue>,
+) -> NeonResult<String> {
+    if input.downcast::<JsArray, _>(cx).is_ok() {
+        console_warn(
+            cx,
+            "FilterSet.addFilters: passing an array of strings is deprecated; \
+             pass a single newline-separated filter list string instead.",
+        )?;
+        let parts: Vec<String> = json_ffi::from_js(cx, input)?;
+        return Ok(parts.join("\n"));
+    }
+    json_ffi::from_js(cx, input)
+}
+
 #[derive(Serialize, Deserialize)]
 struct EngineOptions {
     pub optimize: Option<bool>,
@@ -91,7 +116,6 @@ fn create_filter_set(mut cx: FunctionContext) -> JsResult<JsBox<FilterSet>> {
 fn filter_set_add_filters(mut cx: FunctionContext) -> JsResult<JsValue> {
     let this = cx.argument::<JsBox<FilterSet>>(0)?;
 
-    // Take the first argument, which must be an array
     let rules_handle: Handle<JsValue> = cx.argument(1)?;
     // Second argument is optional parse options. All fields are optional. ParseOptions::default()
     // if unspecified.
@@ -100,7 +124,7 @@ fn filter_set_add_filters(mut cx: FunctionContext) -> JsResult<JsValue> {
         None => ParseOptions::default(),
     };
 
-    let rules: String = json_ffi::from_js(&mut cx, rules_handle)?;
+    let rules: String = filter_rules_from_js(&mut cx, rules_handle)?;
 
     let metadata = this.add_filters(rules, parse_opts);
 

--- a/js/src/lib.rs
+++ b/js/src/lib.rs
@@ -149,9 +149,9 @@ fn engine_constructor(mut cx: FunctionContext) -> JsResult<JsBox<Engine>> {
                     config.optimize.unwrap_or(true)
                 }
             };
-            EngineInternal::from_filter_set(rules, optimize)
+            EngineInternal::new_with_filter_set(rules, optimize)
         }
-        None => EngineInternal::from_filter_set(rules, true),
+        None => EngineInternal::new_with_filter_set(rules, true),
     };
     Ok(cx.boxed(Engine(Mutex::new(engine_internal))))
 }

--- a/js/src/lib.rs
+++ b/js/src/lib.rs
@@ -87,7 +87,7 @@ impl FilterSet {
     fn new(debug: bool) -> Self {
         Self(RefCell::new(FilterSetInternal::new(debug)))
     }
-    fn add_filters(&self, rules: String, opts: ParseOptions) {
+    fn add_filters(&self, rules: String, opts: ParseOptions) -> adblock::lists::FilterListMetadata {
         self.0.borrow_mut().add_filter_list(rules, opts)
     }
 

--- a/js/src/lib.rs
+++ b/js/src/lib.rs
@@ -1,6 +1,4 @@
-use adblock::lists::{
-    FilterFormat, FilterListMetadata, FilterSet as FilterSetInternal, ParseOptions, RuleTypes,
-};
+use adblock::lists::{FilterFormat, FilterSet as FilterSetInternal, ParseOptions, RuleTypes};
 use adblock::resources::resource_assembler::assemble_web_accessible_resources;
 use adblock::resources::Resource;
 use adblock::Engine as EngineInternal;
@@ -64,16 +62,10 @@ impl FilterSet {
     fn new(debug: bool) -> Self {
         Self(RefCell::new(FilterSetInternal::new(debug)))
     }
-    fn add_filters(&self, rules: &[String], opts: ParseOptions) -> FilterListMetadata {
-        self.0.borrow_mut().add_filters(rules, opts)
+    fn add_filters(&self, rules: String, opts: ParseOptions) {
+        self.0.borrow_mut().add_filter_list(rules, opts)
     }
-    fn add_filter(
-        &self,
-        filter: &str,
-        opts: ParseOptions,
-    ) -> Result<(), adblock::lists::FilterParseError> {
-        self.0.borrow_mut().add_filter(filter, opts)
-    }
+
     fn into_content_blocking(
         &self,
     ) -> Result<(Vec<adblock::content_blocking::CbRule>, Vec<String>), ()> {
@@ -108,25 +100,11 @@ fn filter_set_add_filters(mut cx: FunctionContext) -> JsResult<JsValue> {
         None => ParseOptions::default(),
     };
 
-    let rules: Vec<String> = json_ffi::from_js(&mut cx, rules_handle)?;
+    let rules: String = json_ffi::from_js(&mut cx, rules_handle)?;
 
-    let metadata = this.add_filters(&rules, parse_opts);
+    let metadata = this.add_filters(rules, parse_opts);
 
     json_ffi::to_js(&mut cx, &metadata)
-}
-
-fn filter_set_add_filter(mut cx: FunctionContext) -> JsResult<JsBoolean> {
-    let this = cx.argument::<JsBox<FilterSet>>(0)?;
-
-    let filter: String = cx.argument::<JsString>(1)?.value(&mut cx);
-    let parse_opts = match cx.argument_opt(2) {
-        Some(parse_opts_arg) => json_ffi::from_js(&mut cx, parse_opts_arg)?,
-        None => ParseOptions::default(),
-    };
-
-    let ok = this.add_filter(&filter, parse_opts).is_ok();
-    // Return true/false depending on whether or not the filter could be added
-    Ok(JsBoolean::new(&mut cx, ok))
 }
 
 #[derive(Serialize)]
@@ -391,7 +369,6 @@ fn build_rule_types_enum<'a, C: Context<'a>>(cx: &mut C) -> JsResult<'a, JsObjec
 register_module!(mut m, {
     m.export_function("FilterSet_constructor", create_filter_set)?;
     m.export_function("FilterSet_addFilters", filter_set_add_filters)?;
-    m.export_function("FilterSet_addFilter", filter_set_add_filter)?;
     m.export_function(
         "FilterSet_intoContentBlocking",
         filter_set_into_content_blocking,

--- a/js/test/bindings.test.mjs
+++ b/js/test/bindings.test.mjs
@@ -48,6 +48,22 @@ describe('FilterSet.addFilters', () => {
         assert.equal(cosmetic.hide_selectors.length, 0);
     });
 
+    it("Legacy addFilters syntax works", () => {
+      const fs = new FilterSet();
+      fs.addFilters(["||example.com^", "example.com##.ad"], {
+        rule_types: RuleTypes.NETWORK_ONLY,
+      });
+      const engine = new Engine(fs, true);
+      assert.equal(
+        engine.check(
+          "https://example.com/test.js",
+          "https://pub.com",
+          "script",
+        ),
+        true,
+      );
+    });
+
     it('COSMETIC_ONLY skips network rules', () => {
         const fs = new FilterSet();
         fs.addFilters(

--- a/js/test/bindings.test.mjs
+++ b/js/test/bindings.test.mjs
@@ -23,6 +23,20 @@ const { FilterSet, Engine, FilterFormat, RuleTypes, uBlockResources } =
 // ---------------------------------------------------------------------------
 
 describe('FilterSet.addFilters', () => {
+      it('parses metadata comments (title, homepage, expires, redirect)', () => {
+        const fs = new FilterSet();
+        const meta = fs.addFilters([
+            '! Title: Test List',
+            '! Homepage: https://example.com',
+            '! Expires: 2 days',
+            '! Redirect: https://example.com/new-list.txt',
+            '||ads.com^',
+        ].join('\n'));
+        assert.equal(meta.title, 'Test List');
+        assert.equal(meta.homepage, 'https://example.com');
+        assert.ok(meta.expires != null);
+        assert.equal(meta.redirect, 'https://example.com/new-list.txt');
+    });
     it('hosts format parses IP-hostname entries', () => {
         const fs = new FilterSet();
         fs.addFilters('127.0.0.1 ads.example.com', { format: FilterFormat.HOSTS });

--- a/js/test/bindings.test.mjs
+++ b/js/test/bindings.test.mjs
@@ -23,24 +23,9 @@ const { FilterSet, Engine, FilterFormat, RuleTypes, uBlockResources } =
 // ---------------------------------------------------------------------------
 
 describe('FilterSet.addFilters', () => {
-    it('parses metadata comments (title, homepage, expires, redirect)', () => {
-        const fs = new FilterSet();
-        const meta = fs.addFilters([
-            '! Title: Test List',
-            '! Homepage: https://example.com',
-            '! Expires: 2 days',
-            '! Redirect: https://example.com/new-list.txt',
-            '||ads.com^',
-        ]);
-        assert.equal(meta.title, 'Test List');
-        assert.equal(meta.homepage, 'https://example.com');
-        assert.ok(meta.expires != null);
-        assert.equal(meta.redirect, 'https://example.com/new-list.txt');
-    });
-
     it('hosts format parses IP-hostname entries', () => {
         const fs = new FilterSet();
-        fs.addFilters(['127.0.0.1 ads.example.com'], { format: FilterFormat.HOSTS });
+        fs.addFilters('127.0.0.1 ads.example.com', { format: FilterFormat.HOSTS });
         const engine = new Engine(fs, true);
         assert.equal(
             engine.check('https://ads.example.com/', 'https://pub.com', 'script'),
@@ -51,7 +36,7 @@ describe('FilterSet.addFilters', () => {
     it('NETWORK_ONLY skips cosmetic rules', () => {
         const fs = new FilterSet();
         fs.addFilters(
-            ['||example.com^', 'example.com##.ad'],
+            ['||example.com^', 'example.com##.ad'].join('\n'),
             { rule_types: RuleTypes.NETWORK_ONLY },
         );
         const engine = new Engine(fs, true);
@@ -66,7 +51,7 @@ describe('FilterSet.addFilters', () => {
     it('COSMETIC_ONLY skips network rules', () => {
         const fs = new FilterSet();
         fs.addFilters(
-            ['||example.com^', 'example.com##.ad'],
+            ['||example.com^', 'example.com##.ad'].join('\n'),
             { rule_types: RuleTypes.COSMETIC_ONLY },
         );
         const engine = new Engine(fs, true);
@@ -80,47 +65,13 @@ describe('FilterSet.addFilters', () => {
 });
 
 // ---------------------------------------------------------------------------
-// FilterSet.addFilter
-// ---------------------------------------------------------------------------
-
-describe('FilterSet.addFilter', () => {
-    it('returns true for a valid network filter', () => {
-        const fs = new FilterSet();
-        assert.equal(fs.addFilter('||example.com^'), true);
-    });
-
-    it('returns true for a valid cosmetic filter', () => {
-        const fs = new FilterSet();
-        assert.equal(fs.addFilter('example.com##.banner'), true);
-    });
-
-    it('returns false for an empty string', () => {
-        const fs = new FilterSet();
-        assert.equal(fs.addFilter(''), false);
-    });
-
-    it('returns false for a comment line', () => {
-        const fs = new FilterSet();
-        assert.equal(fs.addFilter('! this is a comment'), false);
-    });
-
-    it('accepts hosts format via ParseOptions', () => {
-        const fs = new FilterSet();
-        assert.equal(
-            fs.addFilter('127.0.0.1 ads.example.com', { format: FilterFormat.HOSTS }),
-            true,
-        );
-    });
-});
-
-// ---------------------------------------------------------------------------
 // FilterSet.intoContentBlocking
 // ---------------------------------------------------------------------------
 
 describe('FilterSet.intoContentBlocking', () => {
     it('converts network filters to content blocking rules with trigger/action', () => {
         const fs = new FilterSet(true);
-        fs.addFilters(['||ads.example.com^']);
+        fs.addFilters('||ads.example.com^');
         const result = fs.intoContentBlocking();
         assert.notEqual(result, undefined);
         assert.ok(result.contentBlockingRules.length > 0);
@@ -131,7 +82,7 @@ describe('FilterSet.intoContentBlocking', () => {
 
     it('returns undefined when debug=false', () => {
         const fs = new FilterSet(false);
-        fs.addFilters(['||ads.example.com^']);
+        fs.addFilters('||ads.example.com^');
         assert.equal(fs.intoContentBlocking(), undefined);
     });
 });
@@ -143,9 +94,9 @@ describe('FilterSet.intoContentBlocking', () => {
 describe('FilterSet survives Engine construction (clone semantics)', () => {
     it('FilterSet is still usable after being passed to Engine constructor', () => {
         const fs = new FilterSet();
-        fs.addFilters(['||example.com^']);
+        fs.addFilters('||example.com^');
         const _engine = new Engine(fs, true);
-        assert.doesNotThrow(() => fs.addFilter('||another.com^'));
+        assert.doesNotThrow(() => fs.addFilters('||another.com^'));
     });
 });
 
@@ -156,7 +107,7 @@ describe('FilterSet survives Engine construction (clone semantics)', () => {
 describe('Engine.check — basic blocking', () => {
     it('blocks matching requests, allows non-matching', () => {
         const fs = new FilterSet();
-        fs.addFilters(['||ads.example.com^']);
+        fs.addFilters('||ads.example.com^');
         const engine = new Engine(fs, true);
         assert.equal(engine.check('https://ads.example.com/t.js', 'https://pub.com', 'script'), true);
         assert.equal(engine.check('https://safe.com/t.js', 'https://pub.com', 'script'), false);
@@ -164,7 +115,7 @@ describe('Engine.check — basic blocking', () => {
 
     it('debug=true returns BlockerResult with filter text', () => {
         const fs = new FilterSet(true);
-        fs.addFilters(['||ads.example.com^']);
+        fs.addFilters('||ads.example.com^');
         const engine = new Engine(fs, true);
         const result = engine.check(
             'https://ads.example.com/t.js', 'https://pub.com', 'script', true,
@@ -180,7 +131,7 @@ describe('Engine.check — basic blocking', () => {
 
     it('EngineOptions object works as alternative to boolean', () => {
         const fs = new FilterSet();
-        fs.addFilters(['||blocked.com^']);
+        fs.addFilters('||blocked.com^');
         const engine = new Engine(fs, { optimize: false });
         assert.equal(
             engine.check('https://blocked.com/img.png', 'https://pub.com', 'image'),
@@ -196,7 +147,7 @@ describe('Engine.check — basic blocking', () => {
 describe('Engine.check — exception rules', () => {
     it('exception rule prevents blocking, populates exception field', () => {
         const fs = new FilterSet(true);
-        fs.addFilters(['||ads.example.com^', '@@||ads.example.com^$domain=publisher.com']);
+        fs.addFilters(['||ads.example.com^', '@@||ads.example.com^$domain=publisher.com'].join('\n'));
         const engine = new Engine(fs, true);
         const result = engine.check(
             'https://ads.example.com/tracker.js', 'https://publisher.com', 'script', true,
@@ -208,7 +159,7 @@ describe('Engine.check — exception rules', () => {
 
     it('$important overrides exception rules', () => {
         const fs = new FilterSet(true);
-        fs.addFilters(['||ads.example.com^$important', '@@||ads.example.com^']);
+        fs.addFilters(['||ads.example.com^$important', '@@||ads.example.com^'].join('\n'));
         const engine = new Engine(fs, true);
         const result = engine.check(
             'https://ads.example.com/t.js', 'https://pub.com', 'script', true,
@@ -226,7 +177,7 @@ describe('Engine.check — exception rules', () => {
 describe('Engine.check — $third-party and $1p modifiers', () => {
     it('$third-party rule blocks 3p, allows 1p', () => {
         const fs = new FilterSet();
-        fs.addFilters(['||tracker.com^$third-party']);
+        fs.addFilters('||tracker.com^$third-party');
         const engine = new Engine(fs, true);
         assert.equal(engine.check('https://tracker.com/t.js', 'https://other.com', 'script'), true);
         assert.equal(engine.check('https://tracker.com/t.js', 'https://tracker.com', 'script'), false);
@@ -234,7 +185,7 @@ describe('Engine.check — $third-party and $1p modifiers', () => {
 
     it('$1p rule blocks 1p, allows 3p', () => {
         const fs = new FilterSet();
-        fs.addFilters(['/bad-path$1p']);
+        fs.addFilters('/bad-path$1p');
         const engine = new Engine(fs, true);
         assert.equal(engine.check('https://example.com/bad-path', 'https://example.com', 'script'), true);
         assert.equal(engine.check('https://example.com/bad-path', 'https://other.com', 'script'), false);
@@ -248,7 +199,7 @@ describe('Engine.check — $third-party and $1p modifiers', () => {
 describe('Engine.check — type-specific rules', () => {
     it('$script blocks only script requests', () => {
         const fs = new FilterSet();
-        fs.addFilters(['||ads.example.com^$script']);
+        fs.addFilters('||ads.example.com^$script');
         const engine = new Engine(fs, true);
         assert.equal(engine.check('https://ads.example.com/t.js', 'https://pub.com', 'script'), true);
         assert.equal(engine.check('https://ads.example.com/t.png', 'https://pub.com', 'image'), false);
@@ -256,7 +207,7 @@ describe('Engine.check — type-specific rules', () => {
 
     it('$image blocks only image requests', () => {
         const fs = new FilterSet();
-        fs.addFilters(['||ads.example.com^$image']);
+        fs.addFilters('||ads.example.com^$image');
         const engine = new Engine(fs, true);
         assert.equal(engine.check('https://ads.example.com/t.png', 'https://pub.com', 'image'), true);
         assert.equal(engine.check('https://ads.example.com/t.js', 'https://pub.com', 'script'), false);
@@ -264,7 +215,7 @@ describe('Engine.check — type-specific rules', () => {
 
     it('$stylesheet blocks only stylesheet requests', () => {
         const fs = new FilterSet();
-        fs.addFilters(['||ads.example.com^$stylesheet']);
+        fs.addFilters('||ads.example.com^$stylesheet');
         const engine = new Engine(fs, true);
         assert.equal(engine.check('https://ads.example.com/s.css', 'https://pub.com', 'stylesheet'), true);
         assert.equal(engine.check('https://ads.example.com/s.js', 'https://pub.com', 'script'), false);
@@ -272,7 +223,7 @@ describe('Engine.check — type-specific rules', () => {
 
     it('$xmlhttprequest blocks only XHR requests', () => {
         const fs = new FilterSet();
-        fs.addFilters(['||ads.example.com^$xmlhttprequest']);
+        fs.addFilters('||ads.example.com^$xmlhttprequest');
         const engine = new Engine(fs, true);
         assert.equal(engine.check('https://ads.example.com/api', 'https://pub.com', 'xmlhttprequest'), true);
         assert.equal(engine.check('https://ads.example.com/api', 'https://pub.com', 'image'), false);
@@ -286,7 +237,7 @@ describe('Engine.check — type-specific rules', () => {
 describe('Engine.check — $domain modifier', () => {
     it('blocks only when source matches the domain option', () => {
         const fs = new FilterSet();
-        fs.addFilters(['/ads.js$domain=publisher.com']);
+        fs.addFilters('/ads.js$domain=publisher.com');
         const engine = new Engine(fs, true);
         assert.equal(engine.check('https://cdn.example.com/ads.js', 'https://publisher.com', 'script'), true);
         assert.equal(engine.check('https://cdn.example.com/ads.js', 'https://other.com', 'script'), false);
@@ -294,7 +245,7 @@ describe('Engine.check — $domain modifier', () => {
 
     it('~domain excludes the specified domain', () => {
         const fs = new FilterSet();
-        fs.addFilters(['/ads.js$domain=~safe.com']);
+        fs.addFilters('/ads.js$domain=~safe.com');
         const engine = new Engine(fs, true);
         assert.equal(engine.check('https://cdn.example.com/ads.js', 'https://safe.com', 'script'), false);
         assert.equal(engine.check('https://cdn.example.com/ads.js', 'https://other.com', 'script'), true);
@@ -308,14 +259,14 @@ describe('Engine.check — $domain modifier', () => {
 describe('Engine.check — $badfilter modifier', () => {
     it('cancels a matching blocking rule', () => {
         const fs = new FilterSet();
-        fs.addFilters(['||ads.example.com^', '||ads.example.com^$badfilter']);
+        fs.addFilters(['||ads.example.com^', '||ads.example.com^$badfilter'].join('\n'));
         const engine = new Engine(fs, true);
         assert.equal(engine.check('https://ads.example.com/t.js', 'https://pub.com', 'script'), false);
     });
 
     it('does not cancel a dissimilar rule', () => {
         const fs = new FilterSet();
-        fs.addFilters(['||ads.example.com^', '||other.com^$badfilter']);
+        fs.addFilters(['||ads.example.com^', '||other.com^$badfilter'].join('\n'));
         const engine = new Engine(fs, true);
         assert.equal(engine.check('https://ads.example.com/t.js', 'https://pub.com', 'script'), true);
     });
@@ -328,7 +279,7 @@ describe('Engine.check — $badfilter modifier', () => {
 describe('Engine.check — redirect rules', () => {
     it('redirect field is set when $redirect rule matches and resource is loaded', () => {
         const fs = new FilterSet(true);
-        fs.addFilters(['||ads.example.com^$script,redirect=noopjs']);
+        fs.addFilters('||ads.example.com^$script,redirect=noopjs');
         const engine = new Engine(fs, true);
         engine.useResources([{
             name: 'noopjs',
@@ -346,7 +297,7 @@ describe('Engine.check — redirect rules', () => {
 
     it('redirect is null when no redirect rule applies', () => {
         const fs = new FilterSet(true);
-        fs.addFilters(['||ads.example.com^']);
+        fs.addFilters('||ads.example.com^');
         const engine = new Engine(fs, true);
         const result = engine.check(
             'https://ads.example.com/t.js', 'https://pub.com', 'script', true,
@@ -364,7 +315,7 @@ describe('Engine.check — redirect rules', () => {
 describe('Engine.check — $removeparam modifier', () => {
     it('strips the specified parameter, preserves others', () => {
         const fs = new FilterSet(true);
-        fs.addFilters(['||example.com^$removeparam=tracking_id']);
+        fs.addFilters('||example.com^$removeparam=tracking_id');
         const engine = new Engine(fs, true);
         const result = engine.check(
             'https://example.com/page?tracking_id=abc&keep=1',
@@ -377,7 +328,7 @@ describe('Engine.check — $removeparam modifier', () => {
 
     it('rewritten_url is null when the parameter is absent', () => {
         const fs = new FilterSet(true);
-        fs.addFilters(['||example.com^$removeparam=tracking_id']);
+        fs.addFilters('||example.com^$removeparam=tracking_id');
         const engine = new Engine(fs, true);
         const result = engine.check(
             'https://example.com/page?unrelated=1',
@@ -394,7 +345,7 @@ describe('Engine.check — $removeparam modifier', () => {
 describe('Engine.check — exception rules with tags', () => {
     it('tagged exception activates only after enableTag', () => {
         const fs = new FilterSet(true);
-        fs.addFilters(['||ads.example.com^', '@@||ads.example.com^$tag=unbreak']);
+        fs.addFilters(['||ads.example.com^', '@@||ads.example.com^$tag=unbreak'].join('\n'));
         const engine = new Engine(fs, true);
 
         const before = engine.check(
@@ -419,7 +370,7 @@ describe('Engine.check — exception rules with tags', () => {
 describe('Engine.urlCosmeticResources', () => {
     it('returns matching hide_selectors for the URL', () => {
         const fs = new FilterSet();
-        fs.addFilters(['example.com##.ad-banner', 'example.com##.sponsored-post']);
+        fs.addFilters(['example.com##.ad-banner', 'example.com##.sponsored-post'].join('\n'));
         const engine = new Engine(fs, true);
         const result = engine.urlCosmeticResources('https://example.com/page');
         assert.ok(result.hide_selectors.includes('.ad-banner'));
@@ -428,7 +379,7 @@ describe('Engine.urlCosmeticResources', () => {
 
     it('returns empty hide_selectors for an unmatched URL', () => {
         const fs = new FilterSet();
-        fs.addFilters(['example.com##.ad-banner']);
+        fs.addFilters('example.com##.ad-banner');
         const engine = new Engine(fs, true);
         const result = engine.urlCosmeticResources('https://other-site.com/page');
         assert.equal(result.hide_selectors.length, 0);
@@ -436,7 +387,7 @@ describe('Engine.urlCosmeticResources', () => {
 
     it('generichide exception sets generichide=true', () => {
         const fs = new FilterSet();
-        fs.addFilters(['##.generic-ad', '@@||example.com^$generichide']);
+        fs.addFilters(['##.generic-ad', '@@||example.com^$generichide'].join('\n'));
         const engine = new Engine(fs, true);
         assert.equal(engine.urlCosmeticResources('https://example.com/page').generichide, true);
         assert.equal(engine.urlCosmeticResources('https://other.com/page').generichide, false);
@@ -444,7 +395,7 @@ describe('Engine.urlCosmeticResources', () => {
 
     it('site-specific unhide (#@#) prevents selector from appearing', () => {
         const fs = new FilterSet();
-        fs.addFilters(['example.com##.ad-banner', 'example.com#@#.ad-banner']);
+        fs.addFilters(['example.com##.ad-banner', 'example.com#@#.ad-banner'].join('\n'));
         const engine = new Engine(fs, true);
         const result = engine.urlCosmeticResources('https://example.com/page');
         assert.ok(!result.hide_selectors.includes('.ad-banner'));
@@ -452,7 +403,7 @@ describe('Engine.urlCosmeticResources', () => {
 
     it('generic unhide (#@#) adds to exceptions list', () => {
         const fs = new FilterSet();
-        fs.addFilters(['##.generic-ad', 'example.com#@#.generic-ad']);
+        fs.addFilters(['##.generic-ad', 'example.com#@#.generic-ad'].join('\n'));
         const engine = new Engine(fs, true);
         const result = engine.urlCosmeticResources('https://example.com/page');
         assert.ok(result.exceptions.includes('.generic-ad'));
@@ -460,7 +411,7 @@ describe('Engine.urlCosmeticResources', () => {
 
     it('negated domain (~sub.example.com) excludes subdomain', () => {
         const fs = new FilterSet();
-        fs.addFilters(['example.com,~sub.example.com##.ad']);
+        fs.addFilters('example.com,~sub.example.com##.ad');
         const engine = new Engine(fs, true);
         assert.ok(engine.urlCosmeticResources('https://example.com/page').hide_selectors.includes('.ad'));
         assert.ok(!engine.urlCosmeticResources('https://sub.example.com/page').hide_selectors.includes('.ad'));
@@ -471,7 +422,7 @@ describe('Engine.urlCosmeticResources', () => {
         fs.addFilters([
             'example.com##.items:has-text(Sponsored)',
             'example.com##.ad-banner:remove()',
-        ]);
+        ].join('\n'));
         const engine = new Engine(fs, true);
         const result = engine.urlCosmeticResources('https://example.com/page');
         assert.ok(result.procedural_actions.length >= 2);
@@ -479,7 +430,7 @@ describe('Engine.urlCosmeticResources', () => {
 
     it('scriptlet injection populates injected_script', () => {
         const fs = new FilterSet();
-        fs.addFilters(['example.com##+js(noopjs)']);
+        fs.addFilters('example.com##+js(noopjs)');
         const engine = new Engine(fs, true);
         // ##+js(noopjs) looks up "noopjs.js"; scriptlets use kind: "template"
         engine.useResources([{
@@ -500,7 +451,7 @@ describe('Engine.urlCosmeticResources', () => {
 describe('Engine.hiddenClassIdSelectors', () => {
     it('returns selectors matching class and id names', () => {
         const fs = new FilterSet();
-        fs.addFilters(['##.a-class', '###simple-id']);
+        fs.addFilters(['##.a-class', '###simple-id'].join('\n'));
         const engine = new Engine(fs, true);
         assert.ok(engine.hiddenClassIdSelectors(['a-class'], [], []).includes('.a-class'));
         assert.ok(engine.hiddenClassIdSelectors([], ['simple-id'], []).includes('#simple-id'));
@@ -508,14 +459,14 @@ describe('Engine.hiddenClassIdSelectors', () => {
 
     it('returns empty for unknown class/id names', () => {
         const fs = new FilterSet();
-        fs.addFilters(['##.a-class']);
+        fs.addFilters('##.a-class');
         const engine = new Engine(fs, true);
         assert.deepEqual(engine.hiddenClassIdSelectors(['unknown'], ['unknown'], []), []);
     });
 
     it('exceptions array filters out results', () => {
         const fs = new FilterSet();
-        fs.addFilters(['##.a-class']);
+        fs.addFilters('##.a-class');
         const engine = new Engine(fs, true);
         assert.ok(engine.hiddenClassIdSelectors(['a-class'], [], []).includes('.a-class'));
         assert.ok(!engine.hiddenClassIdSelectors(['a-class'], [], ['.a-class']).includes('.a-class'));
@@ -529,7 +480,7 @@ describe('Engine.hiddenClassIdSelectors', () => {
 describe('Engine serialization', () => {
     it('roundtrip preserves blocking and exception rules', () => {
         const fs = new FilterSet();
-        fs.addFilters(['||blocked.com^', '@@||exception.blocked.com^']);
+        fs.addFilters(['||blocked.com^', '@@||exception.blocked.com^'].join('\n'));
         const src = new Engine(fs, true);
         const buf = src.serialize();
 
@@ -542,7 +493,7 @@ describe('Engine serialization', () => {
 
     it('tag enablement is NOT serialized — must re-enable after deserialize', () => {
         const fs = new FilterSet();
-        fs.addFilters(['adv$tag=stuff', '||blocked.com^']);
+        fs.addFilters(['adv$tag=stuff', '||blocked.com^'].join('\n'));
         const src = new Engine(fs, true);
         src.enableTag('stuff');
         const buf = src.serialize();
@@ -560,7 +511,7 @@ describe('Engine serialization', () => {
 
     it('resources are NOT serialized — must reload after deserialize', () => {
         const fs = new FilterSet(true);
-        fs.addFilters(['||ads.example.com^$script,redirect=noopjs']);
+        fs.addFilters(['||ads.example.com^$script,redirect=noopjs'].join('\n'));
         const resource = {
             name: 'noopjs',
             aliases: [],
@@ -597,7 +548,7 @@ describe('Engine serialization', () => {
 describe('Engine tags', () => {
     it('tagged filter is inactive before enableTag, active after', () => {
         const fs = new FilterSet();
-        fs.addFilters(['adv$tag=stuff']);
+        fs.addFilters(['adv$tag=stuff'].join('\n'));
         const engine = new Engine(fs, true);
         assert.equal(engine.check('https://example.com/adv', 'https://example.com', 'other'), false);
         engine.enableTag('stuff');
@@ -607,7 +558,7 @@ describe('Engine tags', () => {
 
     it('clearTags deactivates all enabled tags', () => {
         const fs = new FilterSet();
-        fs.addFilters(['adv$tag=stuff', '||brianbondy.com/$tag=brian']);
+        fs.addFilters(['adv$tag=stuff', '||brianbondy.com/$tag=brian'].join('\n'));
         const engine = new Engine(fs, true);
         engine.enableTag('stuff');
         engine.enableTag('brian');

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -459,18 +459,18 @@ impl Blocker {
 
         let mut filter_set = FilterSet::new(true);
         filter_set.add_filters(network_filters, Default::default());
-        let engine = Engine::from_filter_set(filter_set, options.enable_optimizations);
+        let engine = Engine::new_with_filter_set(filter_set, options.enable_optimizations);
         Self::from_context(engine.filter_data_context())
     }
 
     #[cfg(test)]
-    pub fn new_from_text(text: String, options: &BlockerOptions) -> Self {
+    pub fn new_with_list_text(text: String, options: &BlockerOptions) -> Self {
         use crate::engine::Engine;
         use crate::FilterSet;
 
         let mut filter_set = FilterSet::new(true);
         filter_set.add_filter_list(text, Default::default());
-        let engine = Engine::from_filter_set(filter_set, options.enable_optimizations);
+        let engine = Engine::new_with_filter_set(filter_set, options.enable_optimizations);
         Self::from_context(engine.filter_data_context())
     }
 

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -451,14 +451,25 @@ impl Blocker {
 
     #[cfg(test)]
     pub fn new(
-        network_filters: Vec<crate::filters::network::NetworkFilter>,
+        network_filters: impl IntoIterator<Item = impl AsRef<str>>,
         options: &BlockerOptions,
     ) -> Self {
         use crate::engine::Engine;
         use crate::FilterSet;
 
         let mut filter_set = FilterSet::new(true);
-        filter_set.network_filters = network_filters;
+        filter_set.add_filters(network_filters, Default::default());
+        let engine = Engine::from_filter_set(filter_set, options.enable_optimizations);
+        Self::from_context(engine.filter_data_context())
+    }
+
+    #[cfg(test)]
+    pub fn new_from_text(text: String, options: &BlockerOptions) -> Self {
+        use crate::engine::Engine;
+        use crate::FilterSet;
+
+        let mut filter_set = FilterSet::new(true);
+        filter_set.add_filter_list(text, Default::default());
         let engine = Engine::from_filter_set(filter_set, options.enable_optimizations);
         Self::from_context(engine.filter_data_context())
     }

--- a/src/content_blocking.rs
+++ b/src/content_blocking.rs
@@ -2,7 +2,7 @@
 
 use crate::filters::cosmetic::CosmeticFilter;
 use crate::filters::network::{NetworkFilter, NetworkFilterFeaturesMask, NetworkFilterMask};
-use crate::lists::ParsedFilter;
+use crate::lists::ParsedLine;
 
 use memchr::{memchr as find_char, memmem};
 use regex::Regex;
@@ -227,15 +227,18 @@ pub enum CbRuleCreationFailure {
     FromNotSupported,
     /// Content blocking rules cannot support procedural cosmetic filter operators.
     ProceduralCosmeticFiltersUnsupported,
+    /// The parsed line is a metadata entry, not a filter rule.
+    NotAFilterRule,
 }
 
-impl TryFrom<ParsedFilter> for CbRuleEquivalent {
+impl TryFrom<ParsedLine> for CbRuleEquivalent {
     type Error = CbRuleCreationFailure;
 
-    fn try_from(v: ParsedFilter) -> Result<Self, Self::Error> {
+    fn try_from(v: ParsedLine) -> Result<Self, Self::Error> {
         match v {
-            ParsedFilter::Network(f) => f.try_into(),
-            ParsedFilter::Cosmetic(f) => Ok(Self::SingleRule(f.try_into()?)),
+            ParsedLine::Network(f) => f.try_into(),
+            ParsedLine::Cosmetic(f) => Ok(Self::SingleRule(f.try_into()?)),
+            _ => Err(CbRuleCreationFailure::NotAFilterRule),
         }
     }
 }

--- a/src/content_blocking.rs
+++ b/src/content_blocking.rs
@@ -227,8 +227,6 @@ pub enum CbRuleCreationFailure {
     FromNotSupported,
     /// Content blocking rules cannot support procedural cosmetic filter operators.
     ProceduralCosmeticFiltersUnsupported,
-    /// The parsed line is a metadata entry, not a filter rule.
-    NotAFilterRule,
 }
 
 impl TryFrom<ParsedLine> for CbRuleEquivalent {
@@ -238,7 +236,6 @@ impl TryFrom<ParsedLine> for CbRuleEquivalent {
         match v {
             ParsedLine::Network(f) => f.try_into(),
             ParsedLine::Cosmetic(f) => Ok(Self::SingleRule(f.try_into()?)),
-            _ => Err(CbRuleCreationFailure::NotAFilterRule),
         }
     }
 }

--- a/src/cosmetic_filter_cache.rs
+++ b/src/cosmetic_filter_cache.rs
@@ -138,7 +138,7 @@ impl CosmeticFilterCache {
 
         let mut filter_set = FilterSet::new(false);
         filter_set.add_filters(rules, Default::default());
-        let engine = Engine::from_filter_set(filter_set, true);
+        let engine = Engine::new_with_filter_set(filter_set, true);
         engine.cosmetic_cache()
     }
 

--- a/src/cosmetic_filter_cache.rs
+++ b/src/cosmetic_filter_cache.rs
@@ -10,8 +10,6 @@
 //! To build `CosmeticFilterCache`, use `CosmeticFilterCacheBuilder`.
 
 use crate::cosmetic_filter_utils::decode_script_with_permission;
-#[cfg(test)]
-use crate::filters::cosmetic::CosmeticFilter;
 use crate::filters::cosmetic::{CosmeticFilterAction, CosmeticFilterOperator};
 use crate::filters::filter_data_context::FilterDataContextRef;
 
@@ -134,12 +132,12 @@ impl CosmeticFilterCache {
     }
 
     #[cfg(test)]
-    pub fn from_rules(rules: Vec<CosmeticFilter>) -> Self {
+    pub fn from_rules(rules: impl IntoIterator<Item = impl AsRef<str>>) -> Self {
         use crate::engine::Engine;
         use crate::FilterSet;
 
-        let mut filter_set = FilterSet::new(true);
-        filter_set.cosmetic_filters = rules;
+        let mut filter_set = FilterSet::new(false);
+        filter_set.add_filters(rules, Default::default());
         let engine = Engine::from_filter_set(filter_set, true);
         engine.cosmetic_cache()
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -9,7 +9,7 @@ use crate::filters::fb_network_builder::NetworkRulesBuilder;
 use crate::filters::filter_data_context::{FilterDataContext, FilterDataContextRef};
 use crate::flatbuffers::containers::flat_serialize::FlatSerialize;
 use crate::flatbuffers::unsafe_tools::VerifiedFlatbufferMemory;
-use crate::lists::{parse_filter, FilterListMetadata, FilterSet, ParseOptions, ParsedLine};
+use crate::lists::{parse_filter, FilterSet, ParseOptions, ParsedLine};
 use crate::regex_manager::RegexManagerDiscardPolicy;
 use crate::request::Request;
 use crate::resources::{Resource, ResourceStorage, ResourceStorageBackend};
@@ -123,36 +123,20 @@ impl Engine {
 
     /// Loads rules from the given `FilterSet`.
     pub fn new_with_filter_set(set: FilterSet, optimize: bool) -> Self {
-        let (engine, _) = Self::from_filter_set_with_metadata(set, optimize);
-        engine
-    }
-
-    #[doc(hidden)]
-    pub(crate) fn from_filter_set_with_metadata(
-        set: FilterSet,
-        optimize: bool,
-    ) -> (Self, Vec<FilterListMetadata>) {
-        let mut metadata_list = vec![];
         let mut network_filters = vec![];
         let mut cosmetic_filters = vec![];
 
         for list_source in set.list_sources {
-            let mut metadata = FilterListMetadata::default();
             for line in list_source.list_text.lines() {
                 let parsed_line = parse_filter(line, set.debug, list_source.parse_options);
                 match parsed_line {
                     Ok(ParsedLine::Network(filter)) => network_filters.push(filter),
                     Ok(ParsedLine::Cosmetic(filter)) => cosmetic_filters.push(filter),
-                    Ok(item) => metadata.add_metadata(item),
                     Err(_) => {}
                 }
             }
-            metadata_list.push(metadata);
         }
-        (
-            Self::new_with_parsed_rules(network_filters, cosmetic_filters, optimize),
-            metadata_list,
-        )
+        Self::new_with_parsed_rules(network_filters, cosmetic_filters, optimize)
     }
 
     /// Check if a request for a network resource from `url`, of type `request_type`, initiated by

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -68,71 +68,28 @@ pub struct EngineDebugInfo {
 
 impl Default for Engine {
     fn default() -> Self {
-        Self::from_filter_set(FilterSet::new(false), false)
+        Self::new_with_filter_set(FilterSet::new(false), false)
     }
 }
 
 impl Engine {
-    /// Loads rules in a single format, enabling optimizations and discarding debug information.
-    #[deprecated(since = "0.13.0", note = "Use `from_text` instead")]
-    pub fn from_rules(
-        rules: impl IntoIterator<Item = impl AsRef<str>>,
-        opts: ParseOptions,
-    ) -> Self {
-        let text = rules.into_iter().fold(String::new(), |mut acc, rule| {
-            acc.push_str(rule.as_ref());
-            acc.push('\n');
-            acc
-        });
-        Self::from_text_parametrised(text, opts, false, true)
+    /// A helper for tests and benchmarks. Use [`Engine::new_with_filter_set`] instead.
+    #[doc(hidden)]
+    pub fn new_with_list_text(list_text: impl Into<String>, opts: ParseOptions) -> Self {
+        Self::new_with_list_text_parametrised(list_text.into(), opts, false, true)
     }
 
-    /// Loads rules, enabling optimizations and including debug information.
-    #[deprecated(since = "0.13.0", note = "Use `from_text` instead")]
-    pub fn from_rules_debug(
-        rules: impl IntoIterator<Item = impl AsRef<str>>,
-        opts: ParseOptions,
-    ) -> Self {
-        let text = rules.into_iter().fold(String::new(), |mut acc, rule| {
-            acc.push_str(rule.as_ref());
-            acc.push('\n');
-            acc
-        });
-        Self::from_text_parametrised(text, opts, true, true)
-    }
-
-    #[deprecated(since = "0.13.0", note = "Use `from_text_parametrised` instead")]
-    pub fn from_rules_parametrised(
-        filter_rules: impl IntoIterator<Item = impl AsRef<str>>,
-        opts: ParseOptions,
-        debug: bool,
-        optimize: bool,
-    ) -> Self {
-        let text = filter_rules
-            .into_iter()
-            .fold(String::new(), |mut acc, rule| {
-                acc.push_str(rule.as_ref());
-                acc.push('\n');
-                acc
-            });
-        let mut filter_set = FilterSet::new(debug);
-        filter_set.add_filter_list(text, opts);
-        Self::from_filter_set(filter_set, optimize)
-    }
-
-    pub fn from_text(text: impl Into<String>, opts: ParseOptions) -> Self {
-        Self::from_text_parametrised(text.into(), opts, false, true)
-    }
-
-    pub fn from_text_parametrised(
-        text: impl Into<String>,
+    /// A helper for tests and benchmarks. Use [`Engine::new_with_filter_set`] instead.
+    #[doc(hidden)]
+    pub fn new_with_list_text_parametrised(
+        list_text: impl Into<String>,
         opts: ParseOptions,
         debug: bool,
         optimize: bool,
     ) -> Self {
         let mut filter_set = FilterSet::new(debug);
-        filter_set.add_filter_list(text.into(), opts);
-        Self::from_filter_set(filter_set, optimize)
+        filter_set.add_filter_list(list_text.into(), opts);
+        Self::new_with_filter_set(filter_set, optimize)
     }
 
     #[cfg(test)]
@@ -145,6 +102,7 @@ impl Engine {
         self.filter_data_context
     }
 
+    /// A helper for tests and benchmarks. Use [`Engine::new_with_filter_set`] instead.
     #[doc(hidden)]
     pub fn new_with_parsed_rules(
         network_filters: Vec<NetworkFilter>,
@@ -167,7 +125,7 @@ impl Engine {
 
     /// Loads rules from the given `FilterSet`. It is recommended to use a `FilterSet` when adding
     /// rules from multiple sources.
-    pub fn from_filter_set(set: FilterSet, optimize: bool) -> Self {
+    pub fn new_with_filter_set(set: FilterSet, optimize: bool) -> Self {
         let (engine, _) = Self::from_filter_set_with_metadata(set, optimize);
         engine
     }
@@ -183,7 +141,7 @@ impl Engine {
 
         for list_source in set.list_sources {
             let mut metadata = FilterListMetadata::default();
-            for line in list_source.lines.lines() {
+            for line in list_source.list_text.lines() {
                 let parsed_line = parse_filter_line(line, set.debug, list_source.parse_options);
                 match parsed_line {
                     Ok(ParsedLine::ParsedFilter(parsed_filter)) => match parsed_filter {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -4,17 +4,19 @@ use crate::blocker::{Blocker, BlockerResult};
 use crate::cosmetic_filter_cache::{CosmeticFilterCache, UrlSpecificResources};
 use crate::cosmetic_filter_cache_builder::CosmeticFilterCacheBuilder;
 use crate::data_format::{deserialize_dat_file, serialize_dat_file, DeserializationError};
-use crate::filters::cosmetic::CosmeticFilter;
 use crate::filters::fb_builder::EngineFlatBuilder;
 use crate::filters::fb_network_builder::NetworkRulesBuilder;
 use crate::filters::filter_data_context::{FilterDataContext, FilterDataContextRef};
-use crate::filters::network::NetworkFilter;
 use crate::flatbuffers::containers::flat_serialize::FlatSerialize;
 use crate::flatbuffers::unsafe_tools::VerifiedFlatbufferMemory;
-use crate::lists::{FilterSet, ParseOptions};
+use crate::lists::{
+    parse_filter_line, FilterListMetadata, FilterSet, ParseOptions, ParsedFilter, ParsedLine,
+};
 use crate::regex_manager::RegexManagerDiscardPolicy;
 use crate::request::Request;
 use crate::resources::{Resource, ResourceStorage, ResourceStorageBackend};
+
+use crate::filters::{cosmetic::CosmeticFilter, network::NetworkFilter};
 
 use std::collections::HashSet;
 
@@ -72,31 +74,64 @@ impl Default for Engine {
 
 impl Engine {
     /// Loads rules in a single format, enabling optimizations and discarding debug information.
+    #[deprecated(since = "0.13.0", note = "Use `from_text` instead")]
     pub fn from_rules(
         rules: impl IntoIterator<Item = impl AsRef<str>>,
         opts: ParseOptions,
     ) -> Self {
-        let mut filter_set = FilterSet::new(false);
-        filter_set.add_filters(rules, opts);
-        Self::from_filter_set(filter_set, true)
+        let text = rules.into_iter().fold(String::new(), |mut acc, rule| {
+            acc.push_str(rule.as_ref());
+            acc.push('\n');
+            acc
+        });
+        Self::from_text_parametrised(text, opts, false, true)
     }
 
     /// Loads rules, enabling optimizations and including debug information.
+    #[deprecated(since = "0.13.0", note = "Use `from_text` instead")]
     pub fn from_rules_debug(
         rules: impl IntoIterator<Item = impl AsRef<str>>,
         opts: ParseOptions,
     ) -> Self {
-        Self::from_rules_parametrised(rules, opts, true, true)
+        let text = rules.into_iter().fold(String::new(), |mut acc, rule| {
+            acc.push_str(rule.as_ref());
+            acc.push('\n');
+            acc
+        });
+        Self::from_text_parametrised(text, opts, true, true)
     }
 
+    #[deprecated(since = "0.13.0", note = "Use `from_text_parametrised` instead")]
     pub fn from_rules_parametrised(
         filter_rules: impl IntoIterator<Item = impl AsRef<str>>,
         opts: ParseOptions,
         debug: bool,
         optimize: bool,
     ) -> Self {
+        let text = filter_rules
+            .into_iter()
+            .fold(String::new(), |mut acc, rule| {
+                acc.push_str(rule.as_ref());
+                acc.push('\n');
+                acc
+            });
         let mut filter_set = FilterSet::new(debug);
-        filter_set.add_filters(filter_rules, opts);
+        filter_set.add_filter_list(text, opts);
+        Self::from_filter_set(filter_set, optimize)
+    }
+
+    pub fn from_text(text: impl Into<String>, opts: ParseOptions) -> Self {
+        Self::from_text_parametrised(text.into(), opts, false, true)
+    }
+
+    pub fn from_text_parametrised(
+        text: impl Into<String>,
+        opts: ParseOptions,
+        debug: bool,
+        optimize: bool,
+    ) -> Self {
+        let mut filter_set = FilterSet::new(debug);
+        filter_set.add_filter_list(text.into(), opts);
         Self::from_filter_set(filter_set, optimize)
     }
 
@@ -110,15 +145,12 @@ impl Engine {
         self.filter_data_context
     }
 
-    /// Loads rules from the given `FilterSet`. It is recommended to use a `FilterSet` when adding
-    /// rules from multiple sources.
-    pub fn from_filter_set(set: FilterSet, optimize: bool) -> Self {
-        let FilterSet {
-            network_filters,
-            cosmetic_filters,
-            ..
-        } = set;
-
+    #[doc(hidden)]
+    pub fn new_with_parsed_rules(
+        network_filters: Vec<NetworkFilter>,
+        cosmetic_filters: Vec<CosmeticFilter>,
+        optimize: bool,
+    ) -> Self {
         let memory = make_flatbuffer(network_filters, cosmetic_filters, optimize);
 
         let filter_data_context = FilterDataContext::new(memory);
@@ -131,6 +163,49 @@ impl Engine {
             resources: ResourceStorage::default(),
             filter_data_context,
         }
+    }
+
+    /// Loads rules from the given `FilterSet`. It is recommended to use a `FilterSet` when adding
+    /// rules from multiple sources.
+    pub fn from_filter_set(set: FilterSet, optimize: bool) -> Self {
+        let (engine, _) = Self::from_filter_set_with_metadata(set, optimize);
+        engine
+    }
+
+    #[doc(hidden)]
+    pub fn from_filter_set_with_metadata(
+        set: FilterSet,
+        optimize: bool,
+    ) -> (Self, Vec<FilterListMetadata>) {
+        let mut metadata_list = vec![];
+        let mut network_filters = vec![];
+        let mut cosmetic_filters = vec![];
+
+        for list_source in set.list_sources {
+            let mut metadata = FilterListMetadata::default();
+            for line in list_source.lines.lines() {
+                let parsed_line = parse_filter_line(line, set.debug, list_source.parse_options);
+                match parsed_line {
+                    Ok(ParsedLine::ParsedFilter(parsed_filter)) => match parsed_filter {
+                        ParsedFilter::Network(filter) => {
+                            network_filters.push(filter);
+                        }
+                        ParsedFilter::Cosmetic(filter) => cosmetic_filters.push(filter),
+                    },
+                    Ok(ParsedLine::Metadata(item)) => {
+                        metadata.add_metadata(item);
+                    }
+                    Err(error) => {
+                        metadata.add_error(error);
+                    }
+                }
+            }
+            metadata_list.push(metadata);
+        }
+        (
+            Self::new_with_parsed_rules(network_filters, cosmetic_filters, optimize),
+            metadata_list,
+        )
     }
 
     /// Check if a request for a network resource from `url`, of type `request_type`, initiated by

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -123,15 +123,14 @@ impl Engine {
         }
     }
 
-    /// Loads rules from the given `FilterSet`. It is recommended to use a `FilterSet` when adding
-    /// rules from multiple sources.
+    /// Loads rules from the given `FilterSet`.
     pub fn new_with_filter_set(set: FilterSet, optimize: bool) -> Self {
         let (engine, _) = Self::from_filter_set_with_metadata(set, optimize);
         engine
     }
 
     #[doc(hidden)]
-    pub fn from_filter_set_with_metadata(
+    pub(crate) fn from_filter_set_with_metadata(
         set: FilterSet,
         optimize: bool,
     ) -> (Self, Vec<FilterListMetadata>) {
@@ -153,9 +152,7 @@ impl Engine {
                     Ok(ParsedLine::Metadata(item)) => {
                         metadata.add_metadata(item);
                     }
-                    Err(error) => {
-                        metadata.add_error(error);
-                    }
+                    Err(_) => {}
                 }
             }
             metadata_list.push(metadata);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -9,9 +9,7 @@ use crate::filters::fb_network_builder::NetworkRulesBuilder;
 use crate::filters::filter_data_context::{FilterDataContext, FilterDataContextRef};
 use crate::flatbuffers::containers::flat_serialize::FlatSerialize;
 use crate::flatbuffers::unsafe_tools::VerifiedFlatbufferMemory;
-use crate::lists::{
-    parse_filter_line, FilterListMetadata, FilterSet, ParseOptions, ParsedFilter, ParsedLine,
-};
+use crate::lists::{parse_filter, FilterListMetadata, FilterSet, ParseOptions, ParsedLine};
 use crate::regex_manager::RegexManagerDiscardPolicy;
 use crate::request::Request;
 use crate::resources::{Resource, ResourceStorage, ResourceStorageBackend};
@@ -141,17 +139,11 @@ impl Engine {
         for list_source in set.list_sources {
             let mut metadata = FilterListMetadata::default();
             for line in list_source.list_text.lines() {
-                let parsed_line = parse_filter_line(line, set.debug, list_source.parse_options);
+                let parsed_line = parse_filter(line, set.debug, list_source.parse_options);
                 match parsed_line {
-                    Ok(ParsedLine::ParsedFilter(parsed_filter)) => match parsed_filter {
-                        ParsedFilter::Network(filter) => {
-                            network_filters.push(filter);
-                        }
-                        ParsedFilter::Cosmetic(filter) => cosmetic_filters.push(filter),
-                    },
-                    Ok(ParsedLine::Metadata(item)) => {
-                        metadata.add_metadata(item);
-                    }
+                    Ok(ParsedLine::Network(filter)) => network_filters.push(filter),
+                    Ok(ParsedLine::Cosmetic(filter)) => cosmetic_filters.push(filter),
+                    Ok(item) => metadata.add_metadata(item),
                     Err(_) => {}
                 }
             }

--- a/src/filters/fb_builder.rs
+++ b/src/filters/fb_builder.rs
@@ -4,8 +4,7 @@ use std::collections::HashMap;
 
 use flatbuffers::WIPOffset;
 
-use crate::filters::fb_network_builder::NetworkFilterListBuilder;
-use crate::flatbuffers::containers::flat_serialize::{FlatBuilder, WIPFlatVec};
+use crate::flatbuffers::containers::flat_serialize::FlatBuilder;
 use crate::flatbuffers::unsafe_tools::VerifiedFlatbufferMemory;
 use crate::utils::Hash;
 
@@ -31,7 +30,9 @@ impl<'a> EngineFlatBuilder<'a> {
 
     pub fn finish(
         &mut self,
-        network_rules: WIPFlatVec<'a, NetworkFilterListBuilder, EngineFlatBuilder<'a>>,
+        network_rules: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<fb::NetworkFilterList<'a>>>,
+        >,
         cosmetic_rules: WIPOffset<fb::CosmeticFilters<'_>>,
     ) -> VerifiedFlatbufferMemory {
         let unique_domains_hashes =

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -940,9 +940,7 @@ impl NetworkFilter {
 
     #[cfg(test)]
     pub(crate) fn matches_test(&self, request: &request::Request) -> bool {
-        let filter_set = crate::FilterSet::new_with_rules(vec![self.clone()], vec![], true);
-        let engine = crate::Engine::from_filter_set(filter_set, true);
-
+        let engine = crate::Engine::new_with_parsed_rules(vec![self.clone()], vec![], true);
         if self.is_exception() {
             engine.check_network_request_exceptions(request)
         } else {

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -122,7 +122,7 @@ impl Default for FilterSet {
 }
 
 /// Corresponds to the `expires` field of `FilterListMetadata`.
-#[derive(Debug, PartialEq, Serialize, Clone)]
+#[derive(Debug, PartialEq, Serialize)]
 pub enum ExpiresInterval {
     Hours(u16),
     Days(u8),
@@ -165,7 +165,7 @@ impl TryFrom<&str> for ExpiresInterval {
 
 /// Includes information about any "special comments" as described by
 /// <https://help.eyeo.com/adblockplus/how-to-write-filters#special-comments>
-#[derive(Default, Clone, Serialize)]
+#[derive(Default, Serialize)]
 pub struct FilterListMetadata {
     /// `! Homepage: http://example.com` - This comment determines which webpage should be linked
     /// as filter list homepage.
@@ -348,7 +348,7 @@ impl FilterSet {
 }
 
 /// Denotes the format of a particular list resource, which affects how its rules should be parsed.
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum FilterFormat {
     /// Rules should be parsed in ABP/uBO-style format.
     Standard,

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -87,15 +87,24 @@ pub struct FilterSet {
 }
 
 /// Collects metadata for the list by reading just until the first non-comment line.
-#[cfg(test)]
 pub fn read_list_metadata(list: &str) -> FilterListMetadata {
-    use crate::Engine;
-
-    let mut filter_set = FilterSet::new(false);
-    filter_set.add_filter_list(list.to_string(), ParseOptions::default());
-    let (_, mut metadata) = Engine::from_filter_set_with_metadata(filter_set, false);
-    assert_eq!(metadata.len(), 1);
-    metadata.pop().unwrap()
+    let mut metadata = FilterListMetadata::default();
+    let mut chars_read = 0;
+    for line in list.lines() {
+        if chars_read > 1024 {
+            break; // stop parsing metadata
+        }
+        chars_read += line.len();
+        if line.starts_with("[") {
+            continue;
+        }
+        if let Some(comment_content) = line.strip_prefix("!") {
+            metadata.try_add_metadata(comment_content);
+        } else {
+            break; // stop parsing metadata
+        }
+    }
+    metadata
 }
 
 impl Default for FilterSet {
@@ -113,7 +122,7 @@ impl Default for FilterSet {
 }
 
 /// Corresponds to the `expires` field of `FilterListMetadata`.
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Debug, PartialEq, Serialize, Clone)]
 pub enum ExpiresInterval {
     Hours(u16),
     Days(u8),
@@ -156,7 +165,7 @@ impl TryFrom<&str> for ExpiresInterval {
 
 /// Includes information about any "special comments" as described by
 /// <https://help.eyeo.com/adblockplus/how-to-write-filters#special-comments>
-#[derive(Default)]
+#[derive(Default, Clone, Serialize)]
 pub struct FilterListMetadata {
     /// `! Homepage: http://example.com` - This comment determines which webpage should be linked
     /// as filter list homepage.
@@ -180,21 +189,17 @@ pub struct FilterListMetadata {
 }
 
 impl FilterListMetadata {
-    pub(crate) fn add_metadata(&mut self, item: ParsedLine) {
-        match item {
-            ParsedLine::Homepage(value) if self.homepage.is_none() => {
-                self.homepage = Some(value);
+    pub(crate) fn try_add_metadata(&mut self, metadata: &str) {
+        if let Some((key, value)) = metadata.trim().split_once(": ") {
+            match key {
+                "Homepage" if self.homepage.is_none() => self.homepage = Some(value.to_string()),
+                "Title" if self.title.is_none() => self.title = Some(value.to_string()),
+                "Expires" if self.expires.is_none() => {
+                    self.expires = Some(ExpiresInterval::try_from(value).unwrap())
+                }
+                "Redirect" if self.redirect.is_none() => self.redirect = Some(value.to_string()),
+                _ => (),
             }
-            ParsedLine::Title(value) if self.title.is_none() => {
-                self.title = Some(value);
-            }
-            ParsedLine::Expires(value) if self.expires.is_none() => {
-                self.expires = Some(value);
-            }
-            ParsedLine::Redirect(value) if self.redirect.is_none() => {
-                self.redirect = Some(value);
-            }
-            _ => (),
         }
     }
 }
@@ -213,11 +218,13 @@ impl FilterSet {
     /// Adds the contents of an entire filter list to this `FilterSet`. Filters that cannot be
     /// parsed successfully are ignored. Returns any discovered metadata about the list of rules
     /// added.
-    pub fn add_filter_list(&mut self, list_text: String, opts: ParseOptions) {
+    pub fn add_filter_list(&mut self, list_text: String, opts: ParseOptions) -> FilterListMetadata {
+        let metadata = read_list_metadata(&list_text);
         self.list_sources.push(ListSource {
             list_text,
             parse_options: opts,
         });
+        metadata
     }
 
     /// Adds a collection of filter rules to this `FilterSet`. Filters that cannot be parsed
@@ -380,11 +387,6 @@ pub enum FilterType {
 pub enum ParsedLine {
     Network(NetworkFilter),
     Cosmetic(CosmeticFilter),
-    Homepage(String),
-    Title(String),
-    Expires(ExpiresInterval),
-    Redirect(String),
-    UnknownMetadata,
 }
 
 impl From<NetworkFilter> for ParsedLine {
@@ -432,27 +434,6 @@ pub fn parse_filter(
     debug: bool,
     opts: ParseOptions,
 ) -> Result<ParsedLine, FilterParseError> {
-    if opts.format == FilterFormat::Standard {
-        if let Some(kv) = line.strip_prefix("! ") {
-            if let Some((key, value)) = kv.split_once(": ") {
-                return Ok(match key {
-                    "Homepage" => ParsedLine::Homepage(value.to_string()),
-                    "Title" => ParsedLine::Title(value.to_string()),
-                    "Expires" => {
-                        if let Ok(expires) = ExpiresInterval::try_from(value) {
-                            ParsedLine::Expires(expires)
-                        } else {
-                            return Err(FilterParseError::InvalidExpiresInterval);
-                        }
-                    }
-                    "Redirect" => ParsedLine::Redirect(value.to_string()),
-                    _ => ParsedLine::UnknownMetadata,
-                });
-            }
-            return Ok(ParsedLine::UnknownMetadata);
-        }
-    }
-
     let filter = line.trim();
 
     if filter.is_empty() {

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -71,7 +71,7 @@ impl Default for ParseOptions {
 
 #[derive(Clone)]
 pub(crate) struct ListSource {
-    pub(crate) lines: String,
+    pub(crate) list_text: String,
     pub(crate) parse_options: ParseOptions,
 }
 
@@ -220,9 +220,9 @@ impl FilterSet {
     /// Adds the contents of an entire filter list to this `FilterSet`. Filters that cannot be
     /// parsed successfully are ignored. Returns any discovered metadata about the list of rules
     /// added.
-    pub fn add_filter_list(&mut self, filter_list: String, opts: ParseOptions) {
+    pub fn add_filter_list(&mut self, list_text: String, opts: ParseOptions) {
         self.list_sources.push(ListSource {
-            lines: filter_list,
+            list_text,
             parse_options: opts,
         });
     }
@@ -235,13 +235,13 @@ impl FilterSet {
         filters: impl IntoIterator<Item = impl AsRef<str>>,
         opts: ParseOptions,
     ) {
-        let lines = filters.into_iter().fold(String::new(), |mut acc, rule| {
+        let list_text = filters.into_iter().fold(String::new(), |mut acc, rule| {
             acc.push_str(rule.as_ref());
             acc.push('\n');
             acc
         });
         self.list_sources.push(ListSource {
-            lines,
+            list_text,
             parse_options: opts,
         });
     }
@@ -275,10 +275,10 @@ impl FilterSet {
         let mut network_filters = vec![];
         let mut cosmetic_filters = vec![];
         for list_source in self.list_sources.iter() {
-            let lines = list_source.lines.lines();
+            let list_text = list_source.list_text.lines();
             let parse_options = list_source.parse_options;
             let (list_network_filters, list_cosmetic_filters) =
-                parse_filters(lines, self.debug, parse_options);
+                parse_filters(list_text, self.debug, parse_options);
             network_filters.extend(list_network_filters);
             cosmetic_filters.extend(list_cosmetic_filters);
         }

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -177,32 +177,25 @@ pub struct FilterListMetadata {
     /// the same as the current address, meaning that it can be used to enforce the "canonical"
     /// address of the filter list.
     pub redirect: Option<String>,
-
-    /// Errors that occurred while parsing the filter list.
-    pub errors: Vec<FilterParseError>,
 }
 
 impl FilterListMetadata {
     pub(crate) fn add_metadata(&mut self, metadata: ParsedMetadata) {
         match metadata {
-            ParsedMetadata::Homepage(value) => {
+            ParsedMetadata::Homepage(value) if self.homepage.is_none() => {
                 self.homepage = Some(value);
             }
-            ParsedMetadata::Title(value) => {
+            ParsedMetadata::Title(value) if self.title.is_none() => {
                 self.title = Some(value);
             }
-            ParsedMetadata::Expires(value) => {
+            ParsedMetadata::Expires(value) if self.expires.is_none() => {
                 self.expires = Some(value);
             }
-            ParsedMetadata::Redirect(value) => {
+            ParsedMetadata::Redirect(value) if self.redirect.is_none() => {
                 self.redirect = Some(value);
             }
-            ParsedMetadata::Unknown => (),
+            _ => (),
         }
-    }
-
-    pub(crate) fn add_error(&mut self, error: FilterParseError) {
-        self.errors.push(error);
     }
 }
 

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -219,7 +219,10 @@ impl FilterSet {
     /// parsed successfully are ignored. Returns any discovered metadata about the list of rules
     /// added.
     pub fn add_filter_list(&mut self, list_text: String, opts: ParseOptions) -> FilterListMetadata {
-        let metadata = read_list_metadata(&list_text);
+        let metadata = match opts.format {
+            FilterFormat::Standard => read_list_metadata(&list_text),
+            FilterFormat::Hosts => FilterListMetadata::default(),
+        };
         self.list_sources.push(ListSource {
             list_text,
             parse_options: opts,

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -69,6 +69,12 @@ impl Default for ParseOptions {
     }
 }
 
+#[derive(Clone)]
+pub(crate) struct ListSource {
+    pub(crate) lines: String,
+    pub(crate) parse_options: ParseOptions,
+}
+
 /// Manages a set of rules to be added to an [`crate::Engine`].
 ///
 /// To be able to efficiently handle special options like `$badfilter`, and to allow optimizations,
@@ -76,34 +82,20 @@ impl Default for ParseOptions {
 /// compound list from multiple different sources before compiling the rules into an `Engine`.
 #[derive(Clone)]
 pub struct FilterSet {
-    debug: bool,
-    pub(crate) network_filters: Vec<NetworkFilter>,
-    pub(crate) cosmetic_filters: Vec<CosmeticFilter>,
+    pub(crate) debug: bool,
+    pub(crate) list_sources: Vec<ListSource>,
 }
 
 /// Collects metadata for the list by reading just until the first non-comment line.
+#[cfg(test)]
 pub fn read_list_metadata(list: &str) -> FilterListMetadata {
-    let mut metadata = FilterListMetadata::default();
+    use crate::Engine;
 
-    // uBO only searches within the first 1024 characters; the same optimization can be useful here
-    let mut cutoff = list.len().min(1024);
-
-    while !list.is_char_boundary(cutoff) {
-        cutoff -= 1;
-    }
-
-    // String slice is safe here because `cutoff` is guaranteed to be a character boundary
-    for line in list[0..cutoff].lines() {
-        if line.starts_with('!') {
-            metadata.try_add(line);
-        } else if line.starts_with('[') {
-            continue;
-        } else {
-            break;
-        }
-    }
-
-    metadata
+    let mut filter_set = FilterSet::new(false);
+    filter_set.add_filter_list(list.to_string(), ParseOptions::default());
+    let (_, mut metadata) = Engine::from_filter_set_with_metadata(filter_set, false);
+    assert_eq!(metadata.len(), 1);
+    metadata.pop().unwrap()
 }
 
 impl Default for FilterSet {
@@ -164,7 +156,7 @@ impl TryFrom<&str> for ExpiresInterval {
 
 /// Includes information about any "special comments" as described by
 /// <https://help.eyeo.com/adblockplus/how-to-write-filters#special-comments>
-#[derive(Default, Serialize)]
+#[derive(Default)]
 pub struct FilterListMetadata {
     /// `! Homepage: http://example.com` - This comment determines which webpage should be linked
     /// as filter list homepage.
@@ -185,32 +177,32 @@ pub struct FilterListMetadata {
     /// the same as the current address, meaning that it can be used to enforce the "canonical"
     /// address of the filter list.
     pub redirect: Option<String>,
+
+    /// Errors that occurred while parsing the filter list.
+    pub errors: Vec<FilterParseError>,
 }
 
 impl FilterListMetadata {
-    /// Attempts to add a line of a filter list to this collection of metadata. Only comment lines
-    /// with valid metadata content will be added. Previously added information will not be
-    /// rewritten.
-    fn try_add(&mut self, line: &str) {
-        if let Some(kv) = line.strip_prefix("! ") {
-            if let Some((key, value)) = kv.split_once(": ") {
-                match key {
-                    "Homepage" if self.homepage.is_none() => {
-                        self.homepage = Some(value.to_string())
-                    }
-                    "Title" if self.title.is_none() => self.title = Some(value.to_string()),
-                    "Expires" if self.expires.is_none() => {
-                        if let Ok(expires) = ExpiresInterval::try_from(value) {
-                            self.expires = Some(expires);
-                        }
-                    }
-                    "Redirect" if self.redirect.is_none() => {
-                        self.redirect = Some(value.to_string())
-                    }
-                    _ => (),
-                }
+    pub(crate) fn add_metadata(&mut self, metadata: ParsedMetadata) {
+        match metadata {
+            ParsedMetadata::Homepage(value) => {
+                self.homepage = Some(value);
             }
+            ParsedMetadata::Title(value) => {
+                self.title = Some(value);
+            }
+            ParsedMetadata::Expires(value) => {
+                self.expires = Some(value);
+            }
+            ParsedMetadata::Redirect(value) => {
+                self.redirect = Some(value);
+            }
+            ParsedMetadata::Unknown => (),
         }
+    }
+
+    pub(crate) fn add_error(&mut self, error: FilterParseError) {
+        self.errors.push(error);
     }
 }
 
@@ -221,54 +213,43 @@ impl FilterSet {
     pub fn new(debug: bool) -> Self {
         Self {
             debug,
-            network_filters: Vec::new(),
-            cosmetic_filters: Vec::new(),
-        }
-    }
-
-    // Used in benchmarks to avoid parsing the rules twice.
-    #[doc(hidden)]
-    pub fn new_with_rules(
-        network_filters: Vec<NetworkFilter>,
-        cosmetic_filters: Vec<CosmeticFilter>,
-        debug: bool,
-    ) -> Self {
-        Self {
-            debug,
-            network_filters,
-            cosmetic_filters,
+            list_sources: Vec::new(),
         }
     }
 
     /// Adds the contents of an entire filter list to this `FilterSet`. Filters that cannot be
     /// parsed successfully are ignored. Returns any discovered metadata about the list of rules
     /// added.
-    pub fn add_filter_list(&mut self, filter_list: &str, opts: ParseOptions) -> FilterListMetadata {
-        self.add_filters(filter_list.lines(), opts)
+    pub fn add_filter_list(&mut self, filter_list: String, opts: ParseOptions) {
+        self.list_sources.push(ListSource {
+            lines: filter_list,
+            parse_options: opts,
+        });
     }
 
     /// Adds a collection of filter rules to this `FilterSet`. Filters that cannot be parsed
     /// successfully are ignored. Returns any discovered metadata about the list of rules added.
+    #[cfg(test)]
     pub fn add_filters(
         &mut self,
         filters: impl IntoIterator<Item = impl AsRef<str>>,
         opts: ParseOptions,
-    ) -> FilterListMetadata {
-        let (metadata, parsed_network_filters, parsed_cosmetic_filters) =
-            parse_filters_with_metadata(filters, self.debug, opts);
-        self.network_filters.extend(parsed_network_filters);
-        self.cosmetic_filters.extend(parsed_cosmetic_filters);
-        metadata
+    ) {
+        let lines = filters.into_iter().fold(String::new(), |mut acc, rule| {
+            acc.push_str(rule.as_ref());
+            acc.push('\n');
+            acc
+        });
+        self.list_sources.push(ListSource {
+            lines,
+            parse_options: opts,
+        });
     }
 
     /// Adds the string representation of a single filter rule to this `FilterSet`.
-    pub fn add_filter(&mut self, filter: &str, opts: ParseOptions) -> Result<(), FilterParseError> {
-        let filter_parsed = parse_filter(filter, self.debug, opts);
-        match filter_parsed? {
-            ParsedFilter::Network(filter) => self.network_filters.push(filter),
-            ParsedFilter::Cosmetic(filter) => self.cosmetic_filters.push(filter),
-        }
-        Ok(())
+    #[cfg(test)]
+    pub fn add_filter(&mut self, filter: &str, opts: ParseOptions) {
+        self.add_filters([filter], opts)
     }
 
     /// Consumes this `FilterSet`, returning an equivalent list of content blocking rules and a
@@ -291,9 +272,20 @@ impl FilterSet {
             return Err(());
         }
 
+        let mut network_filters = vec![];
+        let mut cosmetic_filters = vec![];
+        for list_source in self.list_sources.iter() {
+            let lines = list_source.lines.lines();
+            let parse_options = list_source.parse_options;
+            let (list_network_filters, list_cosmetic_filters) =
+                parse_filters(lines, self.debug, parse_options);
+            network_filters.extend(list_network_filters);
+            cosmetic_filters.extend(list_cosmetic_filters);
+        }
+
         // Store bad filter id to skip them later.
         let mut bad_filter_ids = HashSet::new();
-        for filter in self.network_filters.iter() {
+        for filter in network_filters.iter() {
             if filter.is_badfilter() {
                 bad_filter_ids.insert(filter.get_id());
             }
@@ -304,7 +296,7 @@ impl FilterSet {
 
         let mut filters_used = vec![];
 
-        self.network_filters.into_iter().for_each(|filter| {
+        network_filters.into_iter().for_each(|filter| {
             // Don't process bad filter rules or matching bad filter rules.
             if bad_filter_ids.contains(&filter.get_id()) || filter.is_badfilter() {
                 return;
@@ -329,7 +321,7 @@ impl FilterSet {
 
         let add_fp_document_exception = !filters_used.is_empty();
 
-        self.cosmetic_filters.into_iter().for_each(|filter| {
+        cosmetic_filters.into_iter().for_each(|filter| {
             let original_rule = *filter
                 .raw_line
                 .clone()
@@ -397,6 +389,18 @@ pub enum ParsedFilter {
     Cosmetic(CosmeticFilter),
 }
 
+pub enum ParsedMetadata {
+    Homepage(String),
+    Title(String),
+    Expires(ExpiresInterval),
+    Redirect(String),
+    Unknown,
+}
+pub enum ParsedLine {
+    ParsedFilter(ParsedFilter),
+    Metadata(ParsedMetadata),
+}
+
 impl From<NetworkFilter> for ParsedFilter {
     fn from(v: NetworkFilter) -> Self {
         ParsedFilter::Network(v)
@@ -420,6 +424,8 @@ pub enum FilterParseError {
     Unsupported,
     #[error("empty")]
     Empty,
+    #[error("invalid expires interval")]
+    InvalidExpiresInterval,
 }
 
 impl From<NetworkFilterError> for FilterParseError {
@@ -510,40 +516,52 @@ pub fn parse_filter(
     }
 }
 
+pub(crate) fn parse_filter_line(
+    line: &str,
+    debug: bool,
+    opts: ParseOptions,
+) -> Result<ParsedLine, FilterParseError> {
+    if let Some(kv) = line.strip_prefix("! ") {
+        if let Some((key, value)) = kv.split_once(": ") {
+            let metadata = match key {
+                "Homepage" => ParsedMetadata::Homepage(value.to_string()),
+                "Title" => ParsedMetadata::Title(value.to_string()),
+                "Expires" => {
+                    if let Ok(expires) = ExpiresInterval::try_from(value) {
+                        ParsedMetadata::Expires(expires)
+                    } else {
+                        return Err(FilterParseError::InvalidExpiresInterval);
+                    }
+                }
+                "Redirect" => ParsedMetadata::Redirect(value.to_string()),
+                _ => ParsedMetadata::Unknown,
+            };
+            return Ok(ParsedLine::Metadata(metadata));
+        }
+        return Err(FilterParseError::Unsupported);
+    }
+
+    let parsed_filter = parse_filter(line, debug, opts)?;
+    Ok(ParsedLine::ParsedFilter(parsed_filter))
+}
+
 /// Parse an entire list of filters, ignoring any errors
 pub fn parse_filters(
     list: impl IntoIterator<Item = impl AsRef<str>>,
     debug: bool,
     opts: ParseOptions,
 ) -> (Vec<NetworkFilter>, Vec<CosmeticFilter>) {
-    let (_metadata, network_filters, cosmetic_filters) =
-        parse_filters_with_metadata(list, debug, opts);
-
-    (network_filters, cosmetic_filters)
-}
-
-/// Parse an entire list of filters, ignoring any errors
-pub fn parse_filters_with_metadata(
-    list: impl IntoIterator<Item = impl AsRef<str>>,
-    debug: bool,
-    opts: ParseOptions,
-) -> (FilterListMetadata, Vec<NetworkFilter>, Vec<CosmeticFilter>) {
-    let mut metadata = FilterListMetadata::default();
-
     let list_iter = list.into_iter();
 
     let (network_filters, cosmetic_filters): (Vec<_>, Vec<_>) = list_iter
-        .map(|line| {
-            metadata.try_add(line.as_ref());
-            parse_filter(line.as_ref(), debug, opts)
-        })
+        .map(|line| parse_filter(line.as_ref(), debug, opts))
         .filter_map(Result::ok)
         .partition_map(|filter| match filter {
             ParsedFilter::Network(f) => Either::Left(f),
             ParsedFilter::Cosmetic(f) => Either::Right(f),
         });
 
-    (metadata, network_filters, cosmetic_filters)
+    (network_filters, cosmetic_filters)
 }
 
 /// Given a single line, checks if this would likely be a cosmetic filter, a

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -180,18 +180,18 @@ pub struct FilterListMetadata {
 }
 
 impl FilterListMetadata {
-    pub(crate) fn add_metadata(&mut self, metadata: ParsedMetadata) {
-        match metadata {
-            ParsedMetadata::Homepage(value) if self.homepage.is_none() => {
+    pub(crate) fn add_metadata(&mut self, item: ParsedLine) {
+        match item {
+            ParsedLine::Homepage(value) if self.homepage.is_none() => {
                 self.homepage = Some(value);
             }
-            ParsedMetadata::Title(value) if self.title.is_none() => {
+            ParsedLine::Title(value) if self.title.is_none() => {
                 self.title = Some(value);
             }
-            ParsedMetadata::Expires(value) if self.expires.is_none() => {
+            ParsedLine::Expires(value) if self.expires.is_none() => {
                 self.expires = Some(value);
             }
-            ParsedMetadata::Redirect(value) if self.redirect.is_none() => {
+            ParsedLine::Redirect(value) if self.redirect.is_none() => {
                 self.redirect = Some(value);
             }
             _ => (),
@@ -341,7 +341,7 @@ impl FilterSet {
 }
 
 /// Denotes the format of a particular list resource, which affects how its rules should be parsed.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum FilterFormat {
     /// Rules should be parsed in ABP/uBO-style format.
     Standard,
@@ -376,33 +376,26 @@ pub enum FilterType {
     NotSupported,
 }
 
-/// Successful result of parsing a single filter rule
-pub enum ParsedFilter {
+/// Successful result of parsing a single line from a filter list
+pub enum ParsedLine {
     Network(NetworkFilter),
     Cosmetic(CosmeticFilter),
-}
-
-pub enum ParsedMetadata {
     Homepage(String),
     Title(String),
     Expires(ExpiresInterval),
     Redirect(String),
-    Unknown,
-}
-pub enum ParsedLine {
-    ParsedFilter(ParsedFilter),
-    Metadata(ParsedMetadata),
+    UnknownMetadata,
 }
 
-impl From<NetworkFilter> for ParsedFilter {
+impl From<NetworkFilter> for ParsedLine {
     fn from(v: NetworkFilter) -> Self {
-        ParsedFilter::Network(v)
+        ParsedLine::Network(v)
     }
 }
 
-impl From<CosmeticFilter> for ParsedFilter {
+impl From<CosmeticFilter> for ParsedLine {
     fn from(v: CosmeticFilter) -> Self {
-        ParsedFilter::Cosmetic(v)
+        ParsedLine::Cosmetic(v)
     }
 }
 
@@ -433,12 +426,33 @@ impl From<CosmeticFilterError> for FilterParseError {
     }
 }
 
-/// Parse a single filter rule
+/// Parse a single line from a filter list
 pub fn parse_filter(
     line: &str,
     debug: bool,
     opts: ParseOptions,
-) -> Result<ParsedFilter, FilterParseError> {
+) -> Result<ParsedLine, FilterParseError> {
+    if opts.format == FilterFormat::Standard {
+        if let Some(kv) = line.strip_prefix("! ") {
+            if let Some((key, value)) = kv.split_once(": ") {
+                return Ok(match key {
+                    "Homepage" => ParsedLine::Homepage(value.to_string()),
+                    "Title" => ParsedLine::Title(value.to_string()),
+                    "Expires" => {
+                        if let Ok(expires) = ExpiresInterval::try_from(value) {
+                            ParsedLine::Expires(expires)
+                        } else {
+                            return Err(FilterParseError::InvalidExpiresInterval);
+                        }
+                    }
+                    "Redirect" => ParsedLine::Redirect(value.to_string()),
+                    _ => ParsedLine::UnknownMetadata,
+                });
+            }
+            return Ok(ParsedLine::UnknownMetadata);
+        }
+    }
+
     let filter = line.trim();
 
     if filter.is_empty() {
@@ -509,50 +523,20 @@ pub fn parse_filter(
     }
 }
 
-pub(crate) fn parse_filter_line(
-    line: &str,
-    debug: bool,
-    opts: ParseOptions,
-) -> Result<ParsedLine, FilterParseError> {
-    if let Some(kv) = line.strip_prefix("! ") {
-        if let Some((key, value)) = kv.split_once(": ") {
-            let metadata = match key {
-                "Homepage" => ParsedMetadata::Homepage(value.to_string()),
-                "Title" => ParsedMetadata::Title(value.to_string()),
-                "Expires" => {
-                    if let Ok(expires) = ExpiresInterval::try_from(value) {
-                        ParsedMetadata::Expires(expires)
-                    } else {
-                        return Err(FilterParseError::InvalidExpiresInterval);
-                    }
-                }
-                "Redirect" => ParsedMetadata::Redirect(value.to_string()),
-                _ => ParsedMetadata::Unknown,
-            };
-            return Ok(ParsedLine::Metadata(metadata));
-        }
-        return Err(FilterParseError::Unsupported);
-    }
-
-    let parsed_filter = parse_filter(line, debug, opts)?;
-    Ok(ParsedLine::ParsedFilter(parsed_filter))
-}
-
 /// Parse an entire list of filters, ignoring any errors
 pub fn parse_filters(
     list: impl IntoIterator<Item = impl AsRef<str>>,
     debug: bool,
     opts: ParseOptions,
 ) -> (Vec<NetworkFilter>, Vec<CosmeticFilter>) {
-    let list_iter = list.into_iter();
-
-    let (network_filters, cosmetic_filters): (Vec<_>, Vec<_>) = list_iter
-        .map(|line| parse_filter(line.as_ref(), debug, opts))
-        .filter_map(Result::ok)
-        .partition_map(|filter| match filter {
-            ParsedFilter::Network(f) => Either::Left(f),
-            ParsedFilter::Cosmetic(f) => Either::Right(f),
-        });
+    let (network_filters, cosmetic_filters): (Vec<_>, Vec<_>) = list
+        .into_iter()
+        .filter_map(|line| match parse_filter(line.as_ref(), debug, opts) {
+            Ok(ParsedLine::Network(f)) => Some(Either::Left(f)),
+            Ok(ParsedLine::Cosmetic(f)) => Some(Either::Right(f)),
+            _ => None,
+        })
+        .partition_map(|x| x);
 
     (network_filters, cosmetic_filters)
 }

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -39,19 +39,19 @@ use serde::{Deserialize, Serialize};
 /// # use adblock::lists::ParseOptions;
 /// # use adblock::resources::{MimeType, PermissionMask, Resource, ResourceStorage, ResourceType};
 /// # let mut filter_set = adblock::lists::FilterSet::default();
-/// # let untrusted_filters = vec![""];
-/// # let trusted_filters = vec![""];
+/// # let untrusted_filters = "".to_string();
+/// # let trusted_filters = "".to_string();
 /// const COOKIE_ACCESS: PermissionMask = PermissionMask::from_bits(0b00000001);
 /// const LOCALSTORAGE_ACCESS: PermissionMask = PermissionMask::from_bits(0b00000010);
 ///
 /// // `untrusted_filters` will not be able to use privileged scriptlet injections.
-/// filter_set.add_filters(
+/// filter_set.add_filter_list(
 ///     untrusted_filters,
 ///     Default::default(),
 /// );
 /// // `trusted_filters` will be able to inject scriptlets requiring `COOKIE_ACCESS`
 /// // permissions or `LOCALSTORAGE_ACCESS` permissions.
-/// filter_set.add_filters(
+/// filter_set.add_filter_list(
 ///     trusted_filters,
 ///     ParseOptions {
 ///         permissions: COOKIE_ACCESS | LOCALSTORAGE_ACCESS,

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -59,7 +59,7 @@ use serde::{Deserialize, Serialize};
 ///     },
 /// );
 ///
-/// let mut engine = Engine::from_filter_set(filter_set, true);
+/// let mut engine = Engine::new_with_filter_set(filter_set, true);
 /// // The `trusted-set-cookie` scriptlet cannot be injected without `COOKIE_ACCESS`
 /// // permission.
 /// engine.use_resources([Resource {

--- a/tests/legacy_harness.rs
+++ b/tests/legacy_harness.rs
@@ -34,7 +34,7 @@ mod legacy_test_filters {
             filter.filter
         );
 
-        let engine = Engine::from_rules_debug([raw_filter], Default::default());
+        let engine = Engine::from_text(raw_filter, Default::default());
 
         for to_block in blocked {
             assert!(
@@ -306,8 +306,8 @@ mod legacy_test_filters {
 
         // explicit, separate testcase construction of the "script" option as it is not the deafult
         let request = Request::new("http://tpc.googlesyndication.com/safeframe/1-0-2/html/container.html#xpc=sf-gdn-exp-2&p=http%3A//slashdot.org;", "https://this-is-always-third-party.com", "script").unwrap();
-        let engine = Engine::from_rules_debug(
-            ["||googlesyndication.com/safeframe/$third-party,script"],
+        let engine = Engine::from_text(
+            "||googlesyndication.com/safeframe/$third-party,script",
             Default::default(),
         );
         assert!(engine.check_network_request(&request).matched);
@@ -324,7 +324,7 @@ mod legacy_check_match {
         not_blocked: &[&'a str],
         tags: &[&'a str],
     ) {
-        let mut engine = Engine::from_rules(rules, Default::default()); // first one with the provided rules
+        let mut engine = Engine::from_text(rules.join("\n"), Default::default()); // first one with the provided rules
         engine.use_tags(tags);
 
         let mut engine_deserialized = Engine::default(); // second empty
@@ -395,11 +395,12 @@ mod legacy_check_match {
         {
             // Explicitly write out the full case instead of using check_match helper
             // or tweaking it to allow passing in the source domain for this one case
-            let engine = Engine::from_rules(
+            let engine = Engine::from_text(
                 [
                     "/ads/freewheel/*",
                     "@@||turner.com^*/ads/freewheel/*/AdManager.js$domain=cnn.com",
-                ],
+                ]
+                .join("\n"),
                 Default::default(),
             );
             let mut engine_deserialized = Engine::default(); // second empty
@@ -505,7 +506,7 @@ mod legacy_check_options {
     use adblock::Engine;
 
     fn check_option_rule<'a>(rules: &[&'a str], tests: &[(&'a str, &'a str, &'a str, bool)]) {
-        let engine = Engine::from_rules(rules, Default::default()); // first one with the provided rules
+        let engine = Engine::from_text(rules.join("\n"), Default::default()); // first one with the provided rules
 
         for (url, source_url, request_type, expectation) in tests {
             let request = Request::new(url, source_url, request_type).unwrap();
@@ -851,8 +852,8 @@ mod legacy_misc_tests {
     #[test]
     fn demo_app() {
         // Demo app test
-        let engine = Engine::from_rules(
-            ["||googlesyndication.com/safeframe/$third-party"],
+        let engine = Engine::from_text(
+            "||googlesyndication.com/safeframe/$third-party",
             Default::default(),
         );
 
@@ -882,12 +883,13 @@ mod legacy_misc_tests {
 
     #[test]
     fn serialization_tests() {
-        let engine = Engine::from_rules_parametrised(
+        let engine = Engine::from_text_parametrised(
             [
                 "||googlesyndication.com$third-party",
                 "@@||googlesyndication.ca",
                 "a$explicitcancel",
-            ],
+            ]
+            .join("\n"),
             Default::default(),
             true,
             false,
@@ -974,12 +976,15 @@ mod legacy_misc_tests {
 
     #[test]
     fn find_matching_filters() {
-        let engine = Engine::from_rules_debug(
+        let engine = Engine::from_text_parametrised(
             [
                 "||googlesyndication.com/safeframe/$third-party",
                 "||brianbondy.com/ads",
-            ],
+            ]
+            .join("\n"),
             Default::default(),
+            true,
+            true,
         );
 
         let current_page_frame = "http://slashdot.org";
@@ -1018,13 +1023,16 @@ mod legacy_misc_tests {
 
     #[test]
     fn find_matching_filters_exceptions() {
-        let engine = Engine::from_rules_debug(
+        let engine = Engine::from_text_parametrised(
             [
                 "||googlesyndication.com/safeframe/$third-party",
                 "||brianbondy.com/ads",
                 "@@safeframe",
-            ],
+            ]
+            .join("\n"),
             Default::default(),
+            true,
+            true,
         );
 
         let current_page_frame = "http://slashdot.org";
@@ -1056,9 +1064,11 @@ mod legacy_misc_tests {
     #[test]
     fn matches_with_filter_info_preserves_important() {
         // exceptions have not effect if important filter matches
-        let engine = Engine::from_rules_debug(
-            ["||brianbondy.com^$important", "@@||brianbondy.com^"],
+        let engine = Engine::from_text_parametrised(
+            ["||brianbondy.com^$important", "@@||brianbondy.com^"].join("\n"),
             Default::default(),
+            true,
+            true,
         );
 
         let request =

--- a/tests/legacy_harness.rs
+++ b/tests/legacy_harness.rs
@@ -34,7 +34,7 @@ mod legacy_test_filters {
             filter.filter
         );
 
-        let engine = Engine::from_text(raw_filter, Default::default());
+        let engine = Engine::new_with_list_text(raw_filter, Default::default());
 
         for to_block in blocked {
             assert!(
@@ -306,7 +306,7 @@ mod legacy_test_filters {
 
         // explicit, separate testcase construction of the "script" option as it is not the deafult
         let request = Request::new("http://tpc.googlesyndication.com/safeframe/1-0-2/html/container.html#xpc=sf-gdn-exp-2&p=http%3A//slashdot.org;", "https://this-is-always-third-party.com", "script").unwrap();
-        let engine = Engine::from_text(
+        let engine = Engine::new_with_list_text(
             "||googlesyndication.com/safeframe/$third-party,script",
             Default::default(),
         );
@@ -324,7 +324,7 @@ mod legacy_check_match {
         not_blocked: &[&'a str],
         tags: &[&'a str],
     ) {
-        let mut engine = Engine::from_text(rules.join("\n"), Default::default()); // first one with the provided rules
+        let mut engine = Engine::new_with_list_text(rules.join("\n"), Default::default()); // first one with the provided rules
         engine.use_tags(tags);
 
         let mut engine_deserialized = Engine::default(); // second empty
@@ -395,7 +395,7 @@ mod legacy_check_match {
         {
             // Explicitly write out the full case instead of using check_match helper
             // or tweaking it to allow passing in the source domain for this one case
-            let engine = Engine::from_text(
+            let engine = Engine::new_with_list_text(
                 [
                     "/ads/freewheel/*",
                     "@@||turner.com^*/ads/freewheel/*/AdManager.js$domain=cnn.com",
@@ -506,7 +506,7 @@ mod legacy_check_options {
     use adblock::Engine;
 
     fn check_option_rule<'a>(rules: &[&'a str], tests: &[(&'a str, &'a str, &'a str, bool)]) {
-        let engine = Engine::from_text(rules.join("\n"), Default::default()); // first one with the provided rules
+        let engine = Engine::new_with_list_text(rules.join("\n"), Default::default()); // first one with the provided rules
 
         for (url, source_url, request_type, expectation) in tests {
             let request = Request::new(url, source_url, request_type).unwrap();
@@ -852,7 +852,7 @@ mod legacy_misc_tests {
     #[test]
     fn demo_app() {
         // Demo app test
-        let engine = Engine::from_text(
+        let engine = Engine::new_with_list_text(
             "||googlesyndication.com/safeframe/$third-party",
             Default::default(),
         );
@@ -883,7 +883,7 @@ mod legacy_misc_tests {
 
     #[test]
     fn serialization_tests() {
-        let engine = Engine::from_text_parametrised(
+        let engine = Engine::new_with_list_text_parametrised(
             [
                 "||googlesyndication.com$third-party",
                 "@@||googlesyndication.ca",
@@ -976,7 +976,7 @@ mod legacy_misc_tests {
 
     #[test]
     fn find_matching_filters() {
-        let engine = Engine::from_text_parametrised(
+        let engine = Engine::new_with_list_text_parametrised(
             [
                 "||googlesyndication.com/safeframe/$third-party",
                 "||brianbondy.com/ads",
@@ -1023,7 +1023,7 @@ mod legacy_misc_tests {
 
     #[test]
     fn find_matching_filters_exceptions() {
-        let engine = Engine::from_text_parametrised(
+        let engine = Engine::new_with_list_text_parametrised(
             [
                 "||googlesyndication.com/safeframe/$third-party",
                 "||brianbondy.com/ads",
@@ -1064,7 +1064,7 @@ mod legacy_misc_tests {
     #[test]
     fn matches_with_filter_info_preserves_important() {
         // exceptions have not effect if important filter matches
-        let engine = Engine::from_text_parametrised(
+        let engine = Engine::new_with_list_text_parametrised(
             ["||brianbondy.com^$important", "@@||brianbondy.com^"].join("\n"),
             Default::default(),
             true,

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -124,8 +124,8 @@ fn get_all_filters() -> &'static adblock::lists::FilterSet {
                 .await
                 .iter()
                 .for_each(|(format, list)| {
-                    filter_set.add_filters(
-                        list.lines().map(|s| s.to_owned()).collect::<Vec<_>>(),
+                    filter_set.add_filter_list(
+                        list.clone(),
                         adblock::lists::ParseOptions {
                             format: *format,
                             ..Default::default()

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -150,7 +150,7 @@ fn troubleshoot() {
 }
 
 fn get_blocker_engine() -> Engine {
-    let mut engine = Engine::from_filter_set(get_all_filters().clone(), true);
+    let mut engine = Engine::new_with_filter_set(get_all_filters().clone(), true);
 
     engine.use_tags(&["fb-embeds", "twitter-embeds"]);
 
@@ -278,7 +278,7 @@ fn check_live_redirects() {
 /// Ensure that one engine's serialization result can be exactly reproduced by another engine after
 /// deserializing from it.
 fn stable_serialization_through_load() {
-    let engine1 = Engine::from_filter_set(get_all_filters().clone(), true);
+    let engine1 = Engine::new_with_filter_set(get_all_filters().clone(), true);
     let ser1 = engine1.serialize().to_vec();
 
     let mut engine2 = Engine::default();

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -190,10 +190,10 @@ fn check_rule_matching_browserlike() {
     }
 
     fn load_requests() -> Vec<TestRequest> {
-        let requests_str = rules_from_lists(&["data/requests.json"]);
+        let requests_str = rules_from_lists(["data/requests.json"]);
         requests_str
-            .into_iter()
-            .filter_map(|r| serde_json::from_str(&r).ok())
+            .lines()
+            .filter_map(|r| serde_json::from_str(r).ok())
             .collect()
     }
 
@@ -213,7 +213,7 @@ fn check_rule_matching_browserlike() {
 
     let requests = load_requests();
     let rules = rules_from_lists(&["data/brave/brave-main-list.txt"]);
-    let engine = Engine::from_rules(rules, Default::default());
+    let engine = Engine::from_text(rules, Default::default());
     let (blocked, passes) = bench_rule_matching_browserlike(&engine, &requests);
     let msg = "The number of blocked/passed requests has changed. ".to_string()
         + "If this is expected, update the expected values in the test.";

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -77,8 +77,7 @@ fn check_filter_matching() {
                     .set(NetworkFilterMask::IS_EXCEPTION, false);
                 filters.push(original_filter);
             }
-            let filter_set = adblock::FilterSet::new_with_rules(filters, vec![], true);
-            let engine = adblock::Engine::from_filter_set(filter_set, true);
+            let engine = adblock::Engine::new_with_parsed_rules(filters, vec![], true);
 
             let request_res = Request::new(&req.url, &req.sourceUrl, &req.r#type);
             // The dataset has cases where URL is set to just "http://" or "https://", which we do not support
@@ -121,7 +120,7 @@ fn check_engine_matching() {
         }
         for filter in req.filters {
             let opts = ParseOptions::default();
-            let mut engine = Engine::from_rules_debug(std::slice::from_ref(&filter), opts);
+            let mut engine = Engine::from_text(filter.clone(), opts);
             let resources = build_resources_from_filters(std::slice::from_ref(&filter));
             engine.use_resources(resources);
 

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -120,7 +120,7 @@ fn check_engine_matching() {
         }
         for filter in req.filters {
             let opts = ParseOptions::default();
-            let mut engine = Engine::from_text(filter.clone(), opts);
+            let mut engine = Engine::new_with_list_text(filter.clone(), opts);
             let resources = build_resources_from_filters(std::slice::from_ref(&filter));
             engine.use_resources(resources);
 
@@ -213,7 +213,7 @@ fn check_rule_matching_browserlike() {
 
     let requests = load_requests();
     let rules = rules_from_lists(&["data/brave/brave-main-list.txt"]);
-    let engine = Engine::from_text(rules, Default::default());
+    let engine = Engine::new_with_list_text(rules, Default::default());
     let (blocked, passes) = bench_rule_matching_browserlike(&engine, &requests);
     let msg = "The number of blocked/passed requests has changed. ".to_string()
         + "If this is expected, update the expected values in the test.";

--- a/tests/simple_use.rs
+++ b/tests/simple_use.rs
@@ -10,7 +10,7 @@ fn check_simple_use() {
         "-advertisement/script.",
     ];
 
-    let engine = Engine::from_rules(rules, Default::default());
+    let engine = Engine::from_text(rules.join("\n"), Default::default());
 
     let request = Request::new(
         "http://example.com/-advertisement-icon.",

--- a/tests/simple_use.rs
+++ b/tests/simple_use.rs
@@ -10,7 +10,7 @@ fn check_simple_use() {
         "-advertisement/script.",
     ];
 
-    let engine = Engine::from_text(rules.join("\n"), Default::default());
+    let engine = Engine::new_with_list_text(rules.join("\n"), Default::default());
 
     let request = Request::new(
         "http://example.com/-advertisement-icon.",

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -2,18 +2,11 @@
 //! needed outside of this directory.
 
 #[cfg(not(target_arch = "wasm32"))]
-pub fn rules_from_lists(
-    lists: impl IntoIterator<Item = impl AsRef<str>>,
-) -> impl Iterator<Item = String> {
-    fn read_file_lines(filename: &str) -> impl Iterator<Item = String> {
-        use std::fs::File;
-        use std::io::{BufRead, BufReader};
-
-        let reader = BufReader::new(File::open(filename).unwrap());
-        reader.lines().map(|r| r.unwrap())
+pub fn rules_from_lists(list_files: impl IntoIterator<Item = impl AsRef<str>>) -> String {
+    let mut contents = String::new();
+    for file in list_files {
+        contents.push_str(&std::fs::read_to_string(file.as_ref()).unwrap());
+        contents.push('\n');
     }
-
-    lists
-        .into_iter()
-        .flat_map(|filename| read_file_lines(filename.as_ref()))
+    contents
 }

--- a/tests/ublock-coverage.rs
+++ b/tests/ublock-coverage.rs
@@ -48,11 +48,11 @@ fn get_blocker_engine() -> Engine {
         "data/regression-testing/easyprivacy.txt",
     ]);
 
-    Engine::from_rules_parametrised(rules, Default::default(), true, false)
+    Engine::from_text_parametrised(rules, Default::default(), true, false)
 }
 
 fn get_blocker_engine_default(extra_rules: impl IntoIterator<Item = impl AsRef<str>>) -> Engine {
-    let rules = rules_from_lists([
+    let mut rules = rules_from_lists([
         "data/easylist.to/easylist/easylist.txt",
         "data/easylist.to/easylist/easyprivacy.txt",
         "data/uBlockOrigin/unbreak.txt",
@@ -62,16 +62,19 @@ fn get_blocker_engine_default(extra_rules: impl IntoIterator<Item = impl AsRef<s
         // "data/test/abpjf.txt",
     ]);
 
-    let all_rules = rules.chain(extra_rules.into_iter().map(|r| r.as_ref().to_string()));
+    for rule in extra_rules {
+        rules.push_str(rule.as_ref());
+        rules.push('\n');
+    }
 
-    Engine::from_rules_parametrised(all_rules, Default::default(), true, false)
+    Engine::from_text_parametrised(rules, Default::default(), true, false)
 }
 
 #[test]
 fn check_specific_rules() {
     {
         // exceptions have not effect if important filter matches
-        let engine = Engine::from_rules_debug(["||www.facebook.com/*/plugin"], Default::default());
+        let engine = Engine::from_text("||www.facebook.com/*/plugin", Default::default());
 
         let request =
             Request::new("https://www.facebook.com/v3.2/plugins/comments.ph", "", "").unwrap();
@@ -85,10 +88,8 @@ fn check_specific_rules() {
         use std::path::Path;
 
         // exceptions have no effect if important filter matches
-        let mut engine = Engine::from_rules_debug(
-            [
-                "||cdn.taboola.com/libtrc/*/loader.js$script,redirect=noopjs,important,domain=cnet.com",
-            ],
+        let mut engine = Engine::from_text(
+            "||cdn.taboola.com/libtrc/*/loader.js$script,redirect=noopjs,important,domain=cnet.com",
             Default::default(),
         );
         let resources = adblock::resources::resource_assembler::assemble_web_accessible_resources(

--- a/tests/ublock-coverage.rs
+++ b/tests/ublock-coverage.rs
@@ -48,7 +48,7 @@ fn get_blocker_engine() -> Engine {
         "data/regression-testing/easyprivacy.txt",
     ]);
 
-    Engine::from_text_parametrised(rules, Default::default(), true, false)
+    Engine::new_with_list_text_parametrised(rules, Default::default(), true, false)
 }
 
 fn get_blocker_engine_default(extra_rules: impl IntoIterator<Item = impl AsRef<str>>) -> Engine {
@@ -67,14 +67,14 @@ fn get_blocker_engine_default(extra_rules: impl IntoIterator<Item = impl AsRef<s
         rules.push('\n');
     }
 
-    Engine::from_text_parametrised(rules, Default::default(), true, false)
+    Engine::new_with_list_text_parametrised(rules, Default::default(), true, false)
 }
 
 #[test]
 fn check_specific_rules() {
     {
         // exceptions have not effect if important filter matches
-        let engine = Engine::from_text("||www.facebook.com/*/plugin", Default::default());
+        let engine = Engine::new_with_list_text("||www.facebook.com/*/plugin", Default::default());
 
         let request =
             Request::new("https://www.facebook.com/v3.2/plugins/comments.ph", "", "").unwrap();
@@ -88,7 +88,7 @@ fn check_specific_rules() {
         use std::path::Path;
 
         // exceptions have no effect if important filter matches
-        let mut engine = Engine::from_text(
+        let mut engine = Engine::new_with_list_text(
             "||cdn.taboola.com/libtrc/*/loader.js$script,redirect=noopjs,important,domain=cnet.com",
             Default::default(),
         );

--- a/tests/unit/blocker.rs
+++ b/tests/unit/blocker.rs
@@ -1316,7 +1316,7 @@ mod placeholder_string_tests {
     fn test_constant_placeholder_string() {
         let mut filter_set = crate::lists::FilterSet::new(false);
         filter_set.add_filter_list("||example.com^\n".to_string(), Default::default());
-        let engine = crate::Engine::from_filter_set(filter_set, true);
+        let engine = crate::Engine::new_with_filter_set(filter_set, true);
         let block = engine.check_network_request(
             &crate::request::Request::new("https://example.com", "https://example.com", "document")
                 .unwrap(),
@@ -1455,7 +1455,7 @@ mod legacy_rule_parsing_tests {
             enable_optimizations: false, // optimizations will reduce number of rules
         };
 
-        let blocker = Blocker::new_from_text(rules, &blocker_options);
+        let blocker = Blocker::new_with_list_text(rules, &blocker_options);
 
         // Some filters in the filter_map are pointed at by multiple tokens, increasing the total number of items
         assert!(

--- a/tests/unit/blocker.rs
+++ b/tests/unit/blocker.rs
@@ -2,7 +2,6 @@
 mod blocker_tests {
 
     use super::super::*;
-    use crate::lists::parse_filters;
     use crate::request::Request;
     use crate::resources::{Resource, ResourceStorage};
     use base64::{engine::Engine as _, prelude::BASE64_STANDARD};
@@ -13,13 +12,11 @@ mod blocker_tests {
     fn single_slash() {
         let filters = ["/|"];
 
-        let (network_filters, _) = parse_filters(filters, true, Default::default());
-
         let blocker_options = BlockerOptions {
             enable_optimizations: true,
         };
 
-        let blocker = Blocker::new(network_filters, &blocker_options);
+        let blocker = Blocker::new(filters, &blocker_options);
 
         let request = Request::new(
             "https://example.com/test/",
@@ -42,13 +39,11 @@ mod blocker_tests {
         filters: impl IntoIterator<Item = impl AsRef<str>>,
         requests: &[(Request, bool)],
     ) {
-        let (network_filters, _) = parse_filters(filters, true, Default::default());
-
         let blocker_options: BlockerOptions = BlockerOptions {
             enable_optimizations: false, // optimizations will reduce number of rules
         };
 
-        let blocker = Blocker::new(network_filters, &blocker_options);
+        let blocker = Blocker::new(filters, &blocker_options);
 
         requests.iter().for_each(|(req, expected_result)| {
             let matched_rule = blocker.check(req, &Default::default());
@@ -78,13 +73,11 @@ mod blocker_tests {
         )
         .unwrap();
 
-        let (network_filters, _) = parse_filters(filters, true, Default::default());
-
         let blocker_options: BlockerOptions = BlockerOptions {
             enable_optimizations: false,
         };
 
-        let blocker = Blocker::new(network_filters, &blocker_options);
+        let blocker = Blocker::new(filters, &blocker_options);
         let resources = ResourceStorage::in_memory_from_resources([Resource::simple(
             "noop-0.1s.mp3",
             crate::resources::MimeType::AudioMp3,
@@ -118,13 +111,11 @@ mod blocker_tests {
         )
         .unwrap();
 
-        let (network_filters, _) = parse_filters(filters, true, Default::default());
-
         let blocker_options: BlockerOptions = BlockerOptions {
             enable_optimizations: false,
         };
 
-        let blocker = Blocker::new(network_filters, &blocker_options);
+        let blocker = Blocker::new(filters, &blocker_options);
         let resources = ResourceStorage::in_memory_from_resources([Resource::simple(
             "noop-0.1s.mp3",
             crate::resources::MimeType::AudioMp3,
@@ -153,13 +144,11 @@ mod blocker_tests {
         let request =
             Request::new("https://www3.doubleclick.net", "https://lineups.fun", "xhr").unwrap();
 
-        let (network_filters, _) = parse_filters(filters, true, Default::default());
-
         let blocker_options: BlockerOptions = BlockerOptions {
             enable_optimizations: false,
         };
 
-        let blocker = Blocker::new(network_filters, &blocker_options);
+        let blocker = Blocker::new(filters, &blocker_options);
         let resources = ResourceStorage::in_memory_from_resources([Resource::simple(
             "noop.txt",
             crate::resources::MimeType::TextPlain,
@@ -225,13 +214,11 @@ mod blocker_tests {
     fn trailing_dot_domain() {
         let filters = ["||dot.example.com.^", "||test.example.com^"];
 
-        let (network_filters, _) = parse_filters(filters, true, Default::default());
-
         let blocker_options = BlockerOptions {
             enable_optimizations: true,
         };
 
-        let blocker = Blocker::new(network_filters, &blocker_options);
+        let blocker = Blocker::new(filters, &blocker_options);
 
         let request = Request::new(
             "https://dot.example.com",
@@ -311,13 +298,11 @@ mod blocker_tests {
             ),
         ];
 
-        let (network_filters, _) = parse_filters(filters, true, Default::default());
-
         let blocker_options = BlockerOptions {
             enable_optimizations: false, // optimizations will reduce number of rules
         };
 
-        let blocker = Blocker::new(network_filters, &blocker_options);
+        let blocker = Blocker::new(filters, &blocker_options);
         let resources = ResourceStorage::default();
 
         url_results.into_iter().for_each(|(req, expected_result)| {
@@ -346,13 +331,11 @@ mod blocker_tests {
             "^first-party-only^$csp=script-src 'none',1p",
         ];
 
-        let (network_filters, _) = parse_filters(filters, true, Default::default());
-
         let blocker_options = BlockerOptions {
             enable_optimizations: false,
         };
 
-        let blocker = Blocker::new(network_filters, &blocker_options);
+        let blocker = Blocker::new(filters, &blocker_options);
 
         {
             // No directives should be returned for requests that are not `document` or `subdocument` content types.
@@ -540,13 +523,11 @@ mod blocker_tests {
             "$removeparam=testCase,~xhr",
         ];
 
-        let (network_filters, _) = parse_filters(filters, true, Default::default());
-
         let blocker_options = BlockerOptions {
             enable_optimizations: true,
         };
 
-        let blocker = Blocker::new(network_filters, &blocker_options);
+        let blocker = Blocker::new(filters, &blocker_options);
         let resources = ResourceStorage::in_memory_from_resources([Resource::simple(
             "noopjs",
             crate::resources::MimeType::ApplicationJavascript,
@@ -938,13 +919,11 @@ mod blocker_tests {
         .map(|s| format!("*$removeparam={s}"))
         .collect::<Vec<_>>();
 
-        let (network_filters, _) = parse_filters(&filters, true, Default::default());
-
         let blocker_options = BlockerOptions {
             enable_optimizations: true,
         };
 
-        let blocker = Blocker::new(network_filters, &blocker_options);
+        let blocker = Blocker::new(filters, &blocker_options);
         let resources = ResourceStorage::default();
 
         for (original, expected) in testcases.into_iter() {
@@ -968,13 +947,11 @@ mod blocker_tests {
     fn test_removeparam_same_tokens() {
         let filters = ["$removeparam=example1_", "$removeparam=example1-"];
 
-        let (network_filters, _) = parse_filters(filters, true, Default::default());
-
         let blocker_options = BlockerOptions {
             enable_optimizations: true,
         };
 
-        let blocker = Blocker::new(network_filters, &blocker_options);
+        let blocker = Blocker::new(filters, &blocker_options);
 
         let result = blocker.check(
             &Request::new(
@@ -1000,13 +977,11 @@ mod blocker_tests {
             "@@^exceptc20^$redirect-rule=c:20",
         ];
 
-        let (network_filters, _) = parse_filters(filters, true, Default::default());
-
         let blocker_options = BlockerOptions {
             enable_optimizations: true,
         };
 
-        let blocker = Blocker::new(network_filters, &blocker_options);
+        let blocker = Blocker::new(filters, &blocker_options);
         fn simple_resource(identifier: &str) -> Resource {
             Resource::simple(
                 identifier,
@@ -1162,13 +1137,11 @@ mod blocker_tests {
             })
             .collect();
 
-        let (network_filters, _) = parse_filters(filters, true, Default::default());
-
         let blocker_options: BlockerOptions = BlockerOptions {
             enable_optimizations: false, // optimizations will reduce number of rules
         };
 
-        let mut blocker = Blocker::new(network_filters, &blocker_options);
+        let mut blocker = Blocker::new(filters, &blocker_options);
         let resources = Default::default();
         blocker.enable_tags(&["stuff"]);
         assert_eq!(
@@ -1215,13 +1188,11 @@ mod blocker_tests {
             })
             .collect();
 
-        let (network_filters, _) = parse_filters(filters, true, Default::default());
-
         let blocker_options: BlockerOptions = BlockerOptions {
             enable_optimizations: false, // optimizations will reduce number of rules
         };
 
-        let mut blocker = Blocker::new(network_filters, &blocker_options);
+        let mut blocker = Blocker::new(filters, &blocker_options);
         let resources = Default::default();
         blocker.enable_tags(&["stuff"]);
         blocker.enable_tags(&["brian"]);
@@ -1269,13 +1240,11 @@ mod blocker_tests {
             })
             .collect();
 
-        let (network_filters, _) = parse_filters(filters, true, Default::default());
-
         let blocker_options: BlockerOptions = BlockerOptions {
             enable_optimizations: false, // optimizations will reduce number of rules
         };
 
-        let mut blocker = Blocker::new(network_filters, &blocker_options);
+        let mut blocker = Blocker::new(filters, &blocker_options);
         let resources = Default::default();
         blocker.enable_tags(&["brian", "stuff"]);
         assert_eq!(
@@ -1310,12 +1279,7 @@ mod blocker_tests {
             enable_optimizations: true,
         };
 
-        let mut filter_set = crate::lists::FilterSet::new(true);
-        filter_set
-            .add_filter("@@*ad_banner.png", Default::default())
-            .unwrap();
-
-        let blocker = Blocker::new(filter_set.network_filters, &blocker_options);
+        let blocker = Blocker::new(["@@*ad_banner.png"], &blocker_options);
 
         let resources = Default::default();
 
@@ -1337,12 +1301,7 @@ mod blocker_tests {
             enable_optimizations: true,
         };
 
-        let mut filter_set = crate::lists::FilterSet::new(true);
-        filter_set
-            .add_filter("@@||example.com$generichide", Default::default())
-            .unwrap();
-
-        let blocker = Blocker::new(filter_set.network_filters, &blocker_options);
+        let blocker = Blocker::new(["@@||example.com$generichide\n"], &blocker_options);
 
         assert!(blocker.check_generic_hide(
             &Request::new("https://example.com", "https://example.com", "other").unwrap()
@@ -1356,9 +1315,7 @@ mod placeholder_string_tests {
     #[test]
     fn test_constant_placeholder_string() {
         let mut filter_set = crate::lists::FilterSet::new(false);
-        filter_set
-            .add_filter("||example.com^", Default::default())
-            .unwrap();
+        filter_set.add_filter_list("||example.com^\n".to_string(), Default::default());
         let engine = crate::Engine::from_filter_set(filter_set, true);
         let block = engine.check_network_request(
             &crate::request::Request::new("https://example.com", "https://example.com", "document")
@@ -1472,7 +1429,7 @@ mod legacy_rule_parsing_tests {
         let rules = rules_from_lists(rule_lists);
 
         let (network_filters, cosmetic_filters) = parse_filters(
-            rules,
+            rules.lines(),
             true,
             ParseOptions {
                 format,
@@ -1498,7 +1455,7 @@ mod legacy_rule_parsing_tests {
             enable_optimizations: false, // optimizations will reduce number of rules
         };
 
-        let blocker = Blocker::new(network_filters, &blocker_options);
+        let blocker = Blocker::new_from_text(rules, &blocker_options);
 
         // Some filters in the filter_map are pointed at by multiple tokens, increasing the total number of items
         assert!(

--- a/tests/unit/cosmetic_filter_cache.rs
+++ b/tests/unit/cosmetic_filter_cache.rs
@@ -82,18 +82,12 @@ mod cosmetic_cache_tests {
     use crate::resources::Resource;
     use base64::{engine::Engine as _, prelude::BASE64_STANDARD};
 
-    fn cache_from_rules(rules: Vec<&str>) -> CosmeticFilterCache {
-        let parsed_rules = rules
-            .iter()
-            .map(|r| CosmeticFilter::parse(r, false, Default::default()).unwrap())
-            .collect::<Vec<_>>();
-
-        CosmeticFilterCache::from_rules(parsed_rules)
-    }
-
     #[test]
     fn exceptions() {
-        let cfcache = cache_from_rules(vec!["~example.com##.item", "sub.example.com#@#.item2"]);
+        let cfcache = CosmeticFilterCache::from_rules(vec![
+            "~example.com##.item",
+            "sub.example.com#@#.item2",
+        ]);
         let resources = ResourceStorage::default();
 
         let out = cfcache.hostname_cosmetic_resources(&resources, "test.com", false);
@@ -111,7 +105,7 @@ mod cosmetic_cache_tests {
 
     #[test]
     fn exceptions2() {
-        let cfcache = cache_from_rules(vec!["example.com,~sub.example.com##.item"]);
+        let cfcache = CosmeticFilterCache::from_rules(vec!["example.com,~sub.example.com##.item"]);
         let resources = ResourceStorage::default();
 
         let out = cfcache.hostname_cosmetic_resources(&resources, "test.com", false);
@@ -130,7 +124,7 @@ mod cosmetic_cache_tests {
 
     #[test]
     fn style_exceptions() {
-        let cfcache = cache_from_rules(vec![
+        let cfcache = CosmeticFilterCache::from_rules(vec![
             "example.com,~sub.example.com##.element:style(background: #fff)",
             "sub.test.example.com#@#.element:style(background: #fff)",
             "a1.sub.example.com##.element",
@@ -195,7 +189,7 @@ mod cosmetic_cache_tests {
     fn script_exceptions() {
         use crate::resources::{MimeType, ResourceType};
 
-        let cfcache = cache_from_rules(vec![
+        let cfcache = CosmeticFilterCache::from_rules(vec![
             "example.com,~sub.example.com##+js(set-constant.js, atob, trueFunc)",
             "sub.test.example.com#@#+js(set-constant.js, atob, trueFunc)",
             "cosmetic.net##+js(nowebrtc.js)",
@@ -259,7 +253,7 @@ mod cosmetic_cache_tests {
 
     #[test]
     fn remove_exceptions() {
-        let cfcache = cache_from_rules(vec![
+        let cfcache = CosmeticFilterCache::from_rules(vec![
             "example.com,~sub.example.com##.element:remove()",
             "sub.test.example.com#@#.element:remove()",
             "a1.sub.example.com##.element",
@@ -308,7 +302,7 @@ mod cosmetic_cache_tests {
 
     #[test]
     fn remove_attr_exceptions() {
-        let cfcache = cache_from_rules(vec![
+        let cfcache = CosmeticFilterCache::from_rules(vec![
             "example.com,~sub.example.com##.element:remove-attr(style)",
             "sub.test.example.com#@#.element:remove-attr(style)",
             "a1.sub.example.com##.element",
@@ -371,7 +365,7 @@ mod cosmetic_cache_tests {
 
     #[test]
     fn remove_class_exceptions() {
-        let cfcache = cache_from_rules(vec![
+        let cfcache = CosmeticFilterCache::from_rules(vec![
             "example.com,~sub.example.com##.element:remove-class(overlay)",
             "sub.test.example.com#@#.element:remove-class(overlay)",
             "a1.sub.example.com##.element",
@@ -435,7 +429,7 @@ mod cosmetic_cache_tests {
     #[test]
     #[cfg(feature = "css-validation")]
     fn procedural_actions() {
-        let cfcache = cache_from_rules(vec![
+        let cfcache = CosmeticFilterCache::from_rules(vec![
             "example.com##div:has(video):remove()",
             "example.com##div:has-text(Ad):remove()",
             "example.com##div:has-text(Sponsored) > p",
@@ -501,12 +495,7 @@ mod cosmetic_cache_tests {
             "##.children .including #simple-id",
             "##a.a-class",
         ];
-        let cfcache = CosmeticFilterCache::from_rules(
-            rules
-                .iter()
-                .map(|r| CosmeticFilter::parse(r, false, Default::default()).unwrap())
-                .collect::<Vec<_>>(),
-        );
+        let cfcache = CosmeticFilterCache::from_rules(rules);
 
         let out = cfcache.hidden_class_id_selectors(["with"], EMPTY, &HashSet::default());
         assert_eq!(out, Vec::<String>::new());
@@ -564,12 +553,7 @@ mod cosmetic_cache_tests {
             "example.*#@#.a-class",
             "~test.com###test-element",
         ];
-        let cfcache = CosmeticFilterCache::from_rules(
-            rules
-                .iter()
-                .map(|r| CosmeticFilter::parse(r, false, Default::default()).unwrap())
-                .collect::<Vec<_>>(),
-        );
+        let cfcache = CosmeticFilterCache::from_rules(rules);
         let resources = ResourceStorage::default();
         let exceptions = cfcache
             .hostname_cosmetic_resources(&resources, "example.co.uk", false)
@@ -624,12 +608,7 @@ mod cosmetic_cache_tests {
             "example.com#@#div > p",
             "~example.com##a[href=\"notbad.com\"]",
         ];
-        let cfcache = CosmeticFilterCache::from_rules(
-            rules
-                .iter()
-                .map(|r| CosmeticFilter::parse(r, false, Default::default()).unwrap())
-                .collect::<Vec<_>>(),
-        );
+        let cfcache = CosmeticFilterCache::from_rules(rules);
         let resources = ResourceStorage::default();
 
         let hide_selectors = cfcache
@@ -659,12 +638,7 @@ mod cosmetic_cache_tests {
             "toolforge.org##+js(abort-on-property-read, noAdBlockers)",
             "github.io##div.adToBlock",
         ];
-        let cfcache = CosmeticFilterCache::from_rules(
-            rules
-                .iter()
-                .map(|r| CosmeticFilter::parse(r, false, Default::default()).unwrap())
-                .collect::<Vec<_>>(),
-        );
+        let cfcache = CosmeticFilterCache::from_rules(rules);
         let resources = ResourceStorage::in_memory_from_resources([Resource {
             name: "abort-on-property-read.js".into(),
             aliases: vec!["aopr".to_string()],

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -21,7 +21,7 @@ mod tests {
             ("https://brave.com/about", true),
         ];
 
-        let mut engine = Engine::from_text(filters.join("\n"), Default::default());
+        let mut engine = Engine::new_with_list_text(filters.join("\n"), Default::default());
         engine.enable_tags(&["stuff"]);
         engine.enable_tags(&["brian"]);
 
@@ -55,7 +55,7 @@ mod tests {
             ("https://brave.com/about", true),
         ];
 
-        let mut engine = Engine::from_text(filters.join("\n"), Default::default());
+        let mut engine = Engine::new_with_list_text(filters.join("\n"), Default::default());
         engine.enable_tags(&["brian", "stuff"]);
         engine.disable_tags(&["stuff"]);
 
@@ -87,7 +87,7 @@ mod tests {
             ("https://brianbondy.com/advert", true),
         ];
 
-        let engine = Engine::from_text(filters.join("\n"), Default::default());
+        let engine = Engine::new_with_list_text(filters.join("\n"), Default::default());
 
         url_results.into_iter().for_each(|(url, expected_result)| {
             let request = Request::new(url, "", "").unwrap();
@@ -117,7 +117,7 @@ mod tests {
             ("https://brianbondy.com/advert", false),
         ];
 
-        let mut engine = Engine::from_text(filters.join("\n"), Default::default());
+        let mut engine = Engine::new_with_list_text(filters.join("\n"), Default::default());
         engine.enable_tags(&["brian", "stuff"]);
 
         url_results.into_iter().for_each(|(url, expected_result)| {
@@ -150,7 +150,7 @@ mod tests {
             ("https://brave.com/about", false),
         ];
 
-        let mut engine = Engine::from_text(filters.join("\n"), Default::default());
+        let mut engine = Engine::new_with_list_text(filters.join("\n"), Default::default());
         engine.enable_tags(&["stuff"]);
         engine.enable_tags(&["brian"]);
         let serialized = engine.serialize();
@@ -181,7 +181,7 @@ mod tests {
 
     #[test]
     fn deserialization_generate_simple() {
-        let mut engine = Engine::from_text("ad-banner", Default::default());
+        let mut engine = Engine::new_with_list_text("ad-banner", Default::default());
         let data = engine.serialize().to_vec();
         const EXPECTED_HASH: u64 = 16556115079021991714;
         assert_eq!(hash(&data), EXPECTED_HASH, "{HASH_MISMATCH_MSG}");
@@ -190,7 +190,7 @@ mod tests {
 
     #[test]
     fn deserialization_generate_tags() {
-        let mut engine = Engine::from_text("ad-banner$tag=abc", Default::default());
+        let mut engine = Engine::new_with_list_text("ad-banner$tag=abc", Default::default());
         engine.use_tags(&["abc"]);
         let data = engine.serialize().to_vec();
         const EXPECTED_HASH: u64 = 4864047469838009851;
@@ -200,7 +200,8 @@ mod tests {
 
     #[test]
     fn deserialization_generate_resources() {
-        let mut engine = Engine::from_text("ad-banner$redirect=nooptext", Default::default());
+        let mut engine =
+            Engine::new_with_list_text("ad-banner$redirect=nooptext", Default::default());
 
         engine.use_resources([
             Resource::simple("nooptext", MimeType::TextPlain, ""),
@@ -215,7 +216,8 @@ mod tests {
     #[test]
     fn deserialization_brave_list() {
         let rules = rules_from_lists(["data/brave/brave-main-list.txt"]);
-        let mut engine = Engine::from_text_parametrised(rules, Default::default(), false, true);
+        let mut engine =
+            Engine::new_with_list_text_parametrised(rules, Default::default(), false, true);
         let data = engine.serialize().to_vec();
 
         #[cfg(feature = "debug-info")]
@@ -249,7 +251,7 @@ mod tests {
 
     #[test]
     fn redirect_resource_insertion_works() {
-        let mut engine = Engine::from_text(
+        let mut engine = Engine::new_with_list_text(
             ["ad-banner$redirect=nooptext", "script.js$redirect=noop.js"].join("\n"),
             Default::default(),
         );
@@ -295,7 +297,7 @@ mod tests {
     fn document() {
         let filters = ["||example.com$document", "@@||sub.example.com$document"];
 
-        let engine = Engine::from_text(filters.join("\n"), Default::default());
+        let engine = Engine::new_with_list_text(filters.join("\n"), Default::default());
 
         assert!(
             engine
@@ -328,7 +330,7 @@ mod tests {
     #[test]
     fn implicit_all() {
         {
-            let engine = Engine::from_text("||example.com^", Default::default());
+            let engine = Engine::new_with_list_text("||example.com^", Default::default());
             assert!(
                 engine
                     .check_network_request(
@@ -339,7 +341,8 @@ mod tests {
             );
         }
         {
-            let engine = Engine::from_text("||example.com^$first-party", Default::default());
+            let engine =
+                Engine::new_with_list_text("||example.com^$first-party", Default::default());
             assert!(
                 engine
                     .check_network_request(
@@ -350,7 +353,7 @@ mod tests {
             );
         }
         {
-            let engine = Engine::from_text("||example.com^$script", Default::default());
+            let engine = Engine::new_with_list_text("||example.com^$script", Default::default());
             assert!(
                 !engine
                     .check_network_request(
@@ -361,7 +364,7 @@ mod tests {
             );
         }
         {
-            let engine = Engine::from_text("||example.com^$~script", Default::default());
+            let engine = Engine::new_with_list_text("||example.com^$~script", Default::default());
             assert!(
                 !engine
                     .check_network_request(
@@ -372,7 +375,7 @@ mod tests {
             );
         }
         {
-            let engine = Engine::from_text(
+            let engine = Engine::new_with_list_text(
                 ["||example.com^$document", "@@||example.com^$generichide"].join("\n"),
                 Default::default(),
             );
@@ -386,7 +389,7 @@ mod tests {
             );
         }
         {
-            let engine = Engine::from_text(
+            let engine = Engine::new_with_list_text(
                 "example.com",
                 ParseOptions {
                     format: FilterFormat::Hosts,
@@ -403,7 +406,7 @@ mod tests {
             );
         }
         {
-            let engine = Engine::from_text("||example.com/path", Default::default());
+            let engine = Engine::new_with_list_text("||example.com/path", Default::default());
             assert!(
                 !engine
                     .check_network_request(
@@ -418,7 +421,7 @@ mod tests {
             );
         }
         {
-            let engine = Engine::from_text("||example.com/path^", Default::default());
+            let engine = Engine::new_with_list_text("||example.com/path^", Default::default());
             assert!(
                 !engine
                     .check_network_request(
@@ -436,7 +439,7 @@ mod tests {
 
     #[test]
     fn explicit_all() {
-        let engine = Engine::from_text(
+        let engine = Engine::new_with_list_text(
             "*$all,domain=rarvinzp.click|ytrqcxat.click",
             Default::default(),
         );
@@ -484,7 +487,7 @@ mod tests {
             ("https://example2.com/test.html", vec![".block"], true),
         ];
 
-        let engine = Engine::from_text(filters, Default::default());
+        let engine = Engine::new_with_list_text(filters, Default::default());
 
         url_results
             .into_iter()
@@ -508,7 +511,7 @@ mod tests {
             "||addthis.com^$important,3p,domain=~missingkids.com|~missingkids.org|~sainsburys.jobs|~sitecore.com|~amd.com",
             "||addthis.com/*/addthis_widget.js$script,redirect=addthis.com/addthis_widget.js",
         ], Default::default());
-        let mut engine = Engine::from_filter_set(filter_set, false);
+        let mut engine = Engine::new_with_filter_set(filter_set, false);
 
         engine.use_resources([Resource::simple(
             "addthis.com/addthis_widget.js",
@@ -526,14 +529,14 @@ mod tests {
     fn check_match_case_regex_filtering() {
         {
             // match case without regex is discarded
-            let engine = Engine::from_text("ad.png$match-case", Default::default());
+            let engine = Engine::new_with_list_text("ad.png$match-case", Default::default());
             let request =
                 Request::new("https://example.com/ad.png", "https://example.com", "image").unwrap();
             assert!(!engine.check_network_request(&request).matched);
         }
         {
             // /^https:\/\/[0-9a-z]{3,}\.[-a-z]{10,}\.(?:li[fv]e|top|xyz)\/[a-z]{8}\/\?utm_campaign=\w{40,}/$doc,match-case,domain=life|live|top|xyz
-            let engine = Engine::from_text(
+            let engine = Engine::new_with_list_text(
                 r#"/^https:\/\/[0-9a-z]{3,}\.[-a-z]{10,}\.(?:li[fv]e|top|xyz)\/[a-z]{8}\/\?utm_campaign=\w{40,}/$doc,match-case,domain=life|live|top|xyz"#,
                 Default::default(),
             );
@@ -569,7 +572,7 @@ mod tests {
         }*/
         {
             // /^http:\/\/[a-z]{5}\.[a-z]{5}\.com\/[a-z]{10}\.apk$/$doc,match-case,domain=com
-            let engine = Engine::from_text(
+            let engine = Engine::new_with_list_text(
                 r#"/^http:\/\/[a-z]{5}\.[a-z]{5}\.com\/[a-z]{10}\.apk$/$doc,match-case,domain=com"#,
                 Default::default(),
             );
@@ -619,7 +622,7 @@ mod tests {
         }*/
         {
             // /^https?:\/\/[a-z]{8,15}\.top\/[a-z]{4,}\.json$/$xhr,3p,match-case
-            let engine = Engine::from_text(
+            let engine = Engine::new_with_list_text(
                 r#"/^https?:\/\/[a-z]{8,15}\.top\/[a-z]{4,}\.json$/$xhr,3p,match-case"#,
                 Default::default(),
             );
@@ -660,7 +663,7 @@ mod tests {
         }*/
         {
             // /^https?:\/\/cdn\.[a-z]{4,6}\.xyz\/app\.js$/$script,3p,match-case
-            let engine = Engine::from_text(
+            let engine = Engine::new_with_list_text(
                 r#"/^https?:\/\/cdn\.[a-z]{4,6}\.xyz\/app\.js$/$script,3p,match-case"#,
                 Default::default(),
             );
@@ -683,7 +686,7 @@ mod tests {
         }*/
         {
             // /^https:\/\/cdn\.jsdelivr\.net\/npm\/[-a-z_]{4,22}@latest\/dist\/script\.min\.js$/$script,3p,match-case
-            let engine = Engine::from_text(
+            let engine = Engine::new_with_list_text(
                 r#"/^https:\/\/cdn\.jsdelivr\.net\/npm\/[-a-z_]{4,22}@latest\/dist\/script\.min\.js$/$script,3p,match-case"#,
                 Default::default(),
             );
@@ -784,7 +787,7 @@ mod tests {
             },
         );
 
-        let mut engine = Engine::from_filter_set(filter_set, true);
+        let mut engine = Engine::new_with_filter_set(filter_set, true);
         engine.use_resources(resources);
 
         fn wrap_try(scriptlet_content: &str) -> String {
@@ -873,7 +876,7 @@ mod tests {
             r#"example.com##+js(trusted-set-local-storage-item, "test"test, 3)"#,
         ], Default::default());
 
-        let mut engine = Engine::from_filter_set(filter_set, true);
+        let mut engine = Engine::new_with_filter_set(filter_set, true);
         engine.use_resources(resources);
 
         assert_eq!(engine.url_cosmetic_resources("https://dailymail.co.uk").injected_script, r#"function trustedSetLocalStorageItem(key = '', value = '') { setLocalStorageItemFn('local', true, key, value); }

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -21,7 +21,7 @@ mod tests {
             ("https://brave.com/about", true),
         ];
 
-        let mut engine = Engine::from_rules(filters, Default::default());
+        let mut engine = Engine::from_text(filters.join("\n"), Default::default());
         engine.enable_tags(&["stuff"]);
         engine.enable_tags(&["brian"]);
 
@@ -55,7 +55,7 @@ mod tests {
             ("https://brave.com/about", true),
         ];
 
-        let mut engine = Engine::from_rules(filters, Default::default());
+        let mut engine = Engine::from_text(filters.join("\n"), Default::default());
         engine.enable_tags(&["brian", "stuff"]);
         engine.disable_tags(&["stuff"]);
 
@@ -87,7 +87,7 @@ mod tests {
             ("https://brianbondy.com/advert", true),
         ];
 
-        let engine = Engine::from_rules(filters, Default::default());
+        let engine = Engine::from_text(filters.join("\n"), Default::default());
 
         url_results.into_iter().for_each(|(url, expected_result)| {
             let request = Request::new(url, "", "").unwrap();
@@ -117,7 +117,7 @@ mod tests {
             ("https://brianbondy.com/advert", false),
         ];
 
-        let mut engine = Engine::from_rules(filters, Default::default());
+        let mut engine = Engine::from_text(filters.join("\n"), Default::default());
         engine.enable_tags(&["brian", "stuff"]);
 
         url_results.into_iter().for_each(|(url, expected_result)| {
@@ -150,7 +150,7 @@ mod tests {
             ("https://brave.com/about", false),
         ];
 
-        let mut engine = Engine::from_rules(filters, Default::default());
+        let mut engine = Engine::from_text(filters.join("\n"), Default::default());
         engine.enable_tags(&["stuff"]);
         engine.enable_tags(&["brian"]);
         let serialized = engine.serialize();
@@ -181,7 +181,7 @@ mod tests {
 
     #[test]
     fn deserialization_generate_simple() {
-        let mut engine = Engine::from_rules(["ad-banner"], Default::default());
+        let mut engine = Engine::from_text("ad-banner", Default::default());
         let data = engine.serialize().to_vec();
         const EXPECTED_HASH: u64 = 16556115079021991714;
         assert_eq!(hash(&data), EXPECTED_HASH, "{HASH_MISMATCH_MSG}");
@@ -190,7 +190,7 @@ mod tests {
 
     #[test]
     fn deserialization_generate_tags() {
-        let mut engine = Engine::from_rules(["ad-banner$tag=abc"], Default::default());
+        let mut engine = Engine::from_text("ad-banner$tag=abc", Default::default());
         engine.use_tags(&["abc"]);
         let data = engine.serialize().to_vec();
         const EXPECTED_HASH: u64 = 4864047469838009851;
@@ -200,7 +200,7 @@ mod tests {
 
     #[test]
     fn deserialization_generate_resources() {
-        let mut engine = Engine::from_rules(["ad-banner$redirect=nooptext"], Default::default());
+        let mut engine = Engine::from_text("ad-banner$redirect=nooptext", Default::default());
 
         engine.use_resources([
             Resource::simple("nooptext", MimeType::TextPlain, ""),
@@ -214,8 +214,8 @@ mod tests {
 
     #[test]
     fn deserialization_brave_list() {
-        let rules = rules_from_lists(&["data/brave/brave-main-list.txt"]);
-        let mut engine = Engine::from_rules_parametrised(rules, Default::default(), false, true);
+        let rules = rules_from_lists(["data/brave/brave-main-list.txt"]);
+        let mut engine = Engine::from_text_parametrised(rules, Default::default(), false, true);
         let data = engine.serialize().to_vec();
 
         #[cfg(feature = "debug-info")]
@@ -249,8 +249,8 @@ mod tests {
 
     #[test]
     fn redirect_resource_insertion_works() {
-        let mut engine = Engine::from_rules(
-            ["ad-banner$redirect=nooptext", "script.js$redirect=noop.js"],
+        let mut engine = Engine::from_text(
+            ["ad-banner$redirect=nooptext", "script.js$redirect=noop.js"].join("\n"),
             Default::default(),
         );
 
@@ -295,7 +295,7 @@ mod tests {
     fn document() {
         let filters = ["||example.com$document", "@@||sub.example.com$document"];
 
-        let engine = Engine::from_rules_debug(filters, Default::default());
+        let engine = Engine::from_text(filters.join("\n"), Default::default());
 
         assert!(
             engine
@@ -328,7 +328,7 @@ mod tests {
     #[test]
     fn implicit_all() {
         {
-            let engine = Engine::from_rules_debug(["||example.com^"], Default::default());
+            let engine = Engine::from_text("||example.com^", Default::default());
             assert!(
                 engine
                     .check_network_request(
@@ -339,8 +339,7 @@ mod tests {
             );
         }
         {
-            let engine =
-                Engine::from_rules_debug(["||example.com^$first-party"], Default::default());
+            let engine = Engine::from_text("||example.com^$first-party", Default::default());
             assert!(
                 engine
                     .check_network_request(
@@ -351,7 +350,7 @@ mod tests {
             );
         }
         {
-            let engine = Engine::from_rules_debug(["||example.com^$script"], Default::default());
+            let engine = Engine::from_text("||example.com^$script", Default::default());
             assert!(
                 !engine
                     .check_network_request(
@@ -362,7 +361,7 @@ mod tests {
             );
         }
         {
-            let engine = Engine::from_rules_debug(["||example.com^$~script"], Default::default());
+            let engine = Engine::from_text("||example.com^$~script", Default::default());
             assert!(
                 !engine
                     .check_network_request(
@@ -373,8 +372,8 @@ mod tests {
             );
         }
         {
-            let engine = Engine::from_rules_debug(
-                ["||example.com^$document", "@@||example.com^$generichide"],
+            let engine = Engine::from_text(
+                ["||example.com^$document", "@@||example.com^$generichide"].join("\n"),
                 Default::default(),
             );
             assert!(
@@ -387,8 +386,8 @@ mod tests {
             );
         }
         {
-            let engine = Engine::from_rules_debug(
-                ["example.com"],
+            let engine = Engine::from_text(
+                "example.com",
                 ParseOptions {
                     format: FilterFormat::Hosts,
                     ..Default::default()
@@ -404,7 +403,7 @@ mod tests {
             );
         }
         {
-            let engine = Engine::from_rules_debug(["||example.com/path"], Default::default());
+            let engine = Engine::from_text("||example.com/path", Default::default());
             assert!(
                 !engine
                     .check_network_request(
@@ -419,7 +418,7 @@ mod tests {
             );
         }
         {
-            let engine = Engine::from_rules_debug(["||example.com/path^"], Default::default());
+            let engine = Engine::from_text("||example.com/path^", Default::default());
             assert!(
                 !engine
                     .check_network_request(
@@ -437,8 +436,8 @@ mod tests {
 
     #[test]
     fn explicit_all() {
-        let engine = Engine::from_rules_debug(
-            ["*$all,domain=rarvinzp.click|ytrqcxat.click"],
+        let engine = Engine::from_text(
+            "*$all,domain=rarvinzp.click|ytrqcxat.click",
             Default::default(),
         );
         for content_type in [
@@ -472,7 +471,8 @@ mod tests {
             "example.com##.block",
             "@@||example2.com/test.html$generichide",
             "example2.com##.block",
-        ];
+        ]
+        .join("\n");
         let url_results = [
             ("https://example.com", vec![".block"], true),
             ("https://example.com/test.html", vec![".block"], true),
@@ -484,7 +484,7 @@ mod tests {
             ("https://example2.com/test.html", vec![".block"], true),
         ];
 
-        let engine = Engine::from_rules(filters, Default::default());
+        let engine = Engine::from_text(filters, Default::default());
 
         url_results
             .into_iter()
@@ -526,17 +526,15 @@ mod tests {
     fn check_match_case_regex_filtering() {
         {
             // match case without regex is discarded
-            let engine = Engine::from_rules_debug(["ad.png$match-case"], Default::default());
+            let engine = Engine::from_text("ad.png$match-case", Default::default());
             let request =
                 Request::new("https://example.com/ad.png", "https://example.com", "image").unwrap();
             assert!(!engine.check_network_request(&request).matched);
         }
         {
             // /^https:\/\/[0-9a-z]{3,}\.[-a-z]{10,}\.(?:li[fv]e|top|xyz)\/[a-z]{8}\/\?utm_campaign=\w{40,}/$doc,match-case,domain=life|live|top|xyz
-            let engine = Engine::from_rules_debug(
-                [
-                    r#"/^https:\/\/[0-9a-z]{3,}\.[-a-z]{10,}\.(?:li[fv]e|top|xyz)\/[a-z]{8}\/\?utm_campaign=\w{40,}/$doc,match-case,domain=life|live|top|xyz"#,
-                ],
+            let engine = Engine::from_text(
+                r#"/^https:\/\/[0-9a-z]{3,}\.[-a-z]{10,}\.(?:li[fv]e|top|xyz)\/[a-z]{8}\/\?utm_campaign=\w{40,}/$doc,match-case,domain=life|live|top|xyz"#,
                 Default::default(),
             );
             let request = Request::new("https://www.exampleaaa.xyz/testtest/?utm_campaign=aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd", "https://www.exampleaaa.xyz/testtest/?utm_campaign=aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd", "document").unwrap();
@@ -571,10 +569,8 @@ mod tests {
         }*/
         {
             // /^http:\/\/[a-z]{5}\.[a-z]{5}\.com\/[a-z]{10}\.apk$/$doc,match-case,domain=com
-            let engine = Engine::from_rules_debug(
-                [
-                    r#"/^http:\/\/[a-z]{5}\.[a-z]{5}\.com\/[a-z]{10}\.apk$/$doc,match-case,domain=com"#,
-                ],
+            let engine = Engine::from_text(
+                r#"/^http:\/\/[a-z]{5}\.[a-z]{5}\.com\/[a-z]{10}\.apk$/$doc,match-case,domain=com"#,
                 Default::default(),
             );
             let request = Request::new(
@@ -623,8 +619,8 @@ mod tests {
         }*/
         {
             // /^https?:\/\/[a-z]{8,15}\.top\/[a-z]{4,}\.json$/$xhr,3p,match-case
-            let engine = Engine::from_rules_debug(
-                [r#"/^https?:\/\/[a-z]{8,15}\.top\/[a-z]{4,}\.json$/$xhr,3p,match-case"#],
+            let engine = Engine::from_text(
+                r#"/^https?:\/\/[a-z]{8,15}\.top\/[a-z]{4,}\.json$/$xhr,3p,match-case"#,
                 Default::default(),
             );
             let request = Request::new(
@@ -664,8 +660,8 @@ mod tests {
         }*/
         {
             // /^https?:\/\/cdn\.[a-z]{4,6}\.xyz\/app\.js$/$script,3p,match-case
-            let engine = Engine::from_rules_debug(
-                [r#"/^https?:\/\/cdn\.[a-z]{4,6}\.xyz\/app\.js$/$script,3p,match-case"#],
+            let engine = Engine::from_text(
+                r#"/^https?:\/\/cdn\.[a-z]{4,6}\.xyz\/app\.js$/$script,3p,match-case"#,
                 Default::default(),
             );
             let request = Request::new(
@@ -687,10 +683,8 @@ mod tests {
         }*/
         {
             // /^https:\/\/cdn\.jsdelivr\.net\/npm\/[-a-z_]{4,22}@latest\/dist\/script\.min\.js$/$script,3p,match-case
-            let engine = Engine::from_rules_debug(
-                [
-                    r#"/^https:\/\/cdn\.jsdelivr\.net\/npm\/[-a-z_]{4,22}@latest\/dist\/script\.min\.js$/$script,3p,match-case"#,
-                ],
+            let engine = Engine::from_text(
+                r#"/^https:\/\/cdn\.jsdelivr\.net\/npm\/[-a-z_]{4,22}@latest\/dist\/script\.min\.js$/$script,3p,match-case"#,
                 Default::default(),
             );
             let request = Request::new(

--- a/tests/unit/filters/network_matchers.rs
+++ b/tests/unit/filters/network_matchers.rs
@@ -693,7 +693,7 @@ mod match_tests {
         {
             use crate::Engine;
             let filter = r#"/^https?:\/\/([0-9a-z\-]+\.)?(9anime|animeland|animenova|animeplus|animetoon|animewow|gamestorrent|goodanime|gogoanime|igg-games|kimcartoon|memecenter|readcomiconline|toonget|toonova|watchcartoononline)\.[a-z]{2,4}\/(?!([Ee]xternal|[Ii]mages|[Ss]cripts|[Uu]ploads|ac|ajax|assets|combined|content|cov|cover|(img\/bg)|(img\/icon)|inc|jwplayer|player|playlist-cat-rss|static|thumbs|wp-content|wp-includes)\/)(.*)/$image,other,script,~third-party,xmlhttprequest,domain=~animeland.hu"#;
-            let engine = Engine::from_rules(vec![filter], Default::default());
+            let engine = Engine::from_text(filter, Default::default());
             let url = "https://9anime.to/watch/episode-1";
             let source = "https://9anime.to";
             let request = request::Request::new(url, source, "script").unwrap();

--- a/tests/unit/filters/network_matchers.rs
+++ b/tests/unit/filters/network_matchers.rs
@@ -693,7 +693,7 @@ mod match_tests {
         {
             use crate::Engine;
             let filter = r#"/^https?:\/\/([0-9a-z\-]+\.)?(9anime|animeland|animenova|animeplus|animetoon|animewow|gamestorrent|goodanime|gogoanime|igg-games|kimcartoon|memecenter|readcomiconline|toonget|toonova|watchcartoononline)\.[a-z]{2,4}\/(?!([Ee]xternal|[Ii]mages|[Ss]cripts|[Uu]ploads|ac|ajax|assets|combined|content|cov|cover|(img\/bg)|(img\/icon)|inc|jwplayer|player|playlist-cat-rss|static|thumbs|wp-content|wp-includes)\/)(.*)/$image,other,script,~third-party,xmlhttprequest,domain=~animeland.hu"#;
-            let engine = Engine::from_text(filter, Default::default());
+            let engine = Engine::new_with_list_text(filter, Default::default());
             let url = "https://9anime.to/watch/episode-1";
             let source = "https://9anime.to";
             let request = request::Request::new(url, source, "script").unwrap();

--- a/tests/unit/lists.rs
+++ b/tests/unit/lists.rs
@@ -1,7 +1,6 @@
 #[cfg(test)]
 mod tests {
     use super::super::*;
-    use crate::Engine;
 
     #[test]
     fn parse_hosts_style() {
@@ -291,12 +290,11 @@ mod tests {
             "! Version: 20220411",
             "",
             "! => https://austinhuang.me/0131-block-list/list.txt",
-        ];
+        ]
+        .join("\n");
 
         let mut filter_set = FilterSet::new(false);
-        filter_set.add_filters(list, ParseOptions::default());
-        let (_, mut metadata_list) = Engine::from_filter_set_with_metadata(filter_set, false);
-        let metadata = metadata_list.pop().unwrap();
+        let metadata = filter_set.add_filter_list(list, ParseOptions::default());
 
         assert_eq!(metadata.title, Some("0131 Block List".to_string()));
         assert_eq!(
@@ -322,12 +320,11 @@ mod tests {
             "! Last modified: 09/03/2021",
             "! Expires: 7 days (update frequency)",
             "! Homepage: https://www.haopro.net/",
-        ];
+        ]
+        .join("\n");
 
         let mut filter_set = FilterSet::new(false);
-        filter_set.add_filters(list, ParseOptions::default());
-        let (_, mut metadata_list) = Engine::from_filter_set_with_metadata(filter_set, false);
-        let metadata = metadata_list.pop().unwrap();
+        let metadata = filter_set.add_filter_list(list, ParseOptions::default());
 
         assert_eq!(metadata.title, Some("ABPVN Advanced".to_string()));
         assert_eq!(

--- a/tests/unit/lists.rs
+++ b/tests/unit/lists.rs
@@ -397,18 +397,18 @@ mod tests {
         {
             let input = "example.com##.selector";
             let result = parse_filter(input, true, Default::default());
-            assert!(matches!(result, Ok(ParsedFilter::Cosmetic(..))));
+            assert!(matches!(result, Ok(ParsedLine::Cosmetic(..))));
         }
         {
             let input = "9gag.com#?#article:-abp-has(.promoted)";
             let result = parse_filter(input, true, Default::default());
-            assert!(matches!(result, Ok(ParsedFilter::Cosmetic(..))));
+            assert!(matches!(result, Ok(ParsedLine::Cosmetic(..))));
         }
         #[cfg(feature = "css-validation")]
         {
             let input = "sportowefakty.wp.pl#@?#body > [class]:not([id]):matches-css(position: fixed):matches-css(top: 0px)";
             let result = parse_filter(input, true, Default::default());
-            assert!(matches!(result, Ok(ParsedFilter::Cosmetic(..))));
+            assert!(matches!(result, Ok(ParsedLine::Cosmetic(..))));
         }
         {
             let input =

--- a/tests/unit/lists.rs
+++ b/tests/unit/lists.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests {
     use super::super::*;
+    use crate::Engine;
 
     #[test]
     fn parse_hosts_style() {
@@ -293,7 +294,9 @@ mod tests {
         ];
 
         let mut filter_set = FilterSet::new(false);
-        let metadata = filter_set.add_filters(list, ParseOptions::default());
+        filter_set.add_filters(list, ParseOptions::default());
+        let (_, mut metadata_list) = Engine::from_filter_set_with_metadata(filter_set, false);
+        let metadata = metadata_list.pop().unwrap();
 
         assert_eq!(metadata.title, Some("0131 Block List".to_string()));
         assert_eq!(
@@ -322,7 +325,9 @@ mod tests {
         ];
 
         let mut filter_set = FilterSet::new(false);
-        let metadata = filter_set.add_filters(list, ParseOptions::default());
+        filter_set.add_filters(list, ParseOptions::default());
+        let (_, mut metadata_list) = Engine::from_filter_set_with_metadata(filter_set, false);
+        let metadata = metadata_list.pop().unwrap();
 
         assert_eq!(metadata.title, Some("ABPVN Advanced".to_string()));
         assert_eq!(

--- a/tests/unit/regex_manager.rs
+++ b/tests/unit/regex_manager.rs
@@ -7,7 +7,7 @@ mod tests {
     use mock_instant::thread_local::MockClock;
 
     fn make_engine(line: &str) -> Engine {
-        Engine::from_rules(vec![line], Default::default())
+        Engine::from_text(line, Default::default())
     }
 
     fn make_request(url: &str) -> request::Request {

--- a/tests/unit/regex_manager.rs
+++ b/tests/unit/regex_manager.rs
@@ -7,7 +7,7 @@ mod tests {
     use mock_instant::thread_local::MockClock;
 
     fn make_engine(line: &str) -> Engine {
-        Engine::from_text(line, Default::default())
+        Engine::new_with_list_text(line, Default::default())
     }
 
     fn make_request(url: &str) -> request::Request {

--- a/tests/unit/resources/resource_storage.rs
+++ b/tests/unit/resources/resource_storage.rs
@@ -835,13 +835,13 @@ mod shared_storage_tests {
         let shared_storage = Rc::new(in_memory_storage);
 
         let mut engine1 =
-            crate::Engine::from_rules(["example1.com##+js(test-scriptlet)"], Default::default());
+            crate::Engine::from_text("example1.com##+js(test-scriptlet)", Default::default());
         engine1.use_resource_storage(BraveCoreResourceStorage {
             shared_storage: Rc::clone(&shared_storage),
         });
 
         let mut engine2 =
-            crate::Engine::from_rules(["example2.com##+js(test-scriptlet)"], Default::default());
+            crate::Engine::from_text("example2.com##+js(test-scriptlet)", Default::default());
         engine2.use_resource_storage(BraveCoreResourceStorage {
             shared_storage: Rc::clone(&shared_storage),
         });

--- a/tests/unit/resources/resource_storage.rs
+++ b/tests/unit/resources/resource_storage.rs
@@ -834,14 +834,18 @@ mod shared_storage_tests {
 
         let shared_storage = Rc::new(in_memory_storage);
 
-        let mut engine1 =
-            crate::Engine::from_text("example1.com##+js(test-scriptlet)", Default::default());
+        let mut engine1 = crate::Engine::new_with_list_text(
+            "example1.com##+js(test-scriptlet)",
+            Default::default(),
+        );
         engine1.use_resource_storage(BraveCoreResourceStorage {
             shared_storage: Rc::clone(&shared_storage),
         });
 
-        let mut engine2 =
-            crate::Engine::from_text("example2.com##+js(test-scriptlet)", Default::default());
+        let mut engine2 = crate::Engine::new_with_list_text(
+            "example2.com##+js(test-scriptlet)",
+            Default::default(),
+        );
         engine2.use_resource_storage(BraveCoreResourceStorage {
             shared_storage: Rc::clone(&shared_storage),
         });


### PR DESCRIPTION
The PR introduces a new API to avoid working with `Vec<SomeFilter>`.
Instead FilterSet stores a set of annotated text sources.
This is necessary step to make streaming parsing work.