### PR TITLE
Streaming filter parsing

### DIFF
--- a/src/cosmetic_filter_cache_builder.rs
+++ b/src/cosmetic_filter_cache_builder.rs
@@ -77,16 +77,6 @@ pub(crate) struct CosmeticFilterCacheBuilder<'a> {
 }
 
 impl<'a> CosmeticFilterCacheBuilder<'a> {
-    pub fn from_rules(rules: Vec<CosmeticFilter>, builder: &mut EngineFlatBuilder<'a>) -> Self {
-        let mut self_ = Self::default();
-
-        for rule in rules {
-            self_.add_filter(rule, builder);
-        }
-
-        self_
-    }
-
     pub fn add_filter(&mut self, rule: CosmeticFilter, builder: &mut EngineFlatBuilder<'a>) {
         if rule.has_hostname_constraint() {
             if let Some(generic_rule) = rule.hidden_generic_rule() {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -107,10 +107,61 @@ impl Engine {
         cosmetic_filters: Vec<CosmeticFilter>,
         optimize: bool,
     ) -> Self {
-        let memory = make_flatbuffer(network_filters, cosmetic_filters, optimize);
+        let mut builder = EngineFlatBuilder::default();
+        let mut network_rules_builder = NetworkRulesBuilder::new(optimize);
+        let mut cosmetic_filter_cache_builder = CosmeticFilterCacheBuilder::default();
 
+        for filter in network_filters {
+            network_rules_builder.add_rules(filter, &mut builder);
+        }
+        for filter in cosmetic_filters {
+            cosmetic_filter_cache_builder.add_filter(filter, &mut builder);
+        }
+
+        Self::new_with_builders(
+            network_rules_builder,
+            cosmetic_filter_cache_builder,
+            builder,
+        )
+    }
+
+    /// Loads rules from the given `FilterSet`.
+    pub fn new_with_filter_set(set: FilterSet, optimize: bool) -> Self {
+        let mut builder = EngineFlatBuilder::default();
+        let mut network_rules_builder = NetworkRulesBuilder::new(optimize);
+        let mut cosmetic_filter_cache_builder = CosmeticFilterCacheBuilder::default();
+
+        for list_source in set.list_sources {
+            for line in list_source.list_text.lines() {
+                let parsed_line = parse_filter(line, set.debug, list_source.parse_options);
+                match parsed_line {
+                    Ok(ParsedLine::Network(filter)) => {
+                        network_rules_builder.add_rules(filter, &mut builder)
+                    }
+                    Ok(ParsedLine::Cosmetic(filter)) => {
+                        cosmetic_filter_cache_builder.add_filter(filter, &mut builder)
+                    }
+                    Err(_) => {}
+                }
+            }
+        }
+
+        Self::new_with_builders(
+            network_rules_builder,
+            cosmetic_filter_cache_builder,
+            builder,
+        )
+    }
+
+    fn new_with_builders<'a>(
+        network_rules_builder: NetworkRulesBuilder<'a>,
+        cosmetic_filter_cache_builder: CosmeticFilterCacheBuilder<'a>,
+        mut builder: EngineFlatBuilder<'a>,
+    ) -> Self {
+        let network_rules = FlatSerialize::serialize(network_rules_builder, &mut builder);
+        let cosmetic_rules = FlatSerialize::serialize(cosmetic_filter_cache_builder, &mut builder);
+        let memory = builder.finish(network_rules, cosmetic_rules);
         let filter_data_context = FilterDataContext::new(memory);
-
         Self {
             blocker: Blocker::from_context(FilterDataContextRef::clone(&filter_data_context)),
             cosmetic_cache: CosmeticFilterCache::from_context(FilterDataContextRef::clone(
@@ -119,24 +170,6 @@ impl Engine {
             resources: ResourceStorage::default(),
             filter_data_context,
         }
-    }
-
-    /// Loads rules from the given `FilterSet`.
-    pub fn new_with_filter_set(set: FilterSet, optimize: bool) -> Self {
-        let mut network_filters = vec![];
-        let mut cosmetic_filters = vec![];
-
-        for list_source in set.list_sources {
-            for line in list_source.list_text.lines() {
-                let parsed_line = parse_filter(line, set.debug, list_source.parse_options);
-                match parsed_line {
-                    Ok(ParsedLine::Network(filter)) => network_filters.push(filter),
-                    Ok(ParsedLine::Cosmetic(filter)) => cosmetic_filters.push(filter),
-                    Err(_) => {}
-                }
-            }
-        }
-        Self::new_with_parsed_rules(network_filters, cosmetic_filters, optimize)
     }
 
     /// Check if a request for a network resource from `url`, of type `request_type`, initiated by
@@ -334,19 +367,6 @@ fn _assertions() {
 
     _assert_send::<Engine>();
     _assert_sync::<Engine>();
-}
-
-fn make_flatbuffer(
-    network_filters: Vec<NetworkFilter>,
-    cosmetic_filters: Vec<CosmeticFilter>,
-    optimize: bool,
-) -> VerifiedFlatbufferMemory {
-    let mut builder = EngineFlatBuilder::default();
-    let network_rules_builder = NetworkRulesBuilder::from_rules(network_filters, optimize);
-    let network_rules = FlatSerialize::serialize(network_rules_builder, &mut builder);
-    let cosmetic_rules = CosmeticFilterCacheBuilder::from_rules(cosmetic_filters, &mut builder);
-    let cosmetic_rules = FlatSerialize::serialize(cosmetic_rules, &mut builder);
-    builder.finish(network_rules, cosmetic_rules)
 }
 
 #[cfg(test)]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -112,7 +112,7 @@ impl Engine {
         let mut cosmetic_filter_cache_builder = CosmeticFilterCacheBuilder::default();
 
         for filter in network_filters {
-            network_rules_builder.add_rules(filter, &mut builder);
+            network_rules_builder.add_filter(filter, &mut builder);
         }
         for filter in cosmetic_filters {
             cosmetic_filter_cache_builder.add_filter(filter, &mut builder);
@@ -136,7 +136,7 @@ impl Engine {
                 let parsed_line = parse_filter(line, set.debug, list_source.parse_options);
                 match parsed_line {
                     Ok(ParsedLine::Network(filter)) => {
-                        network_rules_builder.add_rules(filter, &mut builder)
+                        network_rules_builder.add_filter(filter, &mut builder)
                     }
                     Ok(ParsedLine::Cosmetic(filter)) => {
                         cosmetic_filter_cache_builder.add_filter(filter, &mut builder)

--- a/src/filters/fb_network_builder.rs
+++ b/src/filters/fb_network_builder.rs
@@ -11,7 +11,7 @@ use crate::utils::TokensBuffer;
 
 use crate::filters::network::NetworkFilterMaskHelper;
 use crate::flatbuffers::containers::flat_multimap::FlatMultiMapBuilder;
-use crate::flatbuffers::containers::flat_serialize::{FlatBuilder, FlatSerialize, WIPFlatVec};
+use crate::flatbuffers::containers::flat_serialize::{FlatBuilder, FlatSerialize};
 use crate::optimizer;
 use crate::utils::{to_short_hash, Hash, ShortHash};
 
@@ -29,21 +29,29 @@ pub(crate) enum NetworkFilterListId {
     Size = 8,
 }
 
-#[derive(Default, Clone)]
-pub(crate) struct NetworkFilterListBuilder {
-    filters: Vec<NetworkFilter>,
+struct NetworkFilterFlatEntry<'a> {
+    filter: WIPOffset<fb::NetworkFilter<'a>>,
+    id: Hash,
+}
+
+pub(crate) struct NetworkFilterListBuilder<'a> {
+    flat_map_builder: FlatMultiMapBuilder<ShortHash, NetworkFilterFlatEntry<'a>>,
+    token_frequencies: TokenSelector,
+    filters_to_optimize: HashMap<ShortHash, Vec<NetworkFilter>>,
+    tokens_buffer: TokensBuffer,
     optimize: bool,
 }
 
-pub(crate) struct NetworkRulesBuilder {
-    lists: Vec<NetworkFilterListBuilder>,
+pub(crate) struct NetworkRulesBuilder<'a> {
+    lists: Vec<NetworkFilterListBuilder<'a>>,
+    bad_filter_ids: HashSet<Hash>,
 }
 
-impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for &NetworkFilter {
+impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for NetworkFilter {
     type Output = WIPOffset<fb::NetworkFilter<'a>>;
 
     fn serialize(
-        network_filter: &NetworkFilter,
+        network_filter: NetworkFilter,
         builder: &mut EngineFlatBuilder<'a>,
     ) -> WIPOffset<fb::NetworkFilter<'a>> {
         let opt_domains = network_filter.opt_domains.as_ref().map(|v| {
@@ -104,7 +112,7 @@ impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for &NetworkFilter {
             .as_ref()
             .map(|v| builder.create_string(v.as_str()));
 
-        let network_filter = fb::NetworkFilter::create(
+        fb::NetworkFilter::create(
             builder.raw_builder(),
             &fb::NetworkFilterArgs {
                 mask: network_filter.mask.bits(),
@@ -117,177 +125,187 @@ impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for &NetworkFilter {
                 tag,
                 raw_line,
             },
-        );
-
-        network_filter
-    }
-}
-
-impl NetworkFilterListBuilder {
-    fn new(optimize: bool) -> Self {
-        Self {
-            filters: vec![],
-            optimize,
-        }
-    }
-}
-
-impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for NetworkFilterListBuilder {
-    type Output = WIPOffset<fb::NetworkFilterList<'a>>;
-    fn serialize(
-        rule_list: Self,
-        builder: &mut EngineFlatBuilder<'a>,
-    ) -> WIPOffset<fb::NetworkFilterList<'a>> {
-        let mut filter_map_builder = FlatMultiMapBuilder::with_capacity(rule_list.filters.len());
-
-        let mut optimizable = HashMap::<ShortHash, Vec<NetworkFilter>>::new();
-
-        let mut token_frequencies = TokenSelector::new(rule_list.filters.len());
-        let mut tokens_buffer = TokensBuffer::default();
-
-        {
-            for network_filter in rule_list.filters {
-                let flat_filter = if !rule_list.optimize
-                    || !optimizer::is_filter_optimizable_by_patterns(&network_filter)
-                {
-                    Some(FlatSerialize::serialize(&network_filter, builder))
-                } else {
-                    None
-                };
-
-                let mut store_filter = |token: Hash| {
-                    let short_token = to_short_hash(token);
-                    if let Some(flat_filter) = flat_filter {
-                        filter_map_builder.insert(short_token, flat_filter);
-                    } else {
-                        optimizable
-                            .entry(short_token)
-                            .or_default()
-                            .push(network_filter.clone());
-                    }
-                };
-
-                let multi_tokens = network_filter.get_tokens(&mut tokens_buffer);
-                match multi_tokens {
-                    FilterTokens::Empty => {
-                        // No tokens, add to fallback bucket (token 0)
-                        store_filter(0);
-                    }
-                    FilterTokens::OptDomains(opt_domains) => {
-                        // For OptDomains, each domain is treated as a separate token group
-                        for &token in opt_domains.iter() {
-                            store_filter(token);
-                            token_frequencies.record_usage(token);
-                        }
-                    }
-                    FilterTokens::Other(tokens) => {
-                        let best_token = token_frequencies.select_least_used_token(tokens);
-                        token_frequencies.record_usage(best_token);
-                        store_filter(best_token);
-                    }
-                }
-            }
-        }
-
-        if rule_list.optimize {
-            // Sort the entries to ensure deterministic iteration order
-            let mut optimizable_entries: Vec<_> = optimizable.drain().collect();
-            optimizable_entries.sort_unstable_by_key(|(token, _)| *token);
-
-            for (token, v) in optimizable_entries {
-                let optimized = optimizer::optimize(v);
-
-                for filter in optimized {
-                    let flat_filter = FlatSerialize::serialize(&filter, builder);
-                    filter_map_builder.insert(token, flat_filter);
-                }
-            }
-        } else {
-            debug_assert!(
-                optimizable.is_empty(),
-                "Should be empty if optimization is off"
-            );
-        }
-
-        let flat_filter_map = FlatMultiMapBuilder::finish(filter_map_builder, builder);
-
-        fb::NetworkFilterList::create(
-            builder.raw_builder(),
-            &fb::NetworkFilterListArgs {
-                filter_map_index: Some(flat_filter_map.keys),
-                filter_map_values: Some(flat_filter_map.values),
-            },
         )
     }
 }
 
-impl NetworkRulesBuilder {
-    pub fn from_rules(network_filters: Vec<NetworkFilter>, optimize: bool) -> Self {
+impl<'a> NetworkFilterListBuilder<'a> {
+    fn new(optimize: bool) -> Self {
+        Self {
+            flat_map_builder: FlatMultiMapBuilder::with_capacity(1024),
+            token_frequencies: TokenSelector::new(0),
+            filters_to_optimize: HashMap::new(),
+            tokens_buffer: TokensBuffer::default(),
+            optimize,
+        }
+    }
+
+    fn add_filter(&mut self, network_filter: NetworkFilter, builder: &mut EngineFlatBuilder<'a>) {
+        let multi_tokens = network_filter.get_tokens(&mut self.tokens_buffer);
+        let id = network_filter.get_id();
+
+        // Resolve token(s) and record frequencies up-front so the
+        // serialized/optimizable branches share no token logic.
+        let mut single_token: Hash = 0;
+        let tokens: &[Hash] = match multi_tokens {
+            FilterTokens::Empty => std::slice::from_ref(&single_token),
+            FilterTokens::OptDomains => {
+                // tokens_buffer has been populated by get_tokens; record frequencies
+                let slice = self.tokens_buffer.as_slice();
+                for &t in slice {
+                    self.token_frequencies.record_usage(t);
+                }
+                slice
+            }
+            FilterTokens::Other => {
+                single_token = self
+                    .token_frequencies
+                    .select_least_used_token(self.tokens_buffer.as_slice());
+                self.token_frequencies.record_usage(single_token);
+                std::slice::from_ref(&single_token)
+            }
+        };
+
+        if !self.optimize || !optimizer::is_filter_optimizable_by_patterns(&network_filter) {
+            // Serialize immediately; store offset + id for later bad-filter pruning.
+            let filter = FlatSerialize::serialize(network_filter, builder);
+            for &token in tokens {
+                self.flat_map_builder
+                    .insert(to_short_hash(token), NetworkFilterFlatEntry { filter, id });
+            }
+        } else {
+            // Defer to the optimizer; clone only in the multi-token (OptDomains) case.
+            if let Some((last, rest)) = tokens.split_last() {
+                for &token in rest {
+                    self.filters_to_optimize
+                        .entry(to_short_hash(token))
+                        .or_default()
+                        .push(network_filter.clone());
+                }
+                self.filters_to_optimize
+                    .entry(to_short_hash(*last))
+                    .or_default()
+                    .push(network_filter);
+            }
+        }
+    }
+}
+
+impl<'a> NetworkRulesBuilder<'a> {
+    pub fn new(optimize: bool) -> Self {
         let mut lists = vec![];
         for list_id in 0..NetworkFilterListId::Size as usize {
             // Don't optimize removeparam, since it can fuse filters without respecting distinct
             let optimize = optimize && list_id != NetworkFilterListId::RemoveParam as usize;
             lists.push(NetworkFilterListBuilder::new(optimize));
         }
-        let mut self_ = Self { lists };
-
-        let mut badfilter_ids: HashSet<Hash> = HashSet::new();
-
-        // Collect badfilter ids in advance.
-        for filter in network_filters.iter() {
-            if filter.is_badfilter() {
-                badfilter_ids.insert(filter.get_id());
-            }
+        Self {
+            lists,
+            bad_filter_ids: HashSet::new(),
         }
-
-        for filter in network_filters.into_iter() {
-            // skip any bad filters
-            let filter_id = filter.get_id();
-            if badfilter_ids.contains(&filter_id) || filter.is_badfilter() {
-                continue;
-            }
-
-            // Redirects are independent of blocking behavior.
-            if filter.is_redirect() {
-                self_.add_filter(filter.clone(), NetworkFilterListId::Redirects);
-            }
-            type FilterId = NetworkFilterListId;
-
-            let list_id: FilterId = if filter.is_csp() {
-                FilterId::Csp
-            } else if filter.is_removeparam() {
-                FilterId::RemoveParam
-            } else if filter.is_generic_hide() {
-                FilterId::GenericHide
-            } else if filter.is_exception() {
-                FilterId::Exceptions
-            } else if filter.is_important() {
-                FilterId::Importants
-            } else if filter.tag.is_some() && !filter.is_redirect() {
-                // `tag` + `redirect` is unsupported for now.
-                FilterId::TaggedFiltersAll
-            } else if (filter.is_redirect() && filter.also_block_redirect())
-                || !filter.is_redirect()
-            {
-                FilterId::Filters
-            } else {
-                continue;
-            };
-
-            self_.add_filter(filter, list_id);
-        }
-
-        self_
     }
 
-    fn add_filter(&mut self, network_filter: NetworkFilter, list_id: NetworkFilterListId) {
-        self.lists[list_id as usize].filters.push(network_filter);
+    pub fn add_rules(&mut self, filter: NetworkFilter, builder: &mut EngineFlatBuilder<'a>) {
+        if filter.is_badfilter() {
+            // `get_id()` already excludes the BAD_FILTER bit, so this ID matches
+            // the corresponding normal filter that this badfilter is meant to cancel.
+            self.bad_filter_ids.insert(filter.get_id());
+            return;
+        }
+
+        // Redirects are independent of blocking behavior.
+        if filter.is_redirect() {
+            self.add_filter(filter.clone(), NetworkFilterListId::Redirects, builder);
+        }
+        type FilterId = NetworkFilterListId;
+
+        let list_id: FilterId = if filter.is_csp() {
+            FilterId::Csp
+        } else if filter.is_removeparam() {
+            FilterId::RemoveParam
+        } else if filter.is_generic_hide() {
+            FilterId::GenericHide
+        } else if filter.is_exception() {
+            FilterId::Exceptions
+        } else if filter.is_important() {
+            FilterId::Importants
+        } else if filter.tag.is_some() && !filter.is_redirect() {
+            // `tag` + `redirect` is unsupported for now.
+            FilterId::TaggedFiltersAll
+        } else if (filter.is_redirect() && filter.also_block_redirect()) || !filter.is_redirect() {
+            FilterId::Filters
+        } else {
+            return;
+        };
+
+        self.add_filter(filter, list_id, builder);
+    }
+
+    fn add_filter(
+        &mut self,
+        network_filter: NetworkFilter,
+        list_id: NetworkFilterListId,
+        builder: &mut EngineFlatBuilder<'a>,
+    ) {
+        self.lists[list_id as usize].add_filter(network_filter, builder);
     }
 }
 
-impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for NetworkRulesBuilder {
-    type Output = WIPFlatVec<'a, NetworkFilterListBuilder, EngineFlatBuilder<'a>>;
+impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for NetworkFilterFlatEntry<'a> {
+    type Output = WIPOffset<fb::NetworkFilter<'a>>;
+
+    fn serialize(
+        value: Self,
+        _builder: &mut EngineFlatBuilder<'a>,
+    ) -> WIPOffset<fb::NetworkFilter<'a>> {
+        value.filter
+    }
+}
+
+impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for NetworkRulesBuilder<'a> {
+    type Output =
+        WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<fb::NetworkFilterList<'a>>>>;
+
     fn serialize(value: Self, builder: &mut EngineFlatBuilder<'a>) -> Self::Output {
-        FlatSerialize::serialize(value.lists, builder)
+        let mut serialized_lists = vec![];
+
+        for mut rule_list in value.lists {
+            if !rule_list.filters_to_optimize.is_empty() {
+                // Sort entries for deterministic iteration order.
+                let mut optimizable_entries: Vec<_> =
+                    rule_list.filters_to_optimize.drain().collect();
+                optimizable_entries.sort_unstable_by_key(|(token, _)| *token);
+
+                for (token, mut v) in optimizable_entries {
+                    v.retain(|f| !value.bad_filter_ids.contains(&f.get_id()));
+                    let optimized = optimizer::optimize(v);
+
+                    for filter in optimized {
+                        let id = filter.get_id();
+                        let filter = FlatSerialize::serialize(filter, builder);
+                        rule_list
+                            .flat_map_builder
+                            .insert(token, NetworkFilterFlatEntry { filter, id });
+                    }
+                }
+            }
+
+            // Prune already-serialized entries that were cancelled by a $badfilter.
+            rule_list
+                .flat_map_builder
+                .retain_by_value(|entry| !value.bad_filter_ids.contains(&entry.id));
+
+            let flat_filter_map = FlatMultiMapBuilder::finish(rule_list.flat_map_builder, builder);
+
+            serialized_lists.push(fb::NetworkFilterList::create(
+                builder.raw_builder(),
+                &fb::NetworkFilterListArgs {
+                    filter_map_index: Some(flat_filter_map.keys),
+                    filter_map_values: Some(flat_filter_map.values),
+                },
+            ));
+        }
+
+        FlatSerialize::serialize(serialized_lists, builder)
     }
 }

--- a/src/filters/fb_network_builder.rs
+++ b/src/filters/fb_network_builder.rs
@@ -34,7 +34,7 @@ struct NetworkFilterFlatEntry<'a> {
     id: Hash,
 }
 
-pub(crate) struct NetworkFilterListBuilder<'a> {
+struct NetworkFilterListBuilder<'a> {
     flat_map_builder: FlatMultiMapBuilder<ShortHash, NetworkFilterFlatEntry<'a>>,
     token_frequencies: TokenSelector,
     filters_to_optimize: HashMap<ShortHash, Vec<NetworkFilter>>,
@@ -133,7 +133,7 @@ impl<'a> NetworkFilterListBuilder<'a> {
     fn new(optimize: bool) -> Self {
         Self {
             flat_map_builder: FlatMultiMapBuilder::with_capacity(1024),
-            token_frequencies: TokenSelector::new(0),
+            token_frequencies: TokenSelector::new(1024),
             filters_to_optimize: HashMap::new(),
             tokens_buffer: TokensBuffer::default(),
             optimize,
@@ -146,22 +146,20 @@ impl<'a> NetworkFilterListBuilder<'a> {
 
         // Resolve token(s) and record frequencies up-front so the
         // serialized/optimizable branches share no token logic.
-        let mut single_token: Hash = 0;
+        let single_token: Hash;
         let tokens: &[Hash] = match multi_tokens {
-            FilterTokens::Empty => std::slice::from_ref(&single_token),
+            FilterTokens::Empty => {
+                // No tokens, add to fallback bucket (token 0)
+                &[0]
+            }
             FilterTokens::OptDomains => {
-                // tokens_buffer has been populated by get_tokens; record frequencies
-                let slice = self.tokens_buffer.as_slice();
-                for &t in slice {
-                    self.token_frequencies.record_usage(t);
-                }
-                slice
+                // tokens_buffer has been populated by get_tokens
+                self.tokens_buffer.as_slice()
             }
             FilterTokens::Other => {
                 single_token = self
                     .token_frequencies
                     .select_least_used_token(self.tokens_buffer.as_slice());
-                self.token_frequencies.record_usage(single_token);
                 std::slice::from_ref(&single_token)
             }
         };
@@ -170,22 +168,18 @@ impl<'a> NetworkFilterListBuilder<'a> {
             // Serialize immediately; store offset + id for later bad-filter pruning.
             let filter = FlatSerialize::serialize(network_filter, builder);
             for &token in tokens {
+                self.token_frequencies.record_usage(token);
                 self.flat_map_builder
                     .insert(to_short_hash(token), NetworkFilterFlatEntry { filter, id });
             }
         } else {
-            // Defer to the optimizer; clone only in the multi-token (OptDomains) case.
-            if let Some((last, rest)) = tokens.split_last() {
-                for &token in rest {
-                    self.filters_to_optimize
-                        .entry(to_short_hash(token))
-                        .or_default()
-                        .push(network_filter.clone());
-                }
+            // Defer serialization to the optimizer
+            for &token in tokens {
+                self.token_frequencies.record_usage(token);
                 self.filters_to_optimize
-                    .entry(to_short_hash(*last))
+                    .entry(to_short_hash(token))
                     .or_default()
-                    .push(network_filter);
+                    .push(network_filter.clone());
             }
         }
     }
@@ -193,29 +187,29 @@ impl<'a> NetworkFilterListBuilder<'a> {
 
 impl<'a> NetworkRulesBuilder<'a> {
     pub fn new(optimize: bool) -> Self {
-        let mut lists = vec![];
-        for list_id in 0..NetworkFilterListId::Size as usize {
-            // Don't optimize removeparam, since it can fuse filters without respecting distinct
-            let optimize = optimize && list_id != NetworkFilterListId::RemoveParam as usize;
-            lists.push(NetworkFilterListBuilder::new(optimize));
-        }
+        let lists = (0..NetworkFilterListId::Size as usize)
+            .map(|list_id| {
+                // Don't optimize removeparam, since it can fuse filters without respecting distinct
+                let optimize = optimize && list_id != NetworkFilterListId::RemoveParam as usize;
+                NetworkFilterListBuilder::new(optimize)
+            })
+            .collect::<Vec<_>>();
         Self {
             lists,
-            bad_filter_ids: HashSet::new(),
+            bad_filter_ids: HashSet::with_capacity(1024),
         }
     }
 
-    pub fn add_rules(&mut self, filter: NetworkFilter, builder: &mut EngineFlatBuilder<'a>) {
+    pub fn add_filter(&mut self, filter: NetworkFilter, builder: &mut EngineFlatBuilder<'a>) {
         if filter.is_badfilter() {
-            // `get_id()` already excludes the BAD_FILTER bit, so this ID matches
-            // the corresponding normal filter that this badfilter is meant to cancel.
+            // Note: `get_id()` doesn't include BAD_FILTER bit.
             self.bad_filter_ids.insert(filter.get_id());
             return;
         }
 
         // Redirects are independent of blocking behavior.
         if filter.is_redirect() {
-            self.add_filter(filter.clone(), NetworkFilterListId::Redirects, builder);
+            self.add_filter_internal(filter.clone(), NetworkFilterListId::Redirects, builder);
         }
         type FilterId = NetworkFilterListId;
 
@@ -238,10 +232,10 @@ impl<'a> NetworkRulesBuilder<'a> {
             return;
         };
 
-        self.add_filter(filter, list_id, builder);
+        self.add_filter_internal(filter, list_id, builder);
     }
 
-    fn add_filter(
+    fn add_filter_internal(
         &mut self,
         network_filter: NetworkFilter,
         list_id: NetworkFilterListId,

--- a/src/filters/fb_network_builder.rs
+++ b/src/filters/fb_network_builder.rs
@@ -165,7 +165,8 @@ impl<'a> NetworkFilterListBuilder<'a> {
         };
 
         if !self.optimize || !optimizer::is_filter_optimizable_by_patterns(&network_filter) {
-            // Serialize immediately; store offset + id for later bad-filter pruning.
+            // Serialize now (even if it matches to a bad filter later);
+            // Although store the id for later bad-filter pruning.
             let filter = FlatSerialize::serialize(network_filter, builder);
             for &token in tokens {
                 self.token_frequencies.record_usage(token);

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -291,9 +291,7 @@ pub enum FilterPart {
 #[derive(Debug, PartialEq)]
 pub(crate) enum FilterTokens {
     Empty,
-    /// Token data is stored in the `tokens_buffer` passed to `get_tokens`.
     OptDomains,
-    /// Token data is stored in the `tokens_buffer` passed to `get_tokens`.
     Other,
 }
 
@@ -835,6 +833,9 @@ impl NetworkFilter {
         )
     }
 
+    /// Returns the tokens that the filter matches to.
+    ///
+    /// For `!FilterTokens::Empty`, the result is stored in the given `tokens_buffer`.
     pub(crate) fn get_tokens(&self, tokens_buffer: &mut TokensBuffer) -> FilterTokens {
         tokens_buffer.clear();
 
@@ -901,8 +902,7 @@ impl NetworkFilter {
                         return FilterTokens::OptDomains;
                     }
                     // Too many domains to bucket individually; fall back to the catch-all
-                    // bucket (token 0). The opt_domains constraint is still enforced during
-                    // request matching, so correctness is preserved.
+                    // bucket (token 0).
                 }
             }
             FilterTokens::Empty

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -289,10 +289,12 @@ pub enum FilterPart {
 }
 
 #[derive(Debug, PartialEq)]
-pub(crate) enum FilterTokens<'a> {
+pub(crate) enum FilterTokens {
     Empty,
-    OptDomains(&'a [Hash]),
-    Other(&'a [Hash]),
+    /// Token data is stored in the `tokens_buffer` passed to `get_tokens`.
+    OptDomains,
+    /// Token data is stored in the `tokens_buffer` passed to `get_tokens`.
+    Other,
 }
 
 pub struct FilterPartIterator<'a> {
@@ -833,10 +835,7 @@ impl NetworkFilter {
         )
     }
 
-    pub(crate) fn get_tokens<'a>(
-        &'a self,
-        tokens_buffer: &'a mut TokensBuffer,
-    ) -> FilterTokens<'a> {
+    pub(crate) fn get_tokens(&self, tokens_buffer: &mut TokensBuffer) -> FilterTokens {
         tokens_buffer.clear();
 
         // If there is only one domain and no domain negation, we also use this
@@ -896,7 +895,14 @@ impl NetworkFilter {
         {
             if let Some(opt_domains) = self.opt_domains.as_ref() {
                 if !opt_domains.is_empty() {
-                    return FilterTokens::OptDomains(opt_domains);
+                    let cap = tokens_buffer.remaining_capacity();
+                    if opt_domains.len() <= cap {
+                        tokens_buffer.extend(opt_domains.iter().copied());
+                        return FilterTokens::OptDomains;
+                    }
+                    // Too many domains to bucket individually; fall back to the catch-all
+                    // bucket (token 0). The opt_domains constraint is still enforced during
+                    // request matching, so correctness is preserved.
                 }
             }
             FilterTokens::Empty
@@ -908,7 +914,7 @@ impl NetworkFilter {
                 tokens_buffer.push(utils::fast_hash("https"));
             }
 
-            FilterTokens::Other(tokens_buffer.as_slice())
+            FilterTokens::Other
         }
     }
 

--- a/src/flatbuffers/containers/flat_multimap.rs
+++ b/src/flatbuffers/containers/flat_multimap.rs
@@ -107,6 +107,10 @@ impl<I: Ord + std::hash::Hash, V> FlatMultiMapBuilder<I, V> {
         self.entries.push((key, value));
     }
 
+    pub fn retain_by_value(&mut self, retain_if: impl Fn(&V) -> bool) {
+        self.entries.retain(|(_, value)| retain_if(value));
+    }
+
     pub fn finish<'a, B: FlatBuilder<'a>>(
         value: Self,
         builder: &mut B,

--- a/src/flatbuffers/containers/flat_multimap.rs
+++ b/src/flatbuffers/containers/flat_multimap.rs
@@ -107,7 +107,7 @@ impl<I: Ord + std::hash::Hash, V> FlatMultiMapBuilder<I, V> {
         self.entries.push((key, value));
     }
 
-    pub fn retain_by_value(&mut self, retain_if: impl Fn(&V) -> bool) {
+    pub fn retain_by_value(&mut self, mut retain_if: impl FnMut(&V) -> bool) {
         self.entries.retain(|(_, value)| retain_if(value));
     }
 

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -8,5 +8,6 @@ pub fn rules_from_lists(list_files: impl IntoIterator<Item = impl AsRef<str>>) -
         contents.push_str(&std::fs::read_to_string(file.as_ref()).unwrap());
         contents.push('\n');
     }
+    contents.shrink_to_fit();
     contents
 }

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -239,9 +239,9 @@ mod tests {
             );
         }
         let expected_hash: u64 = if cfg!(feature = "css-validation") {
-            10068943306137168952
+            16703814344905873613
         } else {
-            6262681569722546672
+            13012744135002827554
         };
 
         assert_eq!(hash(&data), expected_hash, "{HASH_MISMATCH_MSG}");

--- a/tests/unit/filters/network.rs
+++ b/tests/unit/filters/network.rs
@@ -1252,9 +1252,10 @@ mod parse_tests {
         let rule = "||some.primewire.c*/sw$script,1p";
         let filter = NetworkFilter::parse(rule, true, ParseOptions::default()).unwrap();
         let mut tokens_buffer = utils::TokensBuffer::default();
+        assert_eq!(filter.get_tokens(&mut tokens_buffer), FilterTokens::Other);
         assert_eq!(
-            filter.get_tokens(&mut tokens_buffer),
-            FilterTokens::Other(&[utils::fast_hash("some"), utils::fast_hash("primewire")])
+            tokens_buffer.as_slice(),
+            &[utils::fast_hash("some"), utils::fast_hash("primewire")]
         );
     }
 }


### PR DESCRIPTION
The PR refactor the filter parsing code to allow processing filters one-by-one.

Main changes: 
*  `new_with_filter_set` parses filter one by one and  immediately drops them after processing.
* The filters, matched to bad filters, are always serialized. The offsets are dropped from the hash table on the last stage. The negative impact is minimal, because $badfilter is rare thing. 
*  `get_tokens` uses an extra output param `tokens_buffer` to avoid unwanted allocations.

The PR dramatically reduces allocation count (-25%) and peak memory usage (about -50%).