### PR TITLE
update Rust to 1.96

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95"
+channel = "1.96"
 components = ["clippy", "rustfmt" ]


### PR DESCRIPTION
https://blog.rust-lang.org/2026/05/28/Rust-1.96.0/