### PR TITLE
Improve Engine.check argument errors

### DIFF
--- a/js/src/lib.rs
+++ b/js/src/lib.rs
@@ -53,6 +53,14 @@ mod json_ffi {
     }
 }
 
+fn string_argument(cx: &mut FunctionContext, index: i32, name: &str) -> NeonResult<String> {
+    let value = cx.argument::<JsValue>(index)?;
+    match value.downcast::<JsString, _>(cx) {
+        Ok(value) => Ok(value.value(cx)),
+        Err(_) => cx.throw_type_error(format!("{name} argument expected string")),
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 struct EngineOptions {
     pub optimize: Option<bool>,
@@ -181,9 +189,9 @@ fn engine_constructor(mut cx: FunctionContext) -> JsResult<JsBox<Engine>> {
 fn engine_check(mut cx: FunctionContext) -> JsResult<JsValue> {
     let this = cx.argument::<JsBox<Engine>>(0)?;
 
-    let url: String = cx.argument::<JsString>(1)?.value(&mut cx);
-    let source_url: String = cx.argument::<JsString>(2)?.value(&mut cx);
-    let request_type: String = cx.argument::<JsString>(3)?.value(&mut cx);
+    let url = string_argument(&mut cx, 1, "url")?;
+    let source_url = string_argument(&mut cx, 2, "source_url")?;
+    let request_type = string_argument(&mut cx, 3, "request_type")?;
 
     let debug = match cx.argument_opt(4) {
         Some(arg) => {

--- a/js/test/bindings.test.mjs
+++ b/js/test/bindings.test.mjs
@@ -178,6 +178,22 @@ describe('Engine.check — basic blocking', () => {
         assert.throws(() => engine.check('not a url', 'https://publisher.com', 'script'));
     });
 
+    it('throws descriptive errors for invalid argument types', () => {
+        const engine = new Engine(new FilterSet(), true);
+        assert.throws(
+            () => engine.check(undefined, 'https://publisher.com', 'script'),
+            /url argument expected string/,
+        );
+        assert.throws(
+            () => engine.check('https://example.com', undefined, 'script'),
+            /source_url argument expected string/,
+        );
+        assert.throws(
+            () => engine.check('https://example.com', 'https://publisher.com', undefined),
+            /request_type argument expected string/,
+        );
+    });
+
     it('EngineOptions object works as alternative to boolean', () => {
         const fs = new FilterSet();
         fs.addFilters(['||blocked.com^']);


### PR DESCRIPTION
Problem
- Passing a non-string value to `Engine.check` currently surfaces Neon's generic downcast error, which does not identify which request argument is wrong.

Root cause
- The binding layer directly downcasts the `url`, `source_url`, and `request_type` arguments without adding API-level context.

Solution
- Add a small string argument helper that reports the expected argument name.
- Use it for `Engine.check` request arguments.
- Add JS binding coverage for invalid `url`, `source_url`, and `request_type` values.

Tests run
- cargo fmt --all -- --check
- cargo check -p adblock-rs
- cargo test -p adblock --lib resources::resource_storage -- --nocapture
- npm install --ignore-scripts
- npm run build
- npm run test:js
- cargo test -p adblock-rs --no-default-features
- git diff --check

Fixes #182