### PR TITLE
Ignore invalid patterns when compiling full-regex sets

### DIFF
--- a/src/regex_manager.rs
+++ b/src/regex_manager.rs
@@ -161,6 +161,38 @@ where
     )
 }
 
+fn compile_regex_pattern(pattern: &str) -> Result<BytesRegex, regex::Error> {
+    BytesRegexBuilder::new(pattern).unicode(false).build()
+}
+
+fn compile_regex_set(patterns: Vec<String>, discard_invalid_patterns: bool) -> CompiledRegex {
+    match BytesRegexSetBuilder::new(&patterns).unicode(false).build() {
+        Ok(compiled) => CompiledRegex::CompiledSet(compiled),
+        Err(e) if discard_invalid_patterns => {
+            let valid_patterns: Vec<_> = patterns
+                .into_iter()
+                .filter(|pattern| compile_regex_pattern(pattern).is_ok())
+                .collect();
+
+            match valid_patterns.len() {
+                0 => CompiledRegex::RegexParsingError(e),
+                1 => match compile_regex_pattern(&valid_patterns[0]) {
+                    Ok(compiled) => CompiledRegex::Compiled(compiled),
+                    Err(e) => CompiledRegex::RegexParsingError(e),
+                },
+                _ => match BytesRegexSetBuilder::new(valid_patterns)
+                    .unicode(false)
+                    .build()
+                {
+                    Ok(compiled) => CompiledRegex::CompiledSet(compiled),
+                    Err(e) => CompiledRegex::RegexParsingError(e),
+                },
+            }
+        }
+        Err(e) => CompiledRegex::RegexParsingError(e),
+    }
+}
+
 /// Compiles a filter pattern to a regex. This is only performed *lazily* for
 /// filters containing at least a * or ^ symbol. Because Regexes are expansive,
 /// we try to convert some patterns to plain filters.
@@ -218,7 +250,7 @@ where
         CompiledRegex::MatchAll
     } else if escaped_patterns.len() == 1 {
         let pattern = &escaped_patterns[0];
-        match BytesRegexBuilder::new(pattern).unicode(false).build() {
+        match compile_regex_pattern(pattern) {
             Ok(compiled) => CompiledRegex::Compiled(compiled),
             Err(e) => {
                 // println!("Regex parsing failed ({:?})", e);
@@ -226,13 +258,7 @@ where
             }
         }
     } else {
-        match BytesRegexSetBuilder::new(escaped_patterns)
-            .unicode(false)
-            .build()
-        {
-            Ok(compiled) => CompiledRegex::CompiledSet(compiled),
-            Err(e) => CompiledRegex::RegexParsingError(e),
-        }
+        compile_regex_set(escaped_patterns, is_complete_regex)
     }
 }
 

--- a/tests/unit/regex_manager.rs
+++ b/tests/unit/regex_manager.rs
@@ -1,3 +1,20 @@
+#[cfg(test)]
+mod compile_tests {
+    use crate::regex_manager::compile_regex;
+
+    #[test]
+    fn invalid_complete_regex_does_not_disable_valid_pattern_in_set() {
+        let compiled = compile_regex(
+            [r#"/^https:\/\/b\.com/"#, r#"/(?=a)/"#].into_iter(),
+            false,
+            false,
+            true,
+        );
+
+        assert!(compiled.is_match("https://b.com"));
+    }
+}
+
 #[cfg(all(test, feature = "debug-info"))]
 mod tests {
     use super::super::*;


### PR DESCRIPTION
## Problem

Full-regex filters are compiled lazily. When multiple compatible rules are optimized into a single pattern set, one invalid full-regex pattern can cause the whole `RegexSet` compilation to fail, which prevents valid patterns in the same set from matching.

Fixes #168.

## Root cause

`compile_regex` returned `CompiledRegex::RegexParsingError` for the entire set whenever `BytesRegexSetBuilder` failed. That is correct for generated simple regexes, but too broad for full-regex filter lists where individual list entries may be unsupported or malformed.

## Solution

When a full-regex set fails to compile, retry by keeping only patterns that compile individually. The remaining valid patterns are compiled as a single regex or regex set as appropriate. Non-full-regex generated sets keep the previous strict behavior.

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p adblock invalid_complete_regex_does_not_disable_valid_pattern_in_set --lib --features full-regex-handling`
- `cargo test -p adblock regex_manager --lib --features full-regex-handling,debug-info`
- `cargo test -p adblock --lib --features full-regex-handling`
- `cargo test -p adblock --lib`
- `cargo clippy -p adblock --features full-regex-handling -- -D warnings`
- `git diff --check`