### PR TITLE
[perf] Use Cow/&str in network filter parsing 

### DIFF
--- a/benches/bench_redirect_performance.rs
+++ b/benches/bench_redirect_performance.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use adblock::Engine;
 use criterion::*;
 use tokio::runtime::Runtime;
@@ -56,11 +58,14 @@ async fn get_all_filters() -> Vec<String> {
 }
 
 /// Gets all rules with redirects, and modifies them to apply to resources at `a{0-n}.com/bad.js`
-fn get_redirect_rules() -> Vec<NetworkFilter> {
+fn get_redirect_rules() -> Vec<NetworkFilter<'static>> {
     let async_runtime = Runtime::new().expect("Could not start Tokio runtime");
 
-    let filters = async_runtime.block_on(get_all_filters());
-    let (network_filters, _) = adblock::lists::parse_filters(&filters, true, Default::default());
+    // Leak the filters vec so that parsed NetworkFilter<'static> can borrow from it safely.
+    let filters: &'static [String] =
+        Box::leak(async_runtime.block_on(get_all_filters()).into_boxed_slice());
+    let (network_filters, _) =
+        adblock::lists::parse_filters(filters.iter().map(|s| s.as_str()), true, Default::default());
 
     network_filters
         .into_iter()
@@ -71,7 +76,7 @@ fn get_redirect_rules() -> Vec<NetworkFilter> {
         .map(|(index, mut rule)| {
             rule.mask.insert(NetworkFilterMask::IS_LEFT_ANCHOR);
             rule.mask.insert(NetworkFilterMask::IS_RIGHT_ANCHOR);
-            rule.hostname = Some(format!("a{index}.com/bad.js"));
+            rule.hostname = Some(Cow::Owned(format!("a{index}.com/bad.js")));
 
             rule.filter = adblock::filters::network::FilterPart::Empty;
             rule.mask.remove(NetworkFilterMask::IS_HOSTNAME_ANCHOR);

--- a/benches/bench_redirect_performance.rs
+++ b/benches/bench_redirect_performance.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::sync::OnceLock;
 
 use adblock::Engine;
 use criterion::*;
@@ -57,13 +58,18 @@ async fn get_all_filters() -> Vec<String> {
         .collect()
 }
 
+static ALL_FILTERS: OnceLock<Box<[String]>> = OnceLock::new();
+
+fn all_filters() -> &'static [String] {
+    ALL_FILTERS.get_or_init(|| {
+        let async_runtime = Runtime::new().expect("Could not start Tokio runtime");
+        async_runtime.block_on(get_all_filters()).into_boxed_slice()
+    })
+}
+
 /// Gets all rules with redirects, and modifies them to apply to resources at `a{0-n}.com/bad.js`
 fn get_redirect_rules() -> Vec<NetworkFilter<'static>> {
-    let async_runtime = Runtime::new().expect("Could not start Tokio runtime");
-
-    // Leak the filters vec so that parsed NetworkFilter<'static> can borrow from it safely.
-    let filters: &'static [String] =
-        Box::leak(async_runtime.block_on(get_all_filters()).into_boxed_slice());
+    let filters = all_filters();
     let (network_filters, _) =
         adblock::lists::parse_filters(filters.iter().map(|s| s.as_str()), true, Default::default());
 

--- a/benches/bench_redirect_performance.rs
+++ b/benches/bench_redirect_performance.rs
@@ -122,17 +122,17 @@ fn get_resources_for_filters(#[allow(unused)] filters: &[NetworkFilter]) -> Vec<
             .iter()
             .filter(|f| f.is_redirect())
             .map(|f| {
-                let mut redirect = f.modifier_option.as_ref().unwrap().as_str();
+                let mut redirect = f.modifier_option.as_ref().unwrap().to_string();
                 // strip priority, if present
                 if let Some(i) = redirect.rfind(':') {
-                    redirect = &redirect[0..i];
+                    redirect.truncate(i);
                 }
 
                 Resource {
-                    name: redirect.to_owned(),
+                    name: redirect.clone(),
                     aliases: vec![],
-                    kind: ResourceType::Mime(MimeType::from_extension(redirect)),
-                    content: BASE64_STANDARD.encode(redirect),
+                    kind: ResourceType::Mime(MimeType::from_extension(&redirect)),
+                    content: BASE64_STANDARD.encode(&redirect),
                     dependencies: vec![],
                     permission: Default::default(),
                 }

--- a/benches/bench_redirect_performance.rs
+++ b/benches/bench_redirect_performance.rs
@@ -77,7 +77,7 @@ fn get_redirect_rules() -> Vec<NetworkFilter<'static>> {
         .into_iter()
         .filter(NetworkFilter::is_redirect)
         .filter(NetworkFilter::also_block_redirect)
-        .filter(|rule| rule.modifier_option.as_ref().unwrap() != "none")
+        .filter(|rule| rule.modifier_option.unwrap() != "none")
         .enumerate()
         .map(|(index, mut rule)| {
             rule.mask.insert(NetworkFilterMask::IS_LEFT_ANCHOR);

--- a/benches/bench_redirect_performance.rs
+++ b/benches/bench_redirect_performance.rs
@@ -174,7 +174,7 @@ pub fn build_custom_requests(rules: Vec<NetworkFilter>) -> Vec<Request> {
             let domain = &rule_hostname[..rule_hostname.find('/').unwrap()];
             let hostname = domain;
 
-            let raw_line = rule.raw_line.clone().unwrap();
+            let raw_line = rule.raw_line.as_deref().unwrap().to_string();
             let source_hostname = if rule.opt_domains.is_some() {
                 let domain_start = raw_line.rfind("domain=").unwrap() + "domain=".len();
                 let from_start = &raw_line[domain_start..];

--- a/src/content_blocking.rs
+++ b/src/content_blocking.rs
@@ -229,7 +229,7 @@ pub enum CbRuleCreationFailure {
     ProceduralCosmeticFiltersUnsupported,
 }
 
-impl TryFrom<ParsedLine> for CbRuleEquivalent {
+impl TryFrom<ParsedLine<'_>> for CbRuleEquivalent {
     type Error = CbRuleCreationFailure;
 
     fn try_from(v: ParsedLine) -> Result<Self, Self::Error> {
@@ -301,7 +301,7 @@ impl Iterator for CbRuleEquivalentIterator {
     }
 }
 
-impl TryFrom<NetworkFilter> for CbRuleEquivalent {
+impl TryFrom<NetworkFilter<'_>> for CbRuleEquivalent {
     type Error = CbRuleCreationFailure;
 
     fn try_from(v: NetworkFilter) -> Result<Self, Self::Error> {

--- a/src/content_blocking.rs
+++ b/src/content_blocking.rs
@@ -311,7 +311,7 @@ impl TryFrom<NetworkFilter> for CbRuleEquivalent {
             LazyLock::new(|| Regex::new(r##"\*"##).unwrap());
         static TRAILING_SEPARATOR: LazyLock<Regex> =
             LazyLock::new(|| Regex::new(r##"\^$"##).unwrap());
-        if let Some(raw_line) = &v.raw_line {
+        if let Some(raw_line) = v.raw_line.as_deref() {
             if v.is_redirect() {
                 return Err(CbRuleCreationFailure::NetworkRedirectUnsupported);
             }
@@ -603,7 +603,7 @@ impl TryFrom<CosmeticFilter> for CbRule {
             return Err(CbRuleCreationFailure::ScriptletInjectionsNotSupported);
         }
 
-        if let Some(raw_line) = &v.raw_line {
+        if let Some(raw_line) = v.raw_line.as_deref() {
             let mut hostnames_vec = vec![];
             let mut not_hostnames_vec = vec![];
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -157,10 +157,10 @@ impl Engine {
         )
     }
 
-    fn new_with_builders<'fb, 'filter>(
-        network_rules_builder: NetworkRulesBuilder<'fb, 'filter>,
-        cosmetic_filter_cache_builder: CosmeticFilterCacheBuilder<'fb>,
-        mut builder: EngineFlatBuilder<'fb>,
+    fn new_with_builders<'a, 'f>(
+        network_rules_builder: NetworkRulesBuilder<'a, 'f>,
+        cosmetic_filter_cache_builder: CosmeticFilterCacheBuilder<'a>,
+        mut builder: EngineFlatBuilder<'a>,
     ) -> Self {
         let network_rules = FlatSerialize::serialize(network_rules_builder, &mut builder);
         let cosmetic_rules = FlatSerialize::serialize(cosmetic_filter_cache_builder, &mut builder);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -7,6 +7,7 @@ use crate::data_format::{deserialize_dat_file, serialize_dat_file, Deserializati
 use crate::filters::fb_builder::EngineFlatBuilder;
 use crate::filters::fb_network_builder::NetworkRulesBuilder;
 use crate::filters::filter_data_context::{FilterDataContext, FilterDataContextRef};
+use crate::filters::flatbuffer_generated::fb;
 use crate::flatbuffers::containers::flat_serialize::FlatSerialize;
 use crate::flatbuffers::unsafe_tools::VerifiedFlatbufferMemory;
 use crate::lists::{parse_filter, FilterSet, ParseOptions, ParsedLine};
@@ -118,9 +119,9 @@ impl Engine {
             cosmetic_filter_cache_builder.add_filter(filter, &mut builder);
         }
 
-        Self::new_with_builders(
-            network_rules_builder,
-            cosmetic_filter_cache_builder,
+        Self::new_with_flatbuffer_offsets(
+            FlatSerialize::serialize(network_rules_builder, &mut builder),
+            FlatSerialize::serialize(cosmetic_filter_cache_builder, &mut builder),
             builder,
         )
     }
@@ -149,21 +150,23 @@ impl Engine {
                 }
             }
         }
+        let network_rules_offset = FlatSerialize::serialize(network_rules_builder, &mut builder);
+        // Drop the list sources to reduce peak memory usage.
+        drop(list_sources);
 
-        Self::new_with_builders(
-            network_rules_builder,
-            cosmetic_filter_cache_builder,
-            builder,
-        )
+        let cosmetic_rules_offset =
+            FlatSerialize::serialize(cosmetic_filter_cache_builder, &mut builder);
+
+        Self::new_with_flatbuffer_offsets(network_rules_offset, cosmetic_rules_offset, builder)
     }
 
-    fn new_with_builders<'a, 'f>(
-        network_rules_builder: NetworkRulesBuilder<'a, 'f>,
-        cosmetic_filter_cache_builder: CosmeticFilterCacheBuilder<'a>,
+    fn new_with_flatbuffer_offsets<'a>(
+        network_rules: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<fb::NetworkFilterList<'a>>>,
+        >,
+        cosmetic_rules: flatbuffers::WIPOffset<fb::CosmeticFilters<'a>>,
         mut builder: EngineFlatBuilder<'a>,
     ) -> Self {
-        let network_rules = FlatSerialize::serialize(network_rules_builder, &mut builder);
-        let cosmetic_rules = FlatSerialize::serialize(cosmetic_filter_cache_builder, &mut builder);
         let memory = builder.finish(network_rules, cosmetic_rules);
         let filter_data_context = FilterDataContext::new(memory);
         Self {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -127,13 +127,17 @@ impl Engine {
 
     /// Loads rules from the given `FilterSet`.
     pub fn new_with_filter_set(set: FilterSet, optimize: bool) -> Self {
+        let FilterSet {
+            debug,
+            list_sources,
+        } = set;
         let mut builder = EngineFlatBuilder::default();
         let mut network_rules_builder = NetworkRulesBuilder::new(optimize);
         let mut cosmetic_filter_cache_builder = CosmeticFilterCacheBuilder::default();
 
-        for list_source in set.list_sources {
+        for list_source in &list_sources {
             for line in list_source.list_text.lines() {
-                let parsed_line = parse_filter(line, set.debug, list_source.parse_options);
+                let parsed_line = parse_filter(line, debug, list_source.parse_options);
                 match parsed_line {
                     Ok(ParsedLine::Network(filter)) => {
                         network_rules_builder.add_filter(filter, &mut builder)
@@ -153,10 +157,10 @@ impl Engine {
         )
     }
 
-    fn new_with_builders<'a>(
-        network_rules_builder: NetworkRulesBuilder<'a>,
-        cosmetic_filter_cache_builder: CosmeticFilterCacheBuilder<'a>,
-        mut builder: EngineFlatBuilder<'a>,
+    fn new_with_builders<'fb, 'filter>(
+        network_rules_builder: NetworkRulesBuilder<'fb, 'filter>,
+        cosmetic_filter_cache_builder: CosmeticFilterCacheBuilder<'fb>,
+        mut builder: EngineFlatBuilder<'fb>,
     ) -> Self {
         let network_rules = FlatSerialize::serialize(network_rules_builder, &mut builder);
         let cosmetic_rules = FlatSerialize::serialize(cosmetic_filter_cache_builder, &mut builder);

--- a/src/filters/abstract_network.rs
+++ b/src/filters/abstract_network.rs
@@ -1,4 +1,5 @@
 use memchr::memrchr as find_char_reverse;
+use std::borrow::Cow;
 
 use super::network::NetworkFilterError;
 
@@ -26,7 +27,8 @@ pub(crate) enum NetworkFilterRightAnchor {
 #[derive(Clone)]
 pub(crate) struct NetworkFilterPattern {
     pub(crate) left_anchor: Option<NetworkFilterLeftAnchor>,
-    pub(crate) pattern: String,
+    pub(crate) start: usize,
+    pub(crate) end: usize,
     pub(crate) right_anchor: Option<NetworkFilterRightAnchor>,
 }
 
@@ -34,18 +36,18 @@ pub(crate) struct NetworkFilterPattern {
 /// All `bool` arguments below are `true` if the option stands alone, or `false` if the option is
 /// negated using a prepended `~`.
 #[derive(Clone)]
-pub(crate) enum NetworkFilterOption {
-    Domain(Vec<(bool, String)>),
+pub(crate) enum NetworkFilterOption<'a> {
+    Domain(Vec<(bool, Cow<'a, str>)>),
     Badfilter,
     Important,
     MatchCase,
     ThirdParty(bool),
     FirstParty(bool),
-    Tag(String),
-    Redirect(String),
-    RedirectRule(String),
-    Csp(Option<String>),
-    Removeparam(String),
+    Tag(Cow<'a, str>),
+    Redirect(Cow<'a, str>),
+    RedirectRule(Cow<'a, str>),
+    Csp(Option<Cow<'a, str>>),
+    Removeparam(Cow<'a, str>),
     Generichide,
     Document,
     Image(bool),
@@ -62,7 +64,7 @@ pub(crate) enum NetworkFilterOption {
     All,
 }
 
-impl NetworkFilterOption {
+impl NetworkFilterOption<'_> {
     pub fn is_content_type(&self) -> bool {
         matches!(
             self,
@@ -90,14 +92,16 @@ impl NetworkFilterOption {
 /// Abstract syntax representation of a network filter. This representation can fully specify the
 /// string representation of a filter as written, with the exception of aliased options like `1p`
 /// or `ghide`. This allows separation of concerns between parsing and interpretation.
-pub(crate) struct AbstractNetworkFilter {
+pub(crate) struct AbstractNetworkFilter<'a> {
     pub(crate) exception: bool,
     pub(crate) pattern: NetworkFilterPattern,
-    pub(crate) options: Option<Vec<NetworkFilterOption>>,
+    pub(crate) options: Option<Vec<NetworkFilterOption<'a>>>,
 }
 
-impl AbstractNetworkFilter {
-    pub(crate) fn parse(line: &str) -> Result<Self, NetworkFilterError> {
+impl AbstractNetworkFilter<'_> {
+    pub(crate) fn parse<'a>(
+        line: &'a str,
+    ) -> Result<AbstractNetworkFilter<'a>, NetworkFilterError> {
         let mut filter_index_start: usize = 0;
         let mut filter_index_end: usize = line.len();
 
@@ -139,13 +143,12 @@ impl AbstractNetworkFilter {
             None
         };
 
-        let pattern = &line[filter_index_start..filter_index_end];
-
         Ok(AbstractNetworkFilter {
             exception,
             pattern: NetworkFilterPattern {
                 left_anchor,
-                pattern: pattern.to_string(),
+                start: filter_index_start,
+                end: filter_index_end,
                 right_anchor,
             },
             options,
@@ -153,7 +156,9 @@ impl AbstractNetworkFilter {
     }
 }
 
-fn parse_filter_options(raw_options: &str) -> Result<Vec<NetworkFilterOption>, NetworkFilterError> {
+fn parse_filter_options<'a>(
+    raw_options: &'a str,
+) -> Result<Vec<NetworkFilterOption<'a>>, NetworkFilterError> {
     let mut result = vec![];
 
     for raw_option in raw_options.split(',') {
@@ -170,13 +175,13 @@ fn parse_filter_options(raw_options: &str) -> Result<Vec<NetworkFilterOption>, N
 
         result.push(match (option, negation) {
             ("domain", _) | ("from", _) => {
-                let domains: Vec<(bool, String)> = value
+                let domains: Vec<(bool, Cow<'a, str>)> = value
                     .split('|')
                     .map(|domain| {
                         if let Some(negated_domain) = domain.strip_prefix('~') {
-                            (false, negated_domain.to_string())
+                            (false, Cow::Borrowed(negated_domain))
                         } else {
-                            (true, domain.to_string())
+                            (true, Cow::Borrowed(domain))
                         }
                     })
                     .filter(|(_, d)| !(d.starts_with('/') && d.ends_with('/')))
@@ -195,7 +200,7 @@ fn parse_filter_options(raw_options: &str) -> Result<Vec<NetworkFilterOption>, N
             ("third-party", negated) | ("3p", negated) => NetworkFilterOption::ThirdParty(!negated),
             ("first-party", negated) | ("1p", negated) => NetworkFilterOption::FirstParty(!negated),
             ("tag", true) => return Err(NetworkFilterError::NegatedTag),
-            ("tag", false) => NetworkFilterOption::Tag(String::from(value)),
+            ("tag", false) => NetworkFilterOption::Tag(Cow::Borrowed(value)),
             ("redirect", true) => return Err(NetworkFilterError::NegatedRedirection),
             ("redirect", false) => {
                 // Ignore this filter if no redirection resource is specified
@@ -203,7 +208,7 @@ fn parse_filter_options(raw_options: &str) -> Result<Vec<NetworkFilterOption>, N
                     return Err(NetworkFilterError::EmptyRedirection);
                 }
 
-                NetworkFilterOption::Redirect(String::from(value))
+                NetworkFilterOption::Redirect(Cow::Borrowed(value))
             }
             ("redirect-rule", true) => return Err(NetworkFilterError::NegatedRedirection),
             ("redirect-rule", false) => {
@@ -211,10 +216,10 @@ fn parse_filter_options(raw_options: &str) -> Result<Vec<NetworkFilterOption>, N
                     return Err(NetworkFilterError::EmptyRedirection);
                 }
 
-                NetworkFilterOption::RedirectRule(String::from(value))
+                NetworkFilterOption::RedirectRule(Cow::Borrowed(value))
             }
             ("csp", _) => NetworkFilterOption::Csp(if !value.is_empty() {
-                Some(String::from(value))
+                Some(Cow::Borrowed(value))
             } else {
                 None
             }),
@@ -226,7 +231,7 @@ fn parse_filter_options(raw_options: &str) -> Result<Vec<NetworkFilterOption>, N
                 if !VALID_PARAM.is_match(value) {
                     return Err(NetworkFilterError::RemoveparamRegexUnsupported);
                 }
-                NetworkFilterOption::Removeparam(String::from(value))
+                NetworkFilterOption::Removeparam(Cow::Borrowed(value))
             }
             ("generichide", true) | ("ghide", true) => {
                 return Err(NetworkFilterError::NegatedGenericHide)

--- a/src/filters/abstract_network.rs
+++ b/src/filters/abstract_network.rs
@@ -95,7 +95,7 @@ impl NetworkFilterOption<'_> {
 pub(crate) struct AbstractNetworkFilter<'a> {
     pub(crate) exception: bool,
     pub(crate) pattern: NetworkFilterPattern,
-    pub(crate) raw_options: Option<&'a str>,
+    pub(crate) options: Option<Vec<NetworkFilterOption<'a>>>,
 }
 
 impl AbstractNetworkFilter<'_> {
@@ -113,12 +113,14 @@ impl AbstractNetworkFilter<'_> {
 
         let maybe_options_index: Option<usize> = find_char_reverse(b'$', line.as_bytes());
 
-        let raw_options: Option<&'a str>;
+        let mut options = None;
         if let Some(options_index) = maybe_options_index {
             filter_index_end = options_index;
-            raw_options = Some(&line[filter_index_end + 1..]);
-        } else {
-            raw_options = None;
+
+            // slicing here is safe; the first byte after '$' will be a character boundary
+            let raw_options = &line[filter_index_end + 1..];
+
+            options = Some(parse_filter_options(raw_options)?);
         }
 
         let left_anchor = if line[filter_index_start..].starts_with("||") {
@@ -149,12 +151,12 @@ impl AbstractNetworkFilter<'_> {
                 end: filter_index_end,
                 right_anchor,
             },
-            raw_options,
+            options,
         })
     }
 }
 
-pub(crate) fn parse_filter_options<'a>(
+fn parse_filter_options<'a>(
     raw_options: &'a str,
 ) -> Result<Vec<NetworkFilterOption<'a>>, NetworkFilterError> {
     let mut result = vec![];

--- a/src/filters/abstract_network.rs
+++ b/src/filters/abstract_network.rs
@@ -1,5 +1,4 @@
 use memchr::memrchr as find_char_reverse;
-use std::borrow::Cow;
 
 use super::network::NetworkFilterError;
 
@@ -37,17 +36,17 @@ pub(crate) struct NetworkFilterPattern {
 /// negated using a prepended `~`.
 #[derive(Clone)]
 pub(crate) enum NetworkFilterOption<'a> {
-    Domain(Vec<(bool, Cow<'a, str>)>),
+    Domain(Vec<(bool, &'a str)>),
     Badfilter,
     Important,
     MatchCase,
     ThirdParty(bool),
     FirstParty(bool),
-    Tag(Cow<'a, str>),
-    Redirect(Cow<'a, str>),
-    RedirectRule(Cow<'a, str>),
-    Csp(Option<Cow<'a, str>>),
-    Removeparam(Cow<'a, str>),
+    Tag(&'a str),
+    Redirect(&'a str),
+    RedirectRule(&'a str),
+    Csp(Option<&'a str>),
+    Removeparam(&'a str),
     Generichide,
     Document,
     Image(bool),
@@ -175,13 +174,13 @@ fn parse_filter_options<'a>(
 
         result.push(match (option, negation) {
             ("domain", _) | ("from", _) => {
-                let domains: Vec<(bool, Cow<'a, str>)> = value
+                let domains: Vec<(bool, &'a str)> = value
                     .split('|')
                     .map(|domain| {
                         if let Some(negated_domain) = domain.strip_prefix('~') {
-                            (false, Cow::Borrowed(negated_domain))
+                            (false, negated_domain)
                         } else {
-                            (true, Cow::Borrowed(domain))
+                            (true, domain)
                         }
                     })
                     .filter(|(_, d)| !(d.starts_with('/') && d.ends_with('/')))
@@ -200,7 +199,7 @@ fn parse_filter_options<'a>(
             ("third-party", negated) | ("3p", negated) => NetworkFilterOption::ThirdParty(!negated),
             ("first-party", negated) | ("1p", negated) => NetworkFilterOption::FirstParty(!negated),
             ("tag", true) => return Err(NetworkFilterError::NegatedTag),
-            ("tag", false) => NetworkFilterOption::Tag(Cow::Borrowed(value)),
+            ("tag", false) => NetworkFilterOption::Tag(value),
             ("redirect", true) => return Err(NetworkFilterError::NegatedRedirection),
             ("redirect", false) => {
                 // Ignore this filter if no redirection resource is specified
@@ -208,7 +207,7 @@ fn parse_filter_options<'a>(
                     return Err(NetworkFilterError::EmptyRedirection);
                 }
 
-                NetworkFilterOption::Redirect(Cow::Borrowed(value))
+                NetworkFilterOption::Redirect(value)
             }
             ("redirect-rule", true) => return Err(NetworkFilterError::NegatedRedirection),
             ("redirect-rule", false) => {
@@ -216,13 +215,11 @@ fn parse_filter_options<'a>(
                     return Err(NetworkFilterError::EmptyRedirection);
                 }
 
-                NetworkFilterOption::RedirectRule(Cow::Borrowed(value))
+                NetworkFilterOption::RedirectRule(value)
             }
-            ("csp", _) => NetworkFilterOption::Csp(if !value.is_empty() {
-                Some(Cow::Borrowed(value))
-            } else {
-                None
-            }),
+            ("csp", _) => {
+                NetworkFilterOption::Csp(if !value.is_empty() { Some(value) } else { None })
+            }
             ("removeparam", true) => return Err(NetworkFilterError::NegatedRemoveparam),
             ("removeparam", false) => {
                 if value.is_empty() {
@@ -231,7 +228,7 @@ fn parse_filter_options<'a>(
                 if !VALID_PARAM.is_match(value) {
                     return Err(NetworkFilterError::RemoveparamRegexUnsupported);
                 }
-                NetworkFilterOption::Removeparam(Cow::Borrowed(value))
+                NetworkFilterOption::Removeparam(value)
             }
             ("generichide", true) | ("ghide", true) => {
                 return Err(NetworkFilterError::NegatedGenericHide)

--- a/src/filters/abstract_network.rs
+++ b/src/filters/abstract_network.rs
@@ -95,7 +95,7 @@ impl NetworkFilterOption<'_> {
 pub(crate) struct AbstractNetworkFilter<'a> {
     pub(crate) exception: bool,
     pub(crate) pattern: NetworkFilterPattern,
-    pub(crate) options: Option<Vec<NetworkFilterOption<'a>>>,
+    pub(crate) raw_options: Option<&'a str>,
 }
 
 impl AbstractNetworkFilter<'_> {
@@ -113,14 +113,12 @@ impl AbstractNetworkFilter<'_> {
 
         let maybe_options_index: Option<usize> = find_char_reverse(b'$', line.as_bytes());
 
-        let mut options = None;
+        let raw_options: Option<&'a str>;
         if let Some(options_index) = maybe_options_index {
             filter_index_end = options_index;
-
-            // slicing here is safe; the first byte after '$' will be a character boundary
-            let raw_options = &line[filter_index_end + 1..];
-
-            options = Some(parse_filter_options(raw_options)?);
+            raw_options = Some(&line[filter_index_end + 1..]);
+        } else {
+            raw_options = None;
         }
 
         let left_anchor = if line[filter_index_start..].starts_with("||") {
@@ -151,12 +149,12 @@ impl AbstractNetworkFilter<'_> {
                 end: filter_index_end,
                 right_anchor,
             },
-            options,
+            raw_options,
         })
     }
 }
 
-fn parse_filter_options<'a>(
+pub(crate) fn parse_filter_options<'a>(
     raw_options: &'a str,
 ) -> Result<Vec<NetworkFilterOption<'a>>, NetworkFilterError> {
     let mut result = vec![];

--- a/src/filters/fb_network_builder.rs
+++ b/src/filters/fb_network_builder.rs
@@ -34,28 +34,26 @@ struct NetworkFilterFlatEntry<'a> {
     id: Hash,
 }
 
-pub(crate) struct NetworkFilterListBuilder<'fb, 'filter> {
-    flat_map_builder: FlatMultiMapBuilder<ShortHash, NetworkFilterFlatEntry<'fb>>,
+struct NetworkFilterListBuilder<'a, 'f> {
+    flat_map_builder: FlatMultiMapBuilder<ShortHash, NetworkFilterFlatEntry<'a>>,
     token_frequencies: TokenSelector,
-    filters_to_optimize: HashMap<ShortHash, Vec<NetworkFilter<'filter>>>,
+    filters_to_optimize: HashMap<ShortHash, Vec<NetworkFilter<'f>>>,
     tokens_buffer: TokensBuffer,
     optimize: bool,
 }
 
-pub(crate) struct NetworkRulesBuilder<'fb, 'filter> {
-    lists: Vec<NetworkFilterListBuilder<'fb, 'filter>>,
+pub(crate) struct NetworkRulesBuilder<'a, 'f> {
+    lists: Vec<NetworkFilterListBuilder<'a, 'f>>,
     bad_filter_ids: HashSet<Hash>,
 }
 
-impl<'filter, 'builder> FlatSerialize<'builder, EngineFlatBuilder<'builder>>
-    for NetworkFilter<'filter>
-{
-    type Output = WIPOffset<fb::NetworkFilter<'builder>>;
+impl<'f, 'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for NetworkFilter<'f> {
+    type Output = WIPOffset<fb::NetworkFilter<'a>>;
 
     fn serialize(
-        network_filter: NetworkFilter<'filter>,
-        builder: &mut EngineFlatBuilder<'builder>,
-    ) -> WIPOffset<fb::NetworkFilter<'builder>> {
+        network_filter: NetworkFilter<'f>,
+        builder: &mut EngineFlatBuilder<'a>,
+    ) -> WIPOffset<fb::NetworkFilter<'a>> {
         let opt_domains = network_filter.opt_domains.as_ref().map(|v| {
             let mut o: Vec<u32> = v
                 .iter()
@@ -131,7 +129,7 @@ impl<'filter, 'builder> FlatSerialize<'builder, EngineFlatBuilder<'builder>>
     }
 }
 
-impl<'fb, 'filter> NetworkFilterListBuilder<'fb, 'filter> {
+impl<'a, 'f> NetworkFilterListBuilder<'a, 'f> {
     fn new(optimize: bool) -> Self {
         Self {
             flat_map_builder: FlatMultiMapBuilder::with_capacity(1024),
@@ -144,8 +142,8 @@ impl<'fb, 'filter> NetworkFilterListBuilder<'fb, 'filter> {
 
     fn add_filter(
         &mut self,
-        network_filter: NetworkFilter<'filter>,
-        builder: &mut EngineFlatBuilder<'fb>,
+        network_filter: NetworkFilter<'f>,
+        builder: &mut EngineFlatBuilder<'a>,
     ) {
         let multi_tokens = network_filter.get_tokens(&mut self.tokens_buffer);
         let id = network_filter.get_id();
@@ -192,7 +190,7 @@ impl<'fb, 'filter> NetworkFilterListBuilder<'fb, 'filter> {
     }
 }
 
-impl<'fb, 'filter> NetworkRulesBuilder<'fb, 'filter> {
+impl<'a, 'f> NetworkRulesBuilder<'a, 'f> {
     pub fn new(optimize: bool) -> Self {
         let lists = (0..NetworkFilterListId::Size as usize)
             .map(|list_id| {
@@ -207,11 +205,7 @@ impl<'fb, 'filter> NetworkRulesBuilder<'fb, 'filter> {
         }
     }
 
-    pub fn add_filter(
-        &mut self,
-        filter: NetworkFilter<'filter>,
-        builder: &mut EngineFlatBuilder<'fb>,
-    ) {
+    pub fn add_filter(&mut self, filter: NetworkFilter<'f>, builder: &mut EngineFlatBuilder<'a>) {
         if filter.is_badfilter() {
             // Note: `get_id()` doesn't include BAD_FILTER bit.
             self.bad_filter_ids.insert(filter.get_id());
@@ -248,9 +242,9 @@ impl<'fb, 'filter> NetworkRulesBuilder<'fb, 'filter> {
 
     fn add_filter_internal(
         &mut self,
-        network_filter: NetworkFilter<'filter>,
+        network_filter: NetworkFilter<'f>,
         list_id: NetworkFilterListId,
-        builder: &mut EngineFlatBuilder<'fb>,
+        builder: &mut EngineFlatBuilder<'a>,
     ) {
         self.lists[list_id as usize].add_filter(network_filter, builder);
     }
@@ -267,14 +261,11 @@ impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for NetworkFilterFlatEntry<'a>
     }
 }
 
-impl<'fb, 'filter> FlatSerialize<'fb, EngineFlatBuilder<'fb>>
-    for NetworkRulesBuilder<'fb, 'filter>
-{
-    type Output = WIPOffset<
-        flatbuffers::Vector<'fb, flatbuffers::ForwardsUOffset<fb::NetworkFilterList<'fb>>>,
-    >;
+impl<'a, 'f> FlatSerialize<'a, EngineFlatBuilder<'a>> for NetworkRulesBuilder<'a, 'f> {
+    type Output =
+        WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<fb::NetworkFilterList<'a>>>>;
 
-    fn serialize(value: Self, builder: &mut EngineFlatBuilder<'fb>) -> Self::Output {
+    fn serialize(value: Self, builder: &mut EngineFlatBuilder<'a>) -> Self::Output {
         let mut serialized_lists = vec![];
 
         for mut rule_list in value.lists {

--- a/src/filters/fb_network_builder.rs
+++ b/src/filters/fb_network_builder.rs
@@ -76,18 +76,14 @@ impl<'f, 'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for NetworkFilter<'f> {
 
         let modifier_option = network_filter
             .modifier_option
-            .as_ref()
-            .map(|s| builder.create_string(s.as_ref()));
+            .map(|s| builder.create_string(s));
 
         let hostname = network_filter
             .hostname
             .as_ref()
             .map(|s| builder.create_string(s.as_ref()));
 
-        let tag = network_filter
-            .tag
-            .as_ref()
-            .map(|s| builder.create_string(s.as_ref()));
+        let tag = network_filter.tag.map(|s| builder.create_string(s));
 
         let mut filter_iter = network_filter.filter.iter();
         let filter_count = filter_iter.len();

--- a/src/filters/fb_network_builder.rs
+++ b/src/filters/fb_network_builder.rs
@@ -34,26 +34,28 @@ struct NetworkFilterFlatEntry<'a> {
     id: Hash,
 }
 
-struct NetworkFilterListBuilder<'a> {
-    flat_map_builder: FlatMultiMapBuilder<ShortHash, NetworkFilterFlatEntry<'a>>,
+pub(crate) struct NetworkFilterListBuilder<'fb, 'filter> {
+    flat_map_builder: FlatMultiMapBuilder<ShortHash, NetworkFilterFlatEntry<'fb>>,
     token_frequencies: TokenSelector,
-    filters_to_optimize: HashMap<ShortHash, Vec<NetworkFilter>>,
+    filters_to_optimize: HashMap<ShortHash, Vec<NetworkFilter<'filter>>>,
     tokens_buffer: TokensBuffer,
     optimize: bool,
 }
 
-pub(crate) struct NetworkRulesBuilder<'a> {
-    lists: Vec<NetworkFilterListBuilder<'a>>,
+pub(crate) struct NetworkRulesBuilder<'fb, 'filter> {
+    lists: Vec<NetworkFilterListBuilder<'fb, 'filter>>,
     bad_filter_ids: HashSet<Hash>,
 }
 
-impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for NetworkFilter {
-    type Output = WIPOffset<fb::NetworkFilter<'a>>;
+impl<'filter, 'builder> FlatSerialize<'builder, EngineFlatBuilder<'builder>>
+    for NetworkFilter<'filter>
+{
+    type Output = WIPOffset<fb::NetworkFilter<'builder>>;
 
     fn serialize(
-        network_filter: NetworkFilter,
-        builder: &mut EngineFlatBuilder<'a>,
-    ) -> WIPOffset<fb::NetworkFilter<'a>> {
+        network_filter: NetworkFilter<'filter>,
+        builder: &mut EngineFlatBuilder<'builder>,
+    ) -> WIPOffset<fb::NetworkFilter<'builder>> {
         let opt_domains = network_filter.opt_domains.as_ref().map(|v| {
             let mut o: Vec<u32> = v
                 .iter()
@@ -77,17 +79,17 @@ impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for NetworkFilter {
         let modifier_option = network_filter
             .modifier_option
             .as_ref()
-            .map(|s| builder.create_string(s));
+            .map(|s| builder.create_string(s.as_ref()));
 
         let hostname = network_filter
             .hostname
             .as_ref()
-            .map(|s| builder.create_string(s));
+            .map(|s| builder.create_string(s.as_ref()));
 
         let tag = network_filter
             .tag
             .as_ref()
-            .map(|s| builder.create_string(s));
+            .map(|s| builder.create_string(s.as_ref()));
 
         let mut filter_iter = network_filter.filter.iter();
         let filter_count = filter_iter.len();
@@ -110,7 +112,7 @@ impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for NetworkFilter {
         let raw_line = network_filter
             .raw_line
             .as_ref()
-            .map(|v| builder.create_string(v.as_str()));
+            .map(|v| builder.create_string(v.as_ref()));
 
         fb::NetworkFilter::create(
             builder.raw_builder(),
@@ -129,7 +131,7 @@ impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for NetworkFilter {
     }
 }
 
-impl<'a> NetworkFilterListBuilder<'a> {
+impl<'fb, 'filter> NetworkFilterListBuilder<'fb, 'filter> {
     fn new(optimize: bool) -> Self {
         Self {
             flat_map_builder: FlatMultiMapBuilder::with_capacity(1024),
@@ -140,7 +142,11 @@ impl<'a> NetworkFilterListBuilder<'a> {
         }
     }
 
-    fn add_filter(&mut self, network_filter: NetworkFilter, builder: &mut EngineFlatBuilder<'a>) {
+    fn add_filter(
+        &mut self,
+        network_filter: NetworkFilter<'filter>,
+        builder: &mut EngineFlatBuilder<'fb>,
+    ) {
         let multi_tokens = network_filter.get_tokens(&mut self.tokens_buffer);
         let id = network_filter.get_id();
 
@@ -186,7 +192,7 @@ impl<'a> NetworkFilterListBuilder<'a> {
     }
 }
 
-impl<'a> NetworkRulesBuilder<'a> {
+impl<'fb, 'filter> NetworkRulesBuilder<'fb, 'filter> {
     pub fn new(optimize: bool) -> Self {
         let lists = (0..NetworkFilterListId::Size as usize)
             .map(|list_id| {
@@ -201,7 +207,11 @@ impl<'a> NetworkRulesBuilder<'a> {
         }
     }
 
-    pub fn add_filter(&mut self, filter: NetworkFilter, builder: &mut EngineFlatBuilder<'a>) {
+    pub fn add_filter(
+        &mut self,
+        filter: NetworkFilter<'filter>,
+        builder: &mut EngineFlatBuilder<'fb>,
+    ) {
         if filter.is_badfilter() {
             // Note: `get_id()` doesn't include BAD_FILTER bit.
             self.bad_filter_ids.insert(filter.get_id());
@@ -238,9 +248,9 @@ impl<'a> NetworkRulesBuilder<'a> {
 
     fn add_filter_internal(
         &mut self,
-        network_filter: NetworkFilter,
+        network_filter: NetworkFilter<'filter>,
         list_id: NetworkFilterListId,
-        builder: &mut EngineFlatBuilder<'a>,
+        builder: &mut EngineFlatBuilder<'fb>,
     ) {
         self.lists[list_id as usize].add_filter(network_filter, builder);
     }
@@ -257,11 +267,14 @@ impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for NetworkFilterFlatEntry<'a>
     }
 }
 
-impl<'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for NetworkRulesBuilder<'a> {
-    type Output =
-        WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<fb::NetworkFilterList<'a>>>>;
+impl<'fb, 'filter> FlatSerialize<'fb, EngineFlatBuilder<'fb>>
+    for NetworkRulesBuilder<'fb, 'filter>
+{
+    type Output = WIPOffset<
+        flatbuffers::Vector<'fb, flatbuffers::ForwardsUOffset<fb::NetworkFilterList<'fb>>>,
+    >;
 
-    fn serialize(value: Self, builder: &mut EngineFlatBuilder<'a>) -> Self::Output {
+    fn serialize(value: Self, builder: &mut EngineFlatBuilder<'fb>) -> Self::Output {
         let mut serialized_lists = vec![];
 
         for mut rule_list in value.lists {

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -466,8 +466,7 @@ impl<'a> NetworkFilter<'a> {
             mask.set(NetworkFilterMask::IS_EXCEPTION, true);
         }
 
-        if let Some(raw_options) = parsed.raw_options {
-            let options = crate::filters::abstract_network::parse_filter_options(raw_options)?;
+        if let Some(options) = parsed.options {
             validate_options(&options)?;
 
             macro_rules! apply_content_type {

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -754,6 +754,8 @@ impl<'a> NetworkFilter<'a> {
             None
         };
 
+        // TODO: ignore hostname anchor is not hostname provided
+
         if features_mask.contains(NetworkFilterFeaturesMask::GENERIC_HIDE) && !parsed.exception {
             return Err(NetworkFilterError::GenericHideWithoutException);
         }
@@ -835,13 +837,11 @@ impl<'a> NetworkFilter<'a> {
             | NetworkFilterMask::IS_HOSTNAME_ANCHOR
             | NetworkFilterMask::IS_RIGHT_ANCHOR;
 
-        let id = {
-            let mut rule = String::with_capacity(hostname.len() + 3);
-            rule.push_str("||");
-            rule.push_str(hostname);
-            rule.push('^');
-            utils::fast_hash(&rule)
-        };
+        let mut rule = String::with_capacity(hostname.len() + 3);
+        rule.push_str("||");
+        rule.push_str(hostname);
+        rule.push('^');
+        let id = utils::fast_hash(&rule);
 
         Ok(NetworkFilter {
             filter: FilterPart::Empty,
@@ -851,11 +851,7 @@ impl<'a> NetworkFilter<'a> {
             opt_domains: None,
             opt_not_domains: None,
             tag: None,
-            raw_line: if debug {
-                Some(Cow::Borrowed(hostname))
-            } else {
-                None
-            },
+            raw_line: if debug { Some(Cow::Owned(rule)) } else { None },
             modifier_option: None,
             id,
         })

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -429,13 +429,9 @@ fn cow_ascii_lowercase<'a>(s: &'a str) -> Cow<'a, str> {
     }
 }
 
-fn decode_hostname<'a>(host: &'a str) -> Result<Cow<'a, str>, NetworkFilterError> {
-    let decoded = idna::domain_to_ascii_cow(host.as_bytes(), idna::AsciiDenyList::EMPTY)
-        .map_err(|_| NetworkFilterError::PunycodeError)?;
-    match decoded {
-        Cow::Borrowed(_) => Ok(Cow::Borrowed(host)),
-        Cow::Owned(h) => Ok(Cow::Owned(h)),
-    }
+fn decode_hostname<'a>(host: &'a [u8]) -> Result<Cow<'a, str>, NetworkFilterError> {
+    idna::domain_to_ascii_cow(host, idna::AsciiDenyList::EMPTY)
+        .map_err(|_| NetworkFilterError::PunycodeError)
 }
 
 impl<'a> NetworkFilter<'a> {
@@ -458,7 +454,7 @@ impl<'a> NetworkFilter<'a> {
         let mut cpt_mask_positive: NetworkFilterMask = NetworkFilterMask::NONE;
         let mut cpt_mask_negative: NetworkFilterMask = NetworkFilterMask::NONE;
 
-        let mut hostname: Option<Cow<'a, str>> = None;
+        let mut hostname: Option<&'a [u8]> = None;
 
         let mut opt_domains: Option<Vec<Hash>> = None;
         let mut opt_not_domains: Option<Vec<Hash>> = None;
@@ -665,7 +661,7 @@ impl<'a> NetworkFilter<'a> {
                         mask.set(NetworkFilterMask::IS_HOSTNAME_REGEX, true);
                     }
 
-                    hostname = Some(decode_hostname(&pattern[..first_separator_start])?);
+                    hostname = Some(&pattern.as_bytes()[..first_separator_start]);
                     filter_index_start = first_separator_start;
 
                     // If the only symbol remaining for the selector is '^' then ignore it
@@ -687,14 +683,18 @@ impl<'a> NetworkFilter<'a> {
                 }
             } else {
                 // Look for next /
-                if let Some(i) = find_char(b'/', pattern.as_bytes()) {
-                    hostname = Some(decode_hostname(&pattern[..i])?);
-                    filter_index_start += i;
-                    mask.set(NetworkFilterMask::IS_LEFT_ANCHOR, true);
-                } else {
-                    hostname = Some(decode_hostname(pattern)?);
-                    filter_index_start = filter_index_end;
-                }
+                let slash_index = find_char(b'/', pattern.as_bytes());
+                slash_index
+                    .map(|i| {
+                        hostname = Some(&pattern.as_bytes()[..i]);
+                        filter_index_start += i;
+                        mask.set(NetworkFilterMask::IS_LEFT_ANCHOR, true);
+                    })
+                    .or_else(|| {
+                        hostname = Some(pattern.as_bytes());
+                        filter_index_start = filter_index_end;
+                        None
+                    });
             }
         }
 
@@ -757,6 +757,8 @@ impl<'a> NetworkFilter<'a> {
 
         // TODO: ignore hostname anchor is not hostname provided
 
+        let hostname_decoded = hostname.map(decode_hostname).transpose()?;
+
         if features_mask.contains(NetworkFilterFeaturesMask::GENERIC_HIDE) && !parsed.exception {
             return Err(NetworkFilterError::GenericHideWithoutException);
         }
@@ -793,7 +795,7 @@ impl<'a> NetworkFilter<'a> {
             } else {
                 FilterPart::Empty
             },
-            hostname,
+            hostname: hostname_decoded,
             mask,
             features_mask,
             opt_domains,
@@ -827,7 +829,7 @@ impl<'a> NetworkFilter<'a> {
             return Err(NetworkFilterError::FilterParseError);
         }
 
-        let decoded_hostname = decode_hostname(hostname)?;
+        let decoded_hostname = decode_hostname(hostname.as_bytes())?;
 
         let mask = NetworkFilterMask::THIRD_PARTY
             | NetworkFilterMask::FIRST_PARTY

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -421,38 +421,6 @@ fn validate_options(options: &[NetworkFilterOption<'_>]) -> Result<(), NetworkFi
     Ok(())
 }
 
-impl NetworkFilter<'_> {
-    /// Converts a filter with borrowed fields into an owned filter.
-    #[cfg(test)]
-    pub fn into_owned(self) -> NetworkFilter<'static> {
-        NetworkFilter {
-            mask: self.mask,
-            features_mask: self.features_mask,
-            filter: self.filter.into_owned(),
-            opt_domains: self.opt_domains,
-            opt_not_domains: self.opt_not_domains,
-            modifier_option: self
-                .modifier_option
-                .map(|value| Cow::Owned(value.into_owned())),
-            hostname: self.hostname.map(|value| Cow::Owned(value.into_owned())),
-            tag: self.tag.map(|value| Cow::Owned(value.into_owned())),
-            raw_line: self.raw_line.map(|line| Cow::Owned(line.into_owned())),
-            id: self.id,
-        }
-    }
-}
-
-impl FilterPart<'_> {
-    #[cfg(test)]
-    fn into_owned(self) -> FilterPart<'static> {
-        match self {
-            FilterPart::Empty => FilterPart::Empty,
-            FilterPart::Simple(s) => FilterPart::Simple(Cow::Owned(s.into_owned())),
-            FilterPart::AnyOf(parts) => FilterPart::AnyOf(parts),
-        }
-    }
-}
-
 fn cow_ascii_lowercase<'a>(s: &'a str) -> Cow<'a, str> {
     if s.as_bytes().iter().any(|byte| byte.is_ascii_uppercase()) {
         Cow::Owned(s.to_ascii_lowercase())

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -369,9 +369,9 @@ pub struct NetworkFilter<'a> {
     pub opt_not_domains: Option<Vec<Hash>>,
     /// Used for `$redirect`, `$redirect-rule`, `$csp`, and `$removeparam` - only one of which is
     /// supported per-rule.
-    pub modifier_option: Option<Cow<'a, str>>,
+    pub modifier_option: Option<&'a str>,
     pub hostname: Option<Cow<'a, str>>,
-    pub(crate) tag: Option<Cow<'a, str>>,
+    pub(crate) tag: Option<&'a str>,
 
     pub raw_line: Option<Cow<'a, str>>,
 
@@ -459,8 +459,8 @@ impl<'a> NetworkFilter<'a> {
         let mut opt_domains: Option<Vec<Hash>> = None;
         let mut opt_not_domains: Option<Vec<Hash>> = None;
 
-        let mut modifier_option: Option<Cow<'a, str>> = None;
-        let mut tag: Option<Cow<'a, str>> = None;
+        let mut modifier_option: Option<&'a str> = None;
+        let mut tag: Option<&'a str> = None;
 
         if parsed.exception {
             mask.set(NetworkFilterMask::IS_EXCEPTION, true);
@@ -486,7 +486,7 @@ impl<'a> NetworkFilter<'a> {
                         let mut opt_not_domains_array: Vec<Hash> = vec![];
 
                         for (enabled, domain) in domains {
-                            let domain_hash = utils::fast_hash(domain.as_ref());
+                            let domain_hash = utils::fast_hash(domain);
                             if !enabled {
                                 opt_not_domains_array.push(domain_hash);
                             } else {
@@ -861,7 +861,7 @@ impl<'a> NetworkFilter<'a> {
 
     pub fn get_id(&self) -> Hash {
         compute_filter_id(
-            self.modifier_option.as_deref(),
+            self.modifier_option,
             self.mask,
             self.features_mask,
             self.filter.string_view().as_deref(),

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -470,7 +470,8 @@ impl<'a> NetworkFilter<'a> {
             mask.set(NetworkFilterMask::IS_EXCEPTION, true);
         }
 
-        if let Some(options) = parsed.options {
+        if let Some(raw_options) = parsed.raw_options {
+            let options = crate::filters::abstract_network::parse_filter_options(raw_options)?;
             validate_options(&options)?;
 
             macro_rules! apply_content_type {

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -282,9 +282,9 @@ impl From<&request::RequestType> for NetworkFilterMask {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum FilterPart {
+pub enum FilterPart<'a> {
     Empty,
-    Simple(String),
+    Simple(Cow<'a, str>),
     AnyOf(Vec<String>),
 }
 
@@ -296,7 +296,7 @@ pub(crate) enum FilterTokens {
 }
 
 pub struct FilterPartIterator<'a> {
-    filter_part: &'a FilterPart,
+    filter_part: &'a FilterPart<'a>,
     index: usize,
 }
 
@@ -309,14 +309,14 @@ impl<'a> Iterator for FilterPartIterator<'a> {
             FilterPart::Simple(s) => {
                 if self.index == 0 {
                     self.index += 1;
-                    Some(s.as_str())
+                    Some(s.as_ref())
                 } else {
                     None
                 }
             }
             FilterPart::AnyOf(vec) => {
                 if self.index < vec.len() {
-                    let result = Some(vec[self.index].as_str());
+                    let result = Some(vec[self.index].as_ref());
                     self.index += 1;
                     result
                 } else {
@@ -338,12 +338,17 @@ impl ExactSizeIterator for FilterPartIterator<'_> {
     }
 }
 
-impl FilterPart {
+impl FilterPart<'_> {
     pub fn string_view(&self) -> Option<String> {
         match &self {
             FilterPart::Empty => None,
-            FilterPart::Simple(s) => Some(s.clone()),
-            FilterPart::AnyOf(s) => Some(s.join("|")),
+            FilterPart::Simple(s) => Some(s.to_string()),
+            FilterPart::AnyOf(s) => Some(
+                s.iter()
+                    .map(|part| part.as_ref())
+                    .collect::<Vec<_>>()
+                    .join("|"),
+            ),
         }
     }
 
@@ -356,19 +361,19 @@ impl FilterPart {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NetworkFilter {
+pub struct NetworkFilter<'a> {
     pub mask: NetworkFilterMask,
     pub features_mask: NetworkFilterFeaturesMask,
-    pub filter: FilterPart,
+    pub filter: FilterPart<'a>,
     pub opt_domains: Option<Vec<Hash>>,
     pub opt_not_domains: Option<Vec<Hash>>,
     /// Used for `$redirect`, `$redirect-rule`, `$csp`, and `$removeparam` - only one of which is
     /// supported per-rule.
-    pub modifier_option: Option<String>,
-    pub hostname: Option<String>,
-    pub(crate) tag: Option<String>,
+    pub modifier_option: Option<Cow<'a, str>>,
+    pub hostname: Option<Cow<'a, str>>,
+    pub(crate) tag: Option<Cow<'a, str>>,
 
-    pub raw_line: Option<Box<String>>,
+    pub raw_line: Option<Cow<'a, str>>,
 
     pub id: Hash,
 }
@@ -377,21 +382,21 @@ pub struct NetworkFilter {
 // prevent field access, and don't load the ID from the serialized format.
 /// The ID of a filter is assumed to be correctly calculated for the purposes of this
 /// implementation.
-impl PartialEq for NetworkFilter {
+impl PartialEq for NetworkFilter<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
     }
 }
 
 /// Filters are sorted by ID to preserve a stable ordering of data in the serialized format.
-impl PartialOrd for NetworkFilter {
+impl PartialOrd for NetworkFilter<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.id.partial_cmp(&other.id)
     }
 }
 
 /// Ensure that no invalid option combinations were provided for a filter.
-fn validate_options(options: &[NetworkFilterOption]) -> Result<(), NetworkFilterError> {
+fn validate_options(options: &[NetworkFilterOption<'_>]) -> Result<(), NetworkFilterError> {
     let mut has_csp = false;
     let mut has_content_type = false;
     let mut modifier_options = 0;
@@ -416,8 +421,61 @@ fn validate_options(options: &[NetworkFilterOption]) -> Result<(), NetworkFilter
     Ok(())
 }
 
-impl NetworkFilter {
-    pub fn parse(line: &str, debug: bool, _opts: ParseOptions) -> Result<Self, NetworkFilterError> {
+impl NetworkFilter<'_> {
+    /// Converts a filter with borrowed fields into an owned filter.
+    #[cfg(test)]
+    pub fn into_owned(self) -> NetworkFilter<'static> {
+        NetworkFilter {
+            mask: self.mask,
+            features_mask: self.features_mask,
+            filter: self.filter.into_owned(),
+            opt_domains: self.opt_domains,
+            opt_not_domains: self.opt_not_domains,
+            modifier_option: self
+                .modifier_option
+                .map(|value| Cow::Owned(value.into_owned())),
+            hostname: self.hostname.map(|value| Cow::Owned(value.into_owned())),
+            tag: self.tag.map(|value| Cow::Owned(value.into_owned())),
+            raw_line: self.raw_line.map(|line| Cow::Owned(line.into_owned())),
+            id: self.id,
+        }
+    }
+}
+
+impl FilterPart<'_> {
+    #[cfg(test)]
+    fn into_owned(self) -> FilterPart<'static> {
+        match self {
+            FilterPart::Empty => FilterPart::Empty,
+            FilterPart::Simple(s) => FilterPart::Simple(Cow::Owned(s.into_owned())),
+            FilterPart::AnyOf(parts) => FilterPart::AnyOf(parts),
+        }
+    }
+}
+
+fn cow_ascii_lowercase<'a>(s: &'a str) -> Cow<'a, str> {
+    if s.as_bytes().iter().any(|byte| byte.is_ascii_uppercase()) {
+        Cow::Owned(s.to_ascii_lowercase())
+    } else {
+        Cow::Borrowed(s)
+    }
+}
+
+fn decode_hostname<'a>(host: &'a str) -> Result<Cow<'a, str>, NetworkFilterError> {
+    let decoded = idna::domain_to_ascii_cow(host.as_bytes(), idna::AsciiDenyList::EMPTY)
+        .map_err(|_| NetworkFilterError::PunycodeError)?;
+    match decoded {
+        Cow::Borrowed(_) => Ok(Cow::Borrowed(host)),
+        Cow::Owned(h) => Ok(Cow::Owned(h)),
+    }
+}
+
+impl<'a> NetworkFilter<'a> {
+    pub fn parse(
+        line: &'a str,
+        debug: bool,
+        _opts: ParseOptions,
+    ) -> Result<Self, NetworkFilterError> {
         let parsed = AbstractNetworkFilter::parse(line)?;
 
         // Represent options as a bitmask
@@ -432,13 +490,13 @@ impl NetworkFilter {
         let mut cpt_mask_positive: NetworkFilterMask = NetworkFilterMask::NONE;
         let mut cpt_mask_negative: NetworkFilterMask = NetworkFilterMask::NONE;
 
-        let mut hostname: Option<String> = None;
+        let mut hostname: Option<Cow<'a, str>> = None;
 
         let mut opt_domains: Option<Vec<Hash>> = None;
         let mut opt_not_domains: Option<Vec<Hash>> = None;
 
-        let mut modifier_option: Option<String> = None;
-        let mut tag: Option<String> = None;
+        let mut modifier_option: Option<Cow<'a, str>> = None;
+        let mut tag: Option<Cow<'a, str>> = None;
 
         if parsed.exception {
             mask.set(NetworkFilterMask::IS_EXCEPTION, true);
@@ -464,7 +522,7 @@ impl NetworkFilter {
                         let mut opt_not_domains_array: Vec<Hash> = vec![];
 
                         for (enabled, domain) in domains {
-                            let domain_hash = utils::fast_hash(&domain);
+                            let domain_hash = utils::fast_hash(domain.as_ref());
                             if !enabled {
                                 opt_not_domains_array.push(domain_hash);
                             } else {
@@ -597,7 +655,7 @@ impl NetworkFilter {
             end_url_anchor = true;
         }
 
-        let pattern = &parsed.pattern.pattern;
+        let pattern = &line[parsed.pattern.start..parsed.pattern.end];
 
         let is_regex = check_is_regex(pattern);
         mask.set(NetworkFilterMask::IS_REGEX, is_regex);
@@ -638,7 +696,7 @@ impl NetworkFilter {
                         mask.set(NetworkFilterMask::IS_HOSTNAME_REGEX, true);
                     }
 
-                    hostname = Some(String::from(&pattern[..first_separator_start]));
+                    hostname = Some(decode_hostname(&pattern[..first_separator_start])?);
                     filter_index_start = first_separator_start;
 
                     // If the only symbol remaining for the selector is '^' then ignore it
@@ -660,18 +718,14 @@ impl NetworkFilter {
                 }
             } else {
                 // Look for next /
-                let slash_index = find_char(b'/', pattern.as_bytes());
-                slash_index
-                    .map(|i| {
-                        hostname = Some(String::from(&pattern[..i]));
-                        filter_index_start += i;
-                        mask.set(NetworkFilterMask::IS_LEFT_ANCHOR, true);
-                    })
-                    .or_else(|| {
-                        hostname = Some(String::from(pattern));
-                        filter_index_start = filter_index_end;
-                        None
-                    });
+                if let Some(i) = find_char(b'/', pattern.as_bytes()) {
+                    hostname = Some(decode_hostname(&pattern[..i])?);
+                    filter_index_start += i;
+                    mask.set(NetworkFilterMask::IS_LEFT_ANCHOR, true);
+                } else {
+                    hostname = Some(decode_hostname(pattern)?);
+                    filter_index_start = filter_index_end;
+                }
             }
         }
 
@@ -720,31 +774,17 @@ impl NetworkFilter {
             }
         }
 
-        let filter: Option<String> = if filter_index_end > filter_index_start {
+        let filter = if filter_index_end > filter_index_start {
             let filter_str = &pattern[filter_index_start..filter_index_end];
             mask.set(NetworkFilterMask::IS_REGEX, check_is_regex(filter_str));
             if mask.contains(NetworkFilterMask::MATCH_CASE) {
-                Some(String::from(filter_str))
+                Some(Cow::Borrowed(filter_str))
             } else {
-                Some(filter_str.to_ascii_lowercase())
+                Some(cow_ascii_lowercase(filter_str))
             }
         } else {
             None
         };
-
-        // TODO: ignore hostname anchor is not hostname provided
-
-        let hostname_decoded = hostname
-            .map(|host| {
-                let hostname =
-                    idna::domain_to_ascii_cow(host.as_bytes(), idna::AsciiDenyList::EMPTY)
-                        .map_err(|_| NetworkFilterError::PunycodeError)?;
-                match hostname {
-                    Cow::Borrowed(_) => Ok(host),
-                    Cow::Owned(h) => Ok(h.to_string()),
-                }
-            })
-            .transpose();
 
         if features_mask.contains(NetworkFilterFeaturesMask::GENERIC_HIDE) && !parsed.exception {
             return Err(NetworkFilterError::GenericHideWithoutException);
@@ -782,14 +822,14 @@ impl NetworkFilter {
             } else {
                 FilterPart::Empty
             },
-            hostname: hostname_decoded?,
+            hostname,
             mask,
             features_mask,
             opt_domains,
             opt_not_domains,
             tag,
             raw_line: if debug {
-                Some(Box::new(String::from(line)))
+                Some(Cow::Borrowed(line))
             } else {
                 None
             },
@@ -800,7 +840,7 @@ impl NetworkFilter {
 
     /// Given a hostname, produces an equivalent filter parsed from the form `"||hostname^"`, to
     /// emulate the behavior of hosts-style blocking.
-    pub fn parse_hosts_style(hostname: &str, debug: bool) -> Result<Self, NetworkFilterError> {
+    pub fn parse_hosts_style(hostname: &'a str, debug: bool) -> Result<Self, NetworkFilterError> {
         // Make sure the hostname doesn't contain any invalid characters
         static INVALID_CHARS: LazyLock<Regex> =
             LazyLock::new(|| Regex::new("[/^*!?$&(){}\\[\\]+=~`\\s|@,'\"><:;]").unwrap());
@@ -816,9 +856,41 @@ impl NetworkFilter {
             return Err(NetworkFilterError::FilterParseError);
         }
 
-        // Parse it as a `||hostname^` rule.
-        let rule = format!("||{hostname}^");
-        NetworkFilter::parse(&rule, debug, Default::default())
+        let decoded_hostname = decode_hostname(hostname)?;
+
+        let mask = NetworkFilterMask::THIRD_PARTY
+            | NetworkFilterMask::FIRST_PARTY
+            | NetworkFilterMask::FROM_HTTPS
+            | NetworkFilterMask::FROM_HTTP
+            | NetworkFilterMask::FROM_NETWORK_TYPES
+            | NetworkFilterMask::FROM_ALL_TYPES
+            | NetworkFilterMask::IS_HOSTNAME_ANCHOR
+            | NetworkFilterMask::IS_RIGHT_ANCHOR;
+
+        let id = {
+            let mut rule = String::with_capacity(hostname.len() + 3);
+            rule.push_str("||");
+            rule.push_str(hostname);
+            rule.push('^');
+            utils::fast_hash(&rule)
+        };
+
+        Ok(NetworkFilter {
+            filter: FilterPart::Empty,
+            hostname: Some(decoded_hostname),
+            mask,
+            features_mask: Default::default(),
+            opt_domains: None,
+            opt_not_domains: None,
+            tag: None,
+            raw_line: if debug {
+                Some(Cow::Borrowed(hostname))
+            } else {
+                None
+            },
+            modifier_option: None,
+            id,
+        })
     }
 
     pub fn get_id(&self) -> Hash {
@@ -859,7 +931,12 @@ impl NetworkFilter {
                     (self.is_plain() || self.is_regex()) && !self.is_right_anchor();
                 let skip_first_token = self.is_right_anchor();
 
-                utils::tokenize_filter_to(f, skip_first_token, skip_last_token, tokens_buffer);
+                utils::tokenize_filter_to(
+                    f.as_ref(),
+                    skip_first_token,
+                    skip_last_token,
+                    tokens_buffer,
+                );
             }
             FilterPart::AnyOf(_) => (), // across AnyOf set of filters no single token is guaranteed to match to a request
             _ => (),
@@ -868,13 +945,13 @@ impl NetworkFilter {
         // Append tokens from hostname, if any
         if !self.mask.contains(NetworkFilterMask::IS_HOSTNAME_REGEX) {
             if let Some(hostname) = self.hostname.as_ref() {
-                utils::tokenize_to(hostname, tokens_buffer);
+                utils::tokenize_to(hostname.as_ref(), tokens_buffer);
             }
         } else if let Some(hostname) = self.hostname.as_ref() {
             // Find last dot to tokenize the prefix
             let last_dot_pos = hostname.rfind('.');
             if let Some(last_dot_pos) = last_dot_pos {
-                utils::tokenize_to(&hostname[..last_dot_pos], tokens_buffer);
+                utils::tokenize_to(&hostname.as_ref()[..last_dot_pos], tokens_buffer);
             }
         }
 
@@ -884,7 +961,7 @@ impl NetworkFilter {
                 .contains(NetworkFilterFeaturesMask::IS_REMOVEPARAM)
         {
             if let Some(removeparam) = &self.modifier_option {
-                if VALID_PARAM.is_match(removeparam) {
+                if VALID_PARAM.is_match(removeparam.as_ref()) {
                     utils::tokenize_to(&removeparam.to_ascii_lowercase(), tokens_buffer);
                 }
             }
@@ -959,16 +1036,16 @@ impl NetworkFilter {
     }
 }
 
-impl NetworkFilterMaskHelper for NetworkFilter {
+impl NetworkFilterMaskHelper for NetworkFilter<'_> {
     fn has_flag(&self, v: NetworkFilterMask) -> bool {
         self.mask.contains(v)
     }
 }
 
-impl fmt::Display for NetworkFilter {
+impl fmt::Display for NetworkFilter<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match self.raw_line.as_ref() {
-            Some(r) => write!(f, "{}", r.clone()),
+        match self.raw_line.as_deref() {
+            Some(r) => write!(f, "{r}"),
             None => write!(f, "NetworkFilter"),
         }
     }

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -512,14 +512,11 @@ pub fn parse_filter<'a>(
 }
 
 /// Parse an entire list of filters, ignoring any errors
-pub fn parse_filters<'a, I>(
-    list: I,
+pub fn parse_filters<'a>(
+    list: impl IntoIterator<Item = &'a str>,
     debug: bool,
     opts: ParseOptions,
-) -> (Vec<NetworkFilter<'a>>, Vec<CosmeticFilter>)
-where
-    I: IntoIterator<Item = &'a str>,
-{
+) -> (Vec<NetworkFilter<'a>>, Vec<CosmeticFilter>) {
     let (network_filters, cosmetic_filters): (Vec<_>, Vec<_>) = list
         .into_iter()
         .filter_map(|line| match parse_filter(line, debug, opts) {

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -271,78 +271,80 @@ impl FilterSet {
         use crate::content_blocking;
         use std::collections::HashSet;
 
-        if !self.debug {
+        let FilterSet {
+            debug,
+            list_sources,
+        } = self;
+
+        if !debug {
             return Err(());
         }
 
+        let mut network_filters = vec![];
+        let mut cosmetic_filters = vec![];
+        for list_source in list_sources.iter() {
+            let list_text = list_source.list_text.lines();
+            let parse_options = list_source.parse_options;
+            let (list_network_filters, list_cosmetic_filters) =
+                parse_filters(list_text, debug, parse_options);
+            network_filters.extend(list_network_filters);
+            cosmetic_filters.extend(list_cosmetic_filters);
+        }
+
+        // Store bad filter id to skip them later.
         let mut bad_filter_ids = HashSet::new();
-        for list_source in self.list_sources.iter() {
-            let (network_filters, _) = parse_filters(
-                list_source.list_text.lines(),
-                self.debug,
-                list_source.parse_options,
-            );
-            for filter in network_filters.iter() {
-                if filter.is_badfilter() {
-                    bad_filter_ids.insert(filter.get_id());
-                }
+        for filter in network_filters.iter() {
+            if filter.is_badfilter() {
+                bad_filter_ids.insert(filter.get_id());
             }
         }
 
         let mut ignore_previous_rules = vec![];
         let mut other_rules = vec![];
+
         let mut filters_used = vec![];
 
-        for list_source in self.list_sources.iter() {
-            let (network_filters, cosmetic_filters) = parse_filters(
-                list_source.list_text.lines(),
-                self.debug,
-                list_source.parse_options,
-            );
-
-            network_filters.into_iter().for_each(|filter| {
-                // Don't process bad filter rules or matching bad filter rules.
-                if bad_filter_ids.contains(&filter.get_id()) || filter.is_badfilter() {
-                    return;
-                }
-                let original_rule = filter
-                    .raw_line
-                    .as_ref()
-                    .expect("All rules should be in debug mode")
-                    .to_string();
-                if let Ok(equivalent) =
-                    TryInto::<content_blocking::CbRuleEquivalent>::try_into(filter)
-                {
-                    filters_used.push(original_rule);
-                    equivalent
-                        .into_iter()
-                        .for_each(|cb_rule| match &cb_rule.action.typ {
-                            content_blocking::CbType::IgnorePreviousRules => {
-                                ignore_previous_rules.push(cb_rule)
-                            }
-                            _ => other_rules.push(cb_rule),
-                        });
-                }
-            });
-
-            cosmetic_filters.into_iter().for_each(|filter| {
-                let original_rule = *filter
-                    .raw_line
-                    .clone()
-                    .expect("All rules should be in debug mode");
-                if let Ok(cb_rule) = TryInto::<content_blocking::CbRule>::try_into(filter) {
-                    filters_used.push(original_rule);
-                    match &cb_rule.action.typ {
+        network_filters.into_iter().for_each(|filter| {
+            // Don't process bad filter rules or matching bad filter rules.
+            if bad_filter_ids.contains(&filter.get_id()) || filter.is_badfilter() {
+                return;
+            }
+            let original_rule = filter
+                .raw_line
+                .as_ref()
+                .expect("All rules should be in debug mode")
+                .to_string();
+            if let Ok(equivalent) = TryInto::<content_blocking::CbRuleEquivalent>::try_into(filter)
+            {
+                filters_used.push(original_rule);
+                equivalent
+                    .into_iter()
+                    .for_each(|cb_rule| match &cb_rule.action.typ {
                         content_blocking::CbType::IgnorePreviousRules => {
                             ignore_previous_rules.push(cb_rule)
                         }
                         _ => other_rules.push(cb_rule),
-                    }
-                }
-            });
-        }
+                    });
+            }
+        });
 
         let add_fp_document_exception = !filters_used.is_empty();
+
+        cosmetic_filters.into_iter().for_each(|filter| {
+            let original_rule = *filter
+                .raw_line
+                .clone()
+                .expect("All rules should be in debug mode");
+            if let Ok(cb_rule) = TryInto::<content_blocking::CbRule>::try_into(filter) {
+                filters_used.push(original_rule);
+                match &cb_rule.action.typ {
+                    content_blocking::CbType::IgnorePreviousRules => {
+                        ignore_previous_rules.push(cb_rule)
+                    }
+                    _ => other_rules.push(cb_rule),
+                }
+            }
+        });
 
         other_rules.extend(ignore_previous_rules);
 

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -275,70 +275,74 @@ impl FilterSet {
             return Err(());
         }
 
-        let mut network_filters = vec![];
-        let mut cosmetic_filters = vec![];
-        for list_source in self.list_sources.iter() {
-            let list_text = list_source.list_text.lines();
-            let parse_options = list_source.parse_options;
-            let (list_network_filters, list_cosmetic_filters) =
-                parse_filters(list_text, self.debug, parse_options);
-            network_filters.extend(list_network_filters);
-            cosmetic_filters.extend(list_cosmetic_filters);
-        }
-
-        // Store bad filter id to skip them later.
         let mut bad_filter_ids = HashSet::new();
-        for filter in network_filters.iter() {
-            if filter.is_badfilter() {
-                bad_filter_ids.insert(filter.get_id());
+        for list_source in self.list_sources.iter() {
+            let (network_filters, _) = parse_filters(
+                list_source.list_text.lines(),
+                self.debug,
+                list_source.parse_options,
+            );
+            for filter in network_filters.iter() {
+                if filter.is_badfilter() {
+                    bad_filter_ids.insert(filter.get_id());
+                }
             }
         }
 
         let mut ignore_previous_rules = vec![];
         let mut other_rules = vec![];
-
         let mut filters_used = vec![];
 
-        network_filters.into_iter().for_each(|filter| {
-            // Don't process bad filter rules or matching bad filter rules.
-            if bad_filter_ids.contains(&filter.get_id()) || filter.is_badfilter() {
-                return;
-            }
-            let original_rule = *filter
-                .raw_line
-                .clone()
-                .expect("All rules should be in debug mode");
-            if let Ok(equivalent) = TryInto::<content_blocking::CbRuleEquivalent>::try_into(filter)
-            {
-                filters_used.push(original_rule);
-                equivalent
-                    .into_iter()
-                    .for_each(|cb_rule| match &cb_rule.action.typ {
+        for list_source in self.list_sources.iter() {
+            let (network_filters, cosmetic_filters) = parse_filters(
+                list_source.list_text.lines(),
+                self.debug,
+                list_source.parse_options,
+            );
+
+            network_filters.into_iter().for_each(|filter| {
+                // Don't process bad filter rules or matching bad filter rules.
+                if bad_filter_ids.contains(&filter.get_id()) || filter.is_badfilter() {
+                    return;
+                }
+                let original_rule = filter
+                    .raw_line
+                    .as_ref()
+                    .expect("All rules should be in debug mode")
+                    .to_string();
+                if let Ok(equivalent) =
+                    TryInto::<content_blocking::CbRuleEquivalent>::try_into(filter)
+                {
+                    filters_used.push(original_rule);
+                    equivalent
+                        .into_iter()
+                        .for_each(|cb_rule| match &cb_rule.action.typ {
+                            content_blocking::CbType::IgnorePreviousRules => {
+                                ignore_previous_rules.push(cb_rule)
+                            }
+                            _ => other_rules.push(cb_rule),
+                        });
+                }
+            });
+
+            cosmetic_filters.into_iter().for_each(|filter| {
+                let original_rule = *filter
+                    .raw_line
+                    .clone()
+                    .expect("All rules should be in debug mode");
+                if let Ok(cb_rule) = TryInto::<content_blocking::CbRule>::try_into(filter) {
+                    filters_used.push(original_rule);
+                    match &cb_rule.action.typ {
                         content_blocking::CbType::IgnorePreviousRules => {
                             ignore_previous_rules.push(cb_rule)
                         }
                         _ => other_rules.push(cb_rule),
-                    });
-            }
-        });
+                    }
+                }
+            });
+        }
 
         let add_fp_document_exception = !filters_used.is_empty();
-
-        cosmetic_filters.into_iter().for_each(|filter| {
-            let original_rule = *filter
-                .raw_line
-                .clone()
-                .expect("All rules should be in debug mode");
-            if let Ok(cb_rule) = TryInto::<content_blocking::CbRule>::try_into(filter) {
-                filters_used.push(original_rule);
-                match &cb_rule.action.typ {
-                    content_blocking::CbType::IgnorePreviousRules => {
-                        ignore_previous_rules.push(cb_rule)
-                    }
-                    _ => other_rules.push(cb_rule),
-                }
-            }
-        });
 
         other_rules.extend(ignore_previous_rules);
 
@@ -387,18 +391,18 @@ pub enum FilterType {
 }
 
 /// Successful result of parsing a single line from a filter list
-pub enum ParsedLine {
-    Network(NetworkFilter),
+pub enum ParsedLine<'a> {
+    Network(NetworkFilter<'a>),
     Cosmetic(CosmeticFilter),
 }
 
-impl From<NetworkFilter> for ParsedLine {
-    fn from(v: NetworkFilter) -> Self {
+impl From<NetworkFilter<'static>> for ParsedLine<'static> {
+    fn from(v: NetworkFilter<'static>) -> Self {
         ParsedLine::Network(v)
     }
 }
 
-impl From<CosmeticFilter> for ParsedLine {
+impl From<CosmeticFilter> for ParsedLine<'static> {
     fn from(v: CosmeticFilter) -> Self {
         ParsedLine::Cosmetic(v)
     }
@@ -432,11 +436,11 @@ impl From<CosmeticFilterError> for FilterParseError {
 }
 
 /// Parse a single line from a filter list
-pub fn parse_filter(
-    line: &str,
+pub fn parse_filter<'a>(
+    line: &'a str,
     debug: bool,
     opts: ParseOptions,
-) -> Result<ParsedLine, FilterParseError> {
+) -> Result<ParsedLine<'a>, FilterParseError> {
     let filter = line.trim();
 
     if filter.is_empty() {
@@ -447,12 +451,12 @@ pub fn parse_filter(
         FilterFormat::Standard => match (detect_filter_type(filter), opts.rule_types) {
             (FilterType::Network, RuleTypes::All | RuleTypes::NetworkOnly) => {
                 NetworkFilter::parse(filter, debug, opts)
-                    .map(|f| f.into())
+                    .map(ParsedLine::Network)
                     .map_err(|e| e.into())
             }
             (FilterType::Cosmetic, RuleTypes::All | RuleTypes::CosmeticOnly) => {
                 CosmeticFilter::parse(filter, debug, opts.permissions)
-                    .map(|f| f.into())
+                    .map(ParsedLine::Cosmetic)
                     .map_err(|e| e.into())
             }
             _ => Err(FilterParseError::Unsupported),
@@ -501,21 +505,24 @@ pub fn parse_filter(
             }
 
             NetworkFilter::parse_hosts_style(hostname, debug)
-                .map(|f| f.into())
+                .map(ParsedLine::Network)
                 .map_err(|e| e.into())
         }
     }
 }
 
 /// Parse an entire list of filters, ignoring any errors
-pub fn parse_filters(
-    list: impl IntoIterator<Item = impl AsRef<str>>,
+pub fn parse_filters<'a, I>(
+    list: I,
     debug: bool,
     opts: ParseOptions,
-) -> (Vec<NetworkFilter>, Vec<CosmeticFilter>) {
+) -> (Vec<NetworkFilter<'a>>, Vec<CosmeticFilter>)
+where
+    I: IntoIterator<Item = &'a str>,
+{
     let (network_filters, cosmetic_filters): (Vec<_>, Vec<_>) = list
         .into_iter()
-        .filter_map(|line| match parse_filter(line.as_ref(), debug, opts) {
+        .filter_map(|line| match parse_filter(line, debug, opts) {
             Ok(ParsedLine::Network(f)) => Some(Either::Left(f)),
             Ok(ParsedLine::Cosmetic(f)) => Some(Either::Right(f)),
             _ => None,

--- a/src/network_filter_list.rs
+++ b/src/network_filter_list.rs
@@ -26,7 +26,7 @@ impl From<&NetworkFilter<'_>> for CheckResult {
     fn from(filter: &NetworkFilter) -> Self {
         Self {
             filter_mask: filter.mask,
-            modifier_option: filter.modifier_option.as_ref().map(|s| s.to_string()),
+            modifier_option: filter.modifier_option.map(|s| s.to_string()),
             raw_line: filter.raw_line.as_ref().map(|line| line.to_string()),
         }
     }

--- a/src/network_filter_list.rs
+++ b/src/network_filter_list.rs
@@ -22,12 +22,12 @@ pub struct CheckResult {
     pub raw_line: Option<String>,
 }
 
-impl From<&NetworkFilter> for CheckResult {
+impl From<&NetworkFilter<'_>> for CheckResult {
     fn from(filter: &NetworkFilter) -> Self {
         Self {
             filter_mask: filter.mask,
-            modifier_option: filter.modifier_option.clone(),
-            raw_line: filter.raw_line.clone().map(|v| *v),
+            modifier_option: filter.modifier_option.as_ref().map(|s| s.to_string()),
+            raw_line: filter.raw_line.as_ref().map(|line| line.to_string()),
         }
     }
 }

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -2,15 +2,16 @@ use crate::filters::network::{
     FilterPart, NetworkFilter, NetworkFilterMask, NetworkFilterMaskHelper,
 };
 use itertools::*;
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 trait Optimization {
-    fn fusion(&self, filters: &[NetworkFilter]) -> NetworkFilter;
-    fn group_by_criteria(&self, filter: &NetworkFilter) -> String;
-    fn select(&self, filter: &NetworkFilter) -> bool;
+    fn fusion<'a>(&self, filters: &[NetworkFilter<'a>]) -> NetworkFilter<'a>;
+    fn group_by_criteria(&self, filter: &NetworkFilter<'_>) -> String;
+    fn select(&self, filter: &NetworkFilter<'_>) -> bool;
 }
 
-pub fn is_filter_optimizable_by_patterns(filter: &NetworkFilter) -> bool {
+pub fn is_filter_optimizable_by_patterns(filter: &NetworkFilter<'_>) -> bool {
     filter.opt_domains.is_none()
         && filter.opt_not_domains.is_none()
         && !filter.is_hostname_anchor()
@@ -19,8 +20,8 @@ pub fn is_filter_optimizable_by_patterns(filter: &NetworkFilter) -> bool {
 }
 
 /// Fuse `NetworkFilter`s together by applying optimizations sequentially.
-pub fn optimize(filters: Vec<NetworkFilter>) -> Vec<NetworkFilter> {
-    let mut optimized: Vec<NetworkFilter> = Vec::new();
+pub fn optimize<'a>(filters: Vec<NetworkFilter<'a>>) -> Vec<NetworkFilter<'a>> {
+    let mut optimized: Vec<NetworkFilter<'a>> = Vec::new();
 
     /*
     let union_domain_group = UnionDomainGroup {};
@@ -40,11 +41,11 @@ pub fn optimize(filters: Vec<NetworkFilter>) -> Vec<NetworkFilter> {
     optimized
 }
 
-fn apply_optimisation<T: Optimization>(
+fn apply_optimisation<'a, T: Optimization>(
     optimization: &T,
-    filters: Vec<NetworkFilter>,
-) -> (Vec<NetworkFilter>, Vec<NetworkFilter>) {
-    let (positive, mut negative): (Vec<NetworkFilter>, Vec<NetworkFilter>) =
+    filters: Vec<NetworkFilter<'a>>,
+) -> (Vec<NetworkFilter<'a>>, Vec<NetworkFilter<'a>>) {
+    let (positive, mut negative): (Vec<NetworkFilter<'a>>, Vec<NetworkFilter<'a>>) =
         filters.into_iter().partition_map(|f| {
             if optimization.select(&f) {
                 Either::Left(f)
@@ -53,7 +54,8 @@ fn apply_optimisation<T: Optimization>(
             }
         });
 
-    let mut to_fuse: HashMap<String, Vec<NetworkFilter>> = HashMap::with_capacity(positive.len());
+    let mut to_fuse: HashMap<String, Vec<NetworkFilter<'a>>> =
+        HashMap::with_capacity(positive.len());
     positive
         .into_iter()
         .for_each(|f| insert_dup(&mut to_fuse, optimization.group_by_criteria(&f), f));
@@ -85,7 +87,7 @@ struct SimplePatternGroup {}
 impl Optimization for SimplePatternGroup {
     // Group simple patterns, into a single filter
 
-    fn fusion(&self, filters: &[NetworkFilter]) -> NetworkFilter {
+    fn fusion<'a>(&self, filters: &[NetworkFilter<'a>]) -> NetworkFilter<'a> {
         let base_filter = &filters[0]; // FIXME: can technically panic, if filters list is empty
         let mut filter = base_filter.clone();
 
@@ -100,15 +102,16 @@ impl Optimization for SimplePatternGroup {
             for f in filters {
                 match &f.filter {
                     FilterPart::Empty => (),
-                    FilterPart::Simple(s) => flat_patterns.push(s.clone()),
-                    FilterPart::AnyOf(s) => flat_patterns.extend_from_slice(s),
+                    FilterPart::Simple(s) => flat_patterns.push(s.to_string()),
+                    FilterPart::AnyOf(s) => flat_patterns.extend(s.iter().cloned()),
                 }
             }
 
             if flat_patterns.is_empty() {
                 filter.filter = FilterPart::Empty;
             } else if flat_patterns.len() == 1 {
-                filter.filter = FilterPart::Simple(flat_patterns[0].clone())
+                filter.filter =
+                    FilterPart::Simple(Cow::Owned(flat_patterns.into_iter().next().unwrap()))
             } else {
                 filter.filter = FilterPart::AnyOf(flat_patterns)
             }
@@ -122,10 +125,10 @@ impl Optimization for SimplePatternGroup {
             .set(NetworkFilterMask::IS_COMPLETE_REGEX, is_complete_regex);
 
         if base_filter.raw_line.is_some() {
-            filter.raw_line = Some(Box::new(
+            filter.raw_line = Some(Cow::Owned(
                 filters
                     .iter()
-                    .flat_map(|f| f.raw_line.clone())
+                    .flat_map(|f| f.raw_line.as_deref())
                     .join(" <+> "),
             ))
         }
@@ -133,10 +136,10 @@ impl Optimization for SimplePatternGroup {
         filter
     }
 
-    fn group_by_criteria(&self, filter: &NetworkFilter) -> String {
+    fn group_by_criteria(&self, filter: &NetworkFilter<'_>) -> String {
         format!("{:b}:{:?}", filter.mask, filter.is_complete_regex())
     }
-    fn select(&self, filter: &NetworkFilter) -> bool {
+    fn select(&self, filter: &NetworkFilter<'_>) -> bool {
         is_filter_optimizable_by_patterns(filter)
     }
 }
@@ -145,7 +148,7 @@ impl Optimization for SimplePatternGroup {
 struct UnionDomainGroup {}
 
 impl Optimization for UnionDomainGroup {
-    fn fusion(&self, filters: &[NetworkFilter]) -> NetworkFilter {
+    fn fusion<'a>(&self, filters: &[NetworkFilter<'a>]) -> NetworkFilter<'a> {
         let base_filter = &filters[0]; // FIXME: can technically panic, if filters list is empty
         let mut filter = base_filter.clone();
         let mut domains = HashSet::new();
@@ -178,10 +181,10 @@ impl Optimization for UnionDomainGroup {
         }
 
         if base_filter.raw_line.is_some() {
-            filter.raw_line = Some(Box::new(
+            filter.raw_line = Some(Cow::Owned(
                 filters
                     .iter()
-                    .flat_map(|f| f.raw_line.clone())
+                    .flat_map(|f| f.raw_line.as_deref())
                     .join(" <+> "),
             ))
         }
@@ -189,7 +192,7 @@ impl Optimization for UnionDomainGroup {
         filter
     }
 
-    fn group_by_criteria(&self, filter: &NetworkFilter) -> String {
+    fn group_by_criteria(&self, filter: &NetworkFilter<'_>) -> String {
         format!(
             "{:?}:{}:{:b}:{:?}",
             filter.hostname.as_ref(),
@@ -199,7 +202,7 @@ impl Optimization for UnionDomainGroup {
         )
     }
 
-    fn select(&self, filter: &NetworkFilter) -> bool {
+    fn select(&self, filter: &NetworkFilter<'_>) -> bool {
         !filter.is_csp() && (filter.opt_domains.is_some() || filter.opt_not_domains.is_some())
     }
 }

--- a/tests/legacy_harness.rs
+++ b/tests/legacy_harness.rs
@@ -871,14 +871,14 @@ mod legacy_misc_tests {
         // Host anchor is calculated correctly
         let filter =
             NetworkFilter::parse("||test.com$third-party", false, Default::default()).unwrap();
-        assert_eq!(filter.hostname, Some(String::from("test.com")));
+        assert_eq!(filter.hostname.as_deref(), Some("test.com"));
 
         let filter =
             NetworkFilter::parse("||test.com/ok$third-party", false, Default::default()).unwrap();
-        assert_eq!(filter.hostname, Some(String::from("test.com")));
+        assert_eq!(filter.hostname.as_deref(), Some("test.com"));
 
         let filter = NetworkFilter::parse("||test.com/ok", false, Default::default()).unwrap();
-        assert_eq!(filter.hostname, Some(String::from("test.com")));
+        assert_eq!(filter.hostname.as_deref(), Some("test.com"));
     }
 
     #[test]

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -42,8 +42,8 @@ fn build_resources_from_filters(filters: &[String]) -> Vec<Resource> {
             Resource {
                 name: redirect.to_string(),
                 aliases: vec![],
-                kind: ResourceType::Mime(MimeType::from_extension(&redirect)),
-                content: BASE64_STANDARD.encode(&redirect),
+                kind: ResourceType::Mime(MimeType::from_extension(redirect)),
+                content: BASE64_STANDARD.encode(redirect),
                 dependencies: vec![],
                 permission: Default::default(),
             }

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -37,13 +37,13 @@ fn build_resources_from_filters(filters: &[String]) -> Vec<Resource> {
         .filter_map(Result::ok)
         .filter(|f| f.is_redirect())
         .map(|f| {
-            let redirect = f.modifier_option.unwrap();
+            let redirect = f.modifier_option.unwrap().into_owned();
 
             Resource {
-                name: redirect.to_owned(),
+                name: redirect.clone(),
                 aliases: vec![],
                 kind: ResourceType::Mime(MimeType::from_extension(&redirect)),
-                content: BASE64_STANDARD.encode(redirect),
+                content: BASE64_STANDARD.encode(&redirect),
                 dependencies: vec![],
                 permission: Default::default(),
             }

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -37,10 +37,10 @@ fn build_resources_from_filters(filters: &[String]) -> Vec<Resource> {
         .filter_map(Result::ok)
         .filter(|f| f.is_redirect())
         .map(|f| {
-            let redirect = f.modifier_option.unwrap().into_owned();
+            let redirect = f.modifier_option.unwrap();
 
             Resource {
-                name: redirect.clone(),
+                name: redirect.to_string(),
                 aliases: vec![],
                 kind: ResourceType::Mime(MimeType::from_extension(&redirect)),
                 content: BASE64_STANDARD.encode(&redirect),

--- a/tests/unit/filters/network.rs
+++ b/tests/unit/filters/network.rs
@@ -590,7 +590,7 @@ mod parse_tests {
                 NetworkFilter::parse(r#"||foo.com$csp=self bar """#, true, Default::default())
                     .unwrap();
             assert!(filter.is_csp());
-            assert_eq!(filter.modifier_option.as_deref(), Some(r#"self bar """#));
+            assert_eq!(filter.modifier_option, Some(r#"self bar """#));
         }
         {
             // parses empty CSP
@@ -717,12 +717,12 @@ mod parse_tests {
             let filter =
                 NetworkFilter::parse("||foo.com$redirect=bar.js", true, Default::default())
                     .unwrap();
-            assert_eq!(filter.modifier_option.as_deref(), Some("bar.js"));
+            assert_eq!(filter.modifier_option, Some("bar.js"));
         }
         {
             let filter =
                 NetworkFilter::parse("$redirect=bar.js", true, Default::default()).unwrap();
-            assert_eq!(filter.modifier_option.as_deref(), Some("bar.js"));
+            assert_eq!(filter.modifier_option, Some("bar.js"));
         }
         // parses ~redirect
         {
@@ -797,7 +797,7 @@ mod parse_tests {
                 NetworkFilter::parse("||foo.com^$removeparam=test", true, Default::default())
                     .unwrap();
             assert!(filter.is_removeparam());
-            assert_eq!(filter.modifier_option.as_deref(), Some("test"));
+            assert_eq!(filter.modifier_option, Some("test"));
         }
     }
 

--- a/tests/unit/filters/network.rs
+++ b/tests/unit/filters/network.rs
@@ -39,14 +39,17 @@ mod parse_tests {
         third_party: bool,
     }
 
-    impl From<&NetworkFilter> for NetworkFilterBreakdown {
+    impl From<&NetworkFilter<'_>> for NetworkFilterBreakdown {
         fn from(filter: &NetworkFilter) -> NetworkFilterBreakdown {
             NetworkFilterBreakdown {
                 filter: filter.filter.string_view(),
-                hostname: filter.hostname.as_ref().cloned(),
+                hostname: filter.hostname.as_ref().map(|host| host.to_string()),
                 opt_domains: filter.opt_domains.as_ref().cloned(),
                 opt_not_domains: filter.opt_not_domains.as_ref().cloned(),
-                modifier_option: filter.modifier_option.as_ref().cloned(),
+                modifier_option: filter
+                    .modifier_option
+                    .as_ref()
+                    .map(|value| value.to_string()),
 
                 // filter type
                 is_exception: filter.is_exception(),
@@ -587,7 +590,7 @@ mod parse_tests {
                 NetworkFilter::parse(r#"||foo.com$csp=self bar """#, true, Default::default())
                     .unwrap();
             assert!(filter.is_csp());
-            assert_eq!(filter.modifier_option, Some(String::from(r#"self bar """#)));
+            assert_eq!(filter.modifier_option.as_deref(), Some(r#"self bar """#));
         }
         {
             // parses empty CSP
@@ -714,12 +717,12 @@ mod parse_tests {
             let filter =
                 NetworkFilter::parse("||foo.com$redirect=bar.js", true, Default::default())
                     .unwrap();
-            assert_eq!(filter.modifier_option, Some(String::from("bar.js")));
+            assert_eq!(filter.modifier_option.as_deref(), Some("bar.js"));
         }
         {
             let filter =
                 NetworkFilter::parse("$redirect=bar.js", true, Default::default()).unwrap();
-            assert_eq!(filter.modifier_option, Some(String::from("bar.js")));
+            assert_eq!(filter.modifier_option.as_deref(), Some("bar.js"));
         }
         // parses ~redirect
         {
@@ -794,7 +797,7 @@ mod parse_tests {
                 NetworkFilter::parse("||foo.com^$removeparam=test", true, Default::default())
                     .unwrap();
             assert!(filter.is_removeparam());
-            assert_eq!(filter.modifier_option, Some("test".into()));
+            assert_eq!(filter.modifier_option.as_deref(), Some("test"));
         }
     }
 
@@ -974,7 +977,7 @@ mod parse_tests {
         {
             let filter = NetworkFilter::parse_hosts_style("example.com", true).unwrap();
             assert!(filter.raw_line.is_some());
-            assert_eq!(*filter.raw_line.clone().unwrap(), "||example.com^");
+            assert_eq!(filter.raw_line.as_deref().unwrap(), "example.com");
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some("example.com".to_string());
             defaults.is_plain = true;
@@ -986,7 +989,7 @@ mod parse_tests {
         {
             let filter = NetworkFilter::parse_hosts_style("www.example.com", true).unwrap();
             assert!(filter.raw_line.is_some());
-            assert_eq!(*filter.raw_line.clone().unwrap(), "||www.example.com^");
+            assert_eq!(filter.raw_line.as_deref().unwrap(), "www.example.com");
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some("www.example.com".to_string());
             defaults.is_plain = true;
@@ -998,7 +1001,7 @@ mod parse_tests {
         {
             let filter = NetworkFilter::parse_hosts_style("malware.example.com", true).unwrap();
             assert!(filter.raw_line.is_some());
-            assert_eq!(*filter.raw_line.clone().unwrap(), "||malware.example.com^");
+            assert_eq!(filter.raw_line.as_deref().unwrap(), "malware.example.com");
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some("malware.example.com".to_string());
             defaults.is_plain = true;
@@ -1011,7 +1014,7 @@ mod parse_tests {
         {
             let filter = NetworkFilter::parse_hosts_style("Example.COM", true).unwrap();
             assert!(filter.raw_line.is_some());
-            assert_eq!(*filter.raw_line.clone().unwrap(), "||Example.COM^");
+            assert_eq!(filter.raw_line.as_deref().unwrap(), "Example.COM");
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some("example.com".to_string());
             defaults.is_plain = true;
@@ -1024,7 +1027,7 @@ mod parse_tests {
         {
             let filter = NetworkFilter::parse_hosts_style("WWW.Example.COM", true).unwrap();
             assert!(filter.raw_line.is_some());
-            assert_eq!(*filter.raw_line.clone().unwrap(), "||WWW.Example.COM^");
+            assert_eq!(filter.raw_line.as_deref().unwrap(), "WWW.Example.COM");
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some("www.example.com".to_string());
             defaults.is_plain = true;
@@ -1037,7 +1040,7 @@ mod parse_tests {
         {
             let filter = NetworkFilter::parse_hosts_style("münchen.de", true).unwrap();
             assert!(filter.raw_line.is_some());
-            assert_eq!(*filter.raw_line.clone().unwrap(), "||münchen.de^");
+            assert_eq!(filter.raw_line.as_deref().unwrap(), "münchen.de");
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some("xn--mnchen-3ya.de".to_string());
             defaults.is_plain = true;
@@ -1050,7 +1053,7 @@ mod parse_tests {
         {
             let filter = NetworkFilter::parse_hosts_style("www.münchen.de", true).unwrap();
             assert!(filter.raw_line.is_some());
-            assert_eq!(*filter.raw_line.clone().unwrap(), "||www.münchen.de^");
+            assert_eq!(filter.raw_line.as_deref().unwrap(), "www.münchen.de");
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some("www.xn--mnchen-3ya.de".to_string());
             defaults.is_plain = true;
@@ -1074,9 +1077,9 @@ mod parse_tests {
         let options = vec!["genericblock", "inline-script", "popunder", "popup", "woot"];
 
         for option in options {
-            let filter =
-                NetworkFilter::parse(&format!("||foo.com${option}"), true, Default::default());
-            assert!(filter.err().is_some());
+            let rule = format!("||foo.com${option}");
+            let filter = NetworkFilter::parse(&rule, true, Default::default());
+            assert!(filter.is_err());
         }
     }
 
@@ -1134,9 +1137,8 @@ mod parse_tests {
         for option in options {
             // positive
             {
-                let filter =
-                    NetworkFilter::parse(&format!("||foo.com${option}"), true, Default::default())
-                        .unwrap();
+                let rule = format!("||foo.com${option}");
+                let filter = NetworkFilter::parse(&rule, true, Default::default()).unwrap();
                 let mut defaults = default_network_filter_breakdown();
                 defaults.hostname = Some(String::from("foo.com"));
                 defaults.is_hostname_anchor = true;
@@ -1148,12 +1150,8 @@ mod parse_tests {
             }
 
             {
-                let filter = NetworkFilter::parse(
-                    &format!("||foo.com$object,{option}"),
-                    true,
-                    Default::default(),
-                )
-                .unwrap();
+                let rule = format!("||foo.com$object,{option}");
+                let filter = NetworkFilter::parse(&rule, true, Default::default()).unwrap();
                 let mut defaults = default_network_filter_breakdown();
                 defaults.hostname = Some(String::from("foo.com"));
                 defaults.is_hostname_anchor = true;
@@ -1166,12 +1164,8 @@ mod parse_tests {
             }
 
             {
-                let filter = NetworkFilter::parse(
-                    &format!("||foo.com$domain=bar.com,{option}"),
-                    true,
-                    Default::default(),
-                )
-                .unwrap();
+                let rule = format!("||foo.com$domain=bar.com,{option}");
+                let filter = NetworkFilter::parse(&rule, true, Default::default()).unwrap();
                 let mut defaults = default_network_filter_breakdown();
                 defaults.hostname = Some(String::from("foo.com"));
                 defaults.is_hostname_anchor = true;
@@ -1185,9 +1179,8 @@ mod parse_tests {
 
             // negative
             {
-                let filter =
-                    NetworkFilter::parse(&format!("||foo.com$~{option}"), true, Default::default())
-                        .unwrap();
+                let rule = format!("||foo.com$~{option}");
+                let filter = NetworkFilter::parse(&rule, true, Default::default()).unwrap();
                 let mut defaults = default_network_filter_breakdown();
                 defaults.hostname = Some(String::from("foo.com"));
                 defaults.is_hostname_anchor = true;
@@ -1199,12 +1192,8 @@ mod parse_tests {
             }
 
             {
-                let filter = NetworkFilter::parse(
-                    &format!("||foo.com${option},~{option}"),
-                    true,
-                    Default::default(),
-                )
-                .unwrap();
+                let rule = format!("||foo.com${option},~{option}");
+                let filter = NetworkFilter::parse(&rule, true, Default::default()).unwrap();
                 let mut defaults = default_network_filter_breakdown();
                 defaults.hostname = Some(String::from("foo.com"));
                 defaults.is_hostname_anchor = true;

--- a/tests/unit/filters/network.rs
+++ b/tests/unit/filters/network.rs
@@ -977,7 +977,7 @@ mod parse_tests {
         {
             let filter = NetworkFilter::parse_hosts_style("example.com", true).unwrap();
             assert!(filter.raw_line.is_some());
-            assert_eq!(filter.raw_line.as_deref().unwrap(), "example.com");
+            assert_eq!(filter.raw_line.as_deref().unwrap(), "||example.com^");
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some("example.com".to_string());
             defaults.is_plain = true;
@@ -989,7 +989,7 @@ mod parse_tests {
         {
             let filter = NetworkFilter::parse_hosts_style("www.example.com", true).unwrap();
             assert!(filter.raw_line.is_some());
-            assert_eq!(filter.raw_line.as_deref().unwrap(), "www.example.com");
+            assert_eq!(filter.raw_line.as_deref().unwrap(), "||www.example.com^");
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some("www.example.com".to_string());
             defaults.is_plain = true;
@@ -1001,7 +1001,10 @@ mod parse_tests {
         {
             let filter = NetworkFilter::parse_hosts_style("malware.example.com", true).unwrap();
             assert!(filter.raw_line.is_some());
-            assert_eq!(filter.raw_line.as_deref().unwrap(), "malware.example.com");
+            assert_eq!(
+                filter.raw_line.as_deref().unwrap(),
+                "||malware.example.com^"
+            );
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some("malware.example.com".to_string());
             defaults.is_plain = true;
@@ -1014,7 +1017,7 @@ mod parse_tests {
         {
             let filter = NetworkFilter::parse_hosts_style("Example.COM", true).unwrap();
             assert!(filter.raw_line.is_some());
-            assert_eq!(filter.raw_line.as_deref().unwrap(), "Example.COM");
+            assert_eq!(filter.raw_line.as_deref().unwrap(), "||Example.COM^");
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some("example.com".to_string());
             defaults.is_plain = true;
@@ -1027,7 +1030,7 @@ mod parse_tests {
         {
             let filter = NetworkFilter::parse_hosts_style("WWW.Example.COM", true).unwrap();
             assert!(filter.raw_line.is_some());
-            assert_eq!(filter.raw_line.as_deref().unwrap(), "WWW.Example.COM");
+            assert_eq!(filter.raw_line.as_deref().unwrap(), "||WWW.Example.COM^");
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some("www.example.com".to_string());
             defaults.is_plain = true;
@@ -1040,7 +1043,7 @@ mod parse_tests {
         {
             let filter = NetworkFilter::parse_hosts_style("münchen.de", true).unwrap();
             assert!(filter.raw_line.is_some());
-            assert_eq!(filter.raw_line.as_deref().unwrap(), "münchen.de");
+            assert_eq!(filter.raw_line.as_deref().unwrap(), "||münchen.de^");
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some("xn--mnchen-3ya.de".to_string());
             defaults.is_plain = true;
@@ -1053,7 +1056,7 @@ mod parse_tests {
         {
             let filter = NetworkFilter::parse_hosts_style("www.münchen.de", true).unwrap();
             assert!(filter.raw_line.is_some());
-            assert_eq!(filter.raw_line.as_deref().unwrap(), "www.münchen.de");
+            assert_eq!(filter.raw_line.as_deref().unwrap(), "||www.münchen.de^");
             let mut defaults = default_network_filter_breakdown();
             defaults.hostname = Some("www.xn--mnchen-3ya.de".to_string());
             defaults.is_plain = true;

--- a/tests/unit/lists.rs
+++ b/tests/unit/lists.rs
@@ -197,11 +197,8 @@ mod tests {
     #[test]
     fn parse_filter_failed_fuzz_4() {
         // \\##+js(,\xdd\x8d
-        let parsed = parse_filter(
-            &String::from_utf8(vec![92, 35, 35, 43, 106, 115, 40, 44, 221, 141]).unwrap(),
-            true,
-            Default::default(),
-        );
+        let rule = String::from_utf8(vec![92, 35, 35, 43, 106, 115, 40, 44, 221, 141]).unwrap();
+        let parsed = parse_filter(&rule, true, Default::default());
         #[cfg(feature = "css-validation")]
         assert!(parsed.is_err());
         #[cfg(not(feature = "css-validation"))]


### PR DESCRIPTION
The PR makes `NetworkFilter::parse` reuse the original string via `Cow<.>`.

The PR cuts the number of allocation in half:
```
memory-usage-alloc-count/brave-list-initial/alloc-count
                        time:   [352396 allocs 352396 allocs 352396 allocs]
                        change: [−45.690% −45.690% −45.690%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking memory-usage-alloc-count/brave-list-1000-requests/alloc-count: Warming up 
```

