### PR TITLE
Store extra debug data

### DIFF
--- a/js/src/lib.rs
+++ b/js/src/lib.rs
@@ -82,7 +82,7 @@ impl FilterSet {
     fn new(debug: bool) -> Self {
         Self(RefCell::new(FilterSetInternal::new(debug)))
     }
-    fn add_filters(&self, rules: String, opts: ParseOptions) -> adblock::lists::FilterListMetadata {
+    fn add_filters(&self, rules: String, opts: ParseOptions) -> adblock::lists::AddedFiltersRecord {
         self.0.borrow_mut().add_filter_list(rules, opts)
     }
 

--- a/js/test/bindings.test.mjs
+++ b/js/test/bindings.test.mjs
@@ -25,17 +25,18 @@ const { FilterSet, Engine, FilterFormat, RuleTypes, uBlockResources } =
 describe('FilterSet.addFilters', () => {
       it('parses metadata comments (title, homepage, expires, redirect)', () => {
         const fs = new FilterSet();
-        const meta = fs.addFilters([
+        const { source_index, metadata } = fs.addFilters([
             '! Title: Test List',
             '! Homepage: https://example.com',
             '! Expires: 2 days',
             '! Redirect: https://example.com/new-list.txt',
             '||ads.com^',
         ].join('\n'));
-        assert.equal(meta.title, 'Test List');
-        assert.equal(meta.homepage, 'https://example.com');
-        assert.ok(meta.expires != null);
-        assert.equal(meta.redirect, 'https://example.com/new-list.txt');
+        assert.equal(metadata.title, 'Test List');
+        assert.equal(source_index, 0);
+        assert.equal(metadata.homepage, 'https://example.com');
+        assert.ok(metadata.expires != null);
+        assert.equal(metadata.redirect, 'https://example.com/new-list.txt');
     });
     it('hosts format parses IP-hostname entries', () => {
         const fs = new FilterSet();

--- a/js/test/bindings.test.mjs
+++ b/js/test/bindings.test.mjs
@@ -151,7 +151,7 @@ describe('Engine.check — basic blocking', () => {
             'https://ads.example.com/t.js', 'https://pub.com', 'script', 'get', true
         );
         assert.equal(result.matched, true);
-        assert.equal(result.filter, '||ads.example.com^');
+        assert.equal(result.filter, '0:0: ||ads.example.com^');
     });
 
     it('throws for an invalid URL', () => {
@@ -184,7 +184,7 @@ describe('Engine.check — exception rules', () => {
         );
         assert.equal(result.matched, false);
         assert.equal(typeof result.exception, 'string');
-        assert.equal(result.exception, '@@||ads.example.com^$domain=publisher.com');
+        assert.equal(result.exception, '0:1: @@||ads.example.com^$domain=publisher.com');
     });
 
     it('$important overrides exception rules', () => {
@@ -196,7 +196,7 @@ describe('Engine.check — exception rules', () => {
         );
         assert.equal(result.matched, true);
         assert.equal(result.important, true);
-        assert.equal(result.filter, '||ads.example.com^$important');
+        assert.equal(result.filter, '0:0: ||ads.example.com^$important');
     });
 });
 
@@ -342,7 +342,7 @@ describe('Engine.check — redirect rules', () => {
             'https://ads.example.com/t.js', 'https://pub.com', 'script', 'get', true,
         );
         assert.equal(result.matched, true);
-        assert.equal(result.filter, '||ads.example.com^$script,redirect=noopjs');
+        assert.equal(result.filter, '0:0: ||ads.example.com^$script,redirect=noopjs');
         assert.ok(result.redirect.length > 0);
     });
 
@@ -354,7 +354,7 @@ describe('Engine.check — redirect rules', () => {
             'https://ads.example.com/t.js', 'https://pub.com', 'script', 'get', true,
         );
         assert.equal(result.matched, true);
-        assert.equal(result.filter, '||ads.example.com^');
+        assert.equal(result.filter, '0:0: ||ads.example.com^');
         assert.ok(result.redirect == null);
     });
 });
@@ -410,7 +410,7 @@ describe('Engine.check — exception rules with tags', () => {
             'https://ads.example.com/t.js', 'https://pub.com', 'script', 'get', true,
         );
         assert.equal(after.matched, false);
-        assert.equal(after.exception, '@@||ads.example.com^$tag=unbreak');
+        assert.equal(after.exception, '0:1: @@||ads.example.com^$tag=unbreak');
     });
 });
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -5,10 +5,10 @@ use crate::cosmetic_filter_cache::{CosmeticFilterCache, UrlSpecificResources};
 use crate::cosmetic_filter_cache_builder::CosmeticFilterCacheBuilder;
 use crate::data_format::{deserialize_dat_file, serialize_dat_file, DeserializationError};
 use crate::filters::fb_builder::EngineFlatBuilder;
-use crate::filters::fb_network_builder::NetworkRulesBuilder;
+use crate::filters::fb_network_builder::{NetworkFilterDebugData, NetworkRulesBuilder};
 use crate::filters::filter_data_context::{FilterDataContext, FilterDataContextRef};
 use crate::filters::flatbuffer_generated::fb;
-use crate::flatbuffers::containers::flat_serialize::FlatSerialize;
+use crate::flatbuffers::containers::flat_serialize::{FlatBuilder, FlatSerialize};
 use crate::flatbuffers::unsafe_tools::VerifiedFlatbufferMemory;
 use crate::lists::{parse_filter, FilterSet, ParseOptions, ParsedLine};
 use crate::regex_manager::RegexManagerDiscardPolicy;
@@ -60,9 +60,20 @@ pub struct Engine {
 }
 
 #[cfg(feature = "debug-info")]
+pub struct SourceInfo {
+    pub title: Option<String>,
+    pub homepage: Option<String>,
+    pub network_filter_count: u32,
+    pub cosmetic_filter_count: u32,
+    pub parse_error: u32,
+    pub invalid_lines: Vec<String>,
+}
+
+#[cfg(feature = "debug-info")]
 pub struct EngineDebugInfo {
     pub regex_debug_info: crate::regex_manager::RegexDebugInfo,
     pub flatbuffer_size: usize,
+    pub source_info: Vec<SourceInfo>,
 }
 
 impl Default for Engine {
@@ -101,7 +112,7 @@ impl Engine {
         let mut cosmetic_filter_cache_builder = CosmeticFilterCacheBuilder::default();
 
         for filter in network_filters {
-            network_rules_builder.add_filter(filter, &mut builder);
+            network_rules_builder.add_filter(filter, Default::default(), &mut builder);
         }
         for filter in cosmetic_filters {
             cosmetic_filter_cache_builder.add_filter(filter, &mut builder);
@@ -110,6 +121,8 @@ impl Engine {
         Self::new_with_flatbuffer_offsets(
             FlatSerialize::serialize(network_rules_builder, &mut builder),
             FlatSerialize::serialize(cosmetic_filter_cache_builder, &mut builder),
+            Vec::new(),
+            false,
             builder,
         )
     }
@@ -127,34 +140,91 @@ impl Engine {
     fn new_with_filter_set_internal(set: FilterSet, optimize: bool) -> Self {
         let FilterSet {
             debug,
-            list_sources,
+            ref list_sources,
         } = set;
         let mut builder = EngineFlatBuilder::default();
         let mut network_rules_builder = NetworkRulesBuilder::new(optimize);
         let mut cosmetic_filter_cache_builder = CosmeticFilterCacheBuilder::default();
+        let mut source_info_vec = Vec::new();
 
-        for list_source in &list_sources {
-            for line in list_source.list_text.lines() {
+        for (source_index, list_source) in set.list_sources.iter().enumerate() {
+            let mut network_filter_count = 0;
+            let mut cosmetic_filter_count = 0;
+            let mut parse_error = 0;
+            let mut invalid_lines = Vec::new();
+            for (line_number, line) in list_source.list_text.lines().enumerate() {
                 let parsed_line = parse_filter(line, debug, list_source.parse_options);
                 match parsed_line {
                     Ok(ParsedLine::Network(filter)) => {
-                        network_rules_builder.add_filter(filter, &mut builder)
+                        let debug_data = if debug {
+                            NetworkFilterDebugData {
+                                source_index: source_index as i32,
+                                line_number: line_number as i32,
+                            }
+                        } else {
+                            Default::default()
+                        };
+                        network_rules_builder.add_filter(filter, debug_data, &mut builder);
+                        network_filter_count += 1;
                     }
                     Ok(ParsedLine::Cosmetic(filter)) => {
-                        cosmetic_filter_cache_builder.add_filter(filter, &mut builder)
+                        cosmetic_filter_cache_builder.add_filter(filter, &mut builder);
+                        cosmetic_filter_count += 1;
                     }
-                    Err(_) => {}
+                    Err(_) => {
+                        parse_error += 1;
+                        if set.debug {
+                            invalid_lines.push(line);
+                        }
+                    }
                 }
             }
+
+            let homepage = list_source
+                .metadata
+                .homepage
+                .as_ref()
+                .map(|v| builder.create_string(v.as_str()));
+            let title = list_source
+                .metadata
+                .title
+                .as_ref()
+                .map(|v| builder.create_string(v.as_str()));
+
+            let invalid_lines = if set.debug {
+                Some(FlatSerialize::serialize(invalid_lines, &mut builder))
+            } else {
+                None
+            };
+
+            let source_info = fb::SourceInfo::create(
+                builder.raw_builder(),
+                &fb::SourceInfoArgs {
+                    title,
+                    homepage,
+                    network_filter_count,
+                    cosmetic_filter_count,
+                    parse_error,
+                    invalid_lines,
+                },
+            );
+
+            source_info_vec.push(source_info);
         }
         let network_rules_offset = FlatSerialize::serialize(network_rules_builder, &mut builder);
         // Drop the list sources to reduce peak memory usage.
-        drop(list_sources);
+        _ = list_sources;
 
         let cosmetic_rules_offset =
             FlatSerialize::serialize(cosmetic_filter_cache_builder, &mut builder);
 
-        Self::new_with_flatbuffer_offsets(network_rules_offset, cosmetic_rules_offset, builder)
+        Self::new_with_flatbuffer_offsets(
+            network_rules_offset,
+            cosmetic_rules_offset,
+            source_info_vec,
+            debug,
+            builder,
+        )
     }
 
     fn new_with_flatbuffer_offsets<'a>(
@@ -162,9 +232,12 @@ impl Engine {
             flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<fb::NetworkFilterList<'a>>>,
         >,
         cosmetic_rules: flatbuffers::WIPOffset<fb::CosmeticFilters<'a>>,
-        builder: EngineFlatBuilder<'a>,
+        source_info_vec: Vec<flatbuffers::WIPOffset<fb::SourceInfo<'a>>>,
+        debug: bool,
+        mut builder: EngineFlatBuilder<'a>,
     ) -> Self {
-        let memory = builder.finish(network_rules, cosmetic_rules);
+        let source_info_vec = FlatSerialize::serialize(source_info_vec, &mut builder);
+        let memory = builder.finish(network_rules, cosmetic_rules, source_info_vec, debug);
         let filter_data_context = FilterDataContext::new(memory);
         Self {
             blocker: Blocker::from_context(FilterDataContextRef::clone(&filter_data_context)),
@@ -330,9 +403,26 @@ impl Engine {
 
     #[cfg(feature = "debug-info")]
     pub fn get_debug_info(&self) -> EngineDebugInfo {
+        let engine = self.filter_data_context.memory.root();
+        let source_info = engine
+            .source_info()
+            .iter()
+            .map(|s| SourceInfo {
+                title: s.title().map(|s| s.to_string()),
+                homepage: s.homepage().map(|s| s.to_string()),
+                network_filter_count: s.network_filter_count() as u32,
+                cosmetic_filter_count: s.cosmetic_filter_count() as u32,
+                parse_error: s.parse_error() as u32,
+                invalid_lines: s
+                    .invalid_lines()
+                    .map(|v| v.iter().map(|s| s.to_string()).collect())
+                    .unwrap_or_default(),
+            })
+            .collect();
         EngineDebugInfo {
             regex_debug_info: self.blocker.get_regex_debug_info(),
             flatbuffer_size: self.filter_data_context.memory.data().len(),
+            source_info,
         }
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -158,8 +158,8 @@ impl Engine {
                     Ok(ParsedLine::Network(filter)) => {
                         let debug_data = if debug {
                             NetworkFilterDebugData {
-                                source_index: source_index as i32,
-                                line_number: line_number as i32,
+                                source_index: source_index as u32,
+                                line_number: line_number as u32,
                             }
                         } else {
                             Default::default()

--- a/src/filters/fb_builder.rs
+++ b/src/filters/fb_builder.rs
@@ -34,6 +34,10 @@ impl<'a> EngineFlatBuilder<'a> {
             flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<fb::NetworkFilterList<'a>>>,
         >,
         cosmetic_rules: WIPOffset<fb::CosmeticFilters<'_>>,
+        source_info_vec: WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<fb::SourceInfo<'a>>>,
+        >,
+        debug: bool,
     ) -> VerifiedFlatbufferMemory {
         let unique_domains_hashes =
             Some(self.fb_builder.create_vector(&self.unique_domains_hashes));
@@ -43,6 +47,8 @@ impl<'a> EngineFlatBuilder<'a> {
                 network_rules: Some(network_rules),
                 unique_domains_hashes,
                 cosmetic_filters: Some(cosmetic_rules),
+                debug,
+                source_info: Some(source_info_vec),
             },
         );
         self.raw_builder().finish(engine, None);

--- a/src/filters/fb_network.rs
+++ b/src/filters/fb_network.rs
@@ -158,8 +158,37 @@ impl<'a> FlatNetworkFilter<'a> {
     }
 
     #[inline(always)]
-    pub fn raw_line(&self) -> Option<String> {
-        self.fb_filter.raw_line().map(|v| v.to_string())
+    pub fn raw_line(&self) -> String {
+        debug_assert!(
+            self.filter_data_context.debug,
+            "raw_line is only available in debug mode"
+        );
+        match self.fb_filter.raw_line() {
+            Some(v) => v.to_string(),
+            None => {
+                debug_assert!(false, "raw_line is not set");
+                Default::default()
+            }
+        }
+    }
+
+    #[inline(always)]
+    pub fn source_index(&self) -> i32 {
+        debug_assert!(
+            self.filter_data_context.debug,
+            "raw_line is only available in debug mode"
+        );
+        self.fb_filter.source_index()
+    }
+
+    #[inline(always)]
+    pub fn line_number(&self) -> i32 {
+        debug_assert!(
+            self.filter_data_context.debug,
+            "raw_line is only available in debug mode"
+        );
+
+        self.fb_filter.line_number()
     }
 }
 

--- a/src/filters/fb_network.rs
+++ b/src/filters/fb_network.rs
@@ -9,6 +9,8 @@ use crate::request::Request;
 
 use crate::filters::flatbuffer_generated::fb;
 
+pub(crate) const NO_SOURCE_LINE_INFO: u32 = u32::MAX;
+
 /// A list of string parts that can be matched against a URL.
 pub(crate) enum FlatPatterns<'a> {
     /// No patterns to match
@@ -173,22 +175,33 @@ impl<'a> FlatNetworkFilter<'a> {
     }
 
     #[inline(always)]
-    pub fn source_index(&self) -> i32 {
+    pub fn source_index(&self) -> Option<u32> {
         debug_assert!(
             self.filter_data_context.debug,
             "raw_line is only available in debug mode"
         );
-        self.fb_filter.source_index()
+
+        let index = self.fb_filter.source_index();
+        if index == NO_SOURCE_LINE_INFO {
+            None
+        } else {
+            Some(index)
+        }
     }
 
     #[inline(always)]
-    pub fn line_number(&self) -> i32 {
+    pub fn line_number(&self) -> Option<u32> {
         debug_assert!(
             self.filter_data_context.debug,
             "raw_line is only available in debug mode"
         );
 
-        self.fb_filter.line_number()
+        let number = self.fb_filter.line_number();
+        if number == NO_SOURCE_LINE_INFO {
+            None
+        } else {
+            Some(number)
+        }
     }
 }
 

--- a/src/filters/fb_network_builder.rs
+++ b/src/filters/fb_network_builder.rs
@@ -34,6 +34,21 @@ struct NetworkFilterFlatEntry<'a> {
     id: Hash,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct NetworkFilterDebugData {
+    pub(crate) source_index: i32,
+    pub(crate) line_number: i32,
+}
+
+impl Default for NetworkFilterDebugData {
+    fn default() -> Self {
+        Self {
+            source_index: -1,
+            line_number: -1,
+        }
+    }
+}
+
 struct NetworkFilterListBuilder<'a, 'f> {
     flat_map_builder: FlatMultiMapBuilder<ShortHash, NetworkFilterFlatEntry<'a>>,
     token_frequencies: TokenSelector,
@@ -47,11 +62,13 @@ pub(crate) struct NetworkRulesBuilder<'a, 'f> {
     bad_filter_ids: HashSet<Hash>,
 }
 
-impl<'f, 'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for NetworkFilter<'f> {
+impl<'a, 'f> FlatSerialize<'a, EngineFlatBuilder<'a>>
+    for (NetworkFilter<'f>, NetworkFilterDebugData)
+{
     type Output = WIPOffset<fb::NetworkFilter<'a>>;
 
     fn serialize(
-        network_filter: NetworkFilter<'f>,
+        (network_filter, debug_data): (NetworkFilter<'f>, NetworkFilterDebugData),
         builder: &mut EngineFlatBuilder<'a>,
     ) -> WIPOffset<fb::NetworkFilter<'a>> {
         let opt_domains = network_filter.opt_domains.as_ref().map(|v| {
@@ -120,6 +137,8 @@ impl<'f, 'a> FlatSerialize<'a, EngineFlatBuilder<'a>> for NetworkFilter<'f> {
                 hostname,
                 tag,
                 raw_line,
+                source_index: debug_data.source_index,
+                line_number: debug_data.line_number,
             },
         )
     }
@@ -139,6 +158,7 @@ impl<'a, 'f> NetworkFilterListBuilder<'a, 'f> {
     fn add_filter(
         &mut self,
         network_filter: NetworkFilter<'f>,
+        debug_data: NetworkFilterDebugData,
         builder: &mut EngineFlatBuilder<'a>,
     ) {
         let multi_tokens = network_filter.get_tokens(&mut self.tokens_buffer);
@@ -170,7 +190,7 @@ impl<'a, 'f> NetworkFilterListBuilder<'a, 'f> {
         {
             // Serialize now (even if it matches to a bad filter later);
             // Although store the id for later bad-filter pruning.
-            let filter = FlatSerialize::serialize(network_filter, builder);
+            let filter = FlatSerialize::serialize((network_filter, debug_data), builder);
             for &token in tokens {
                 self.token_frequencies.record_usage(token);
                 self.flat_map_builder
@@ -204,7 +224,12 @@ impl<'a, 'f> NetworkRulesBuilder<'a, 'f> {
         }
     }
 
-    pub fn add_filter(&mut self, filter: NetworkFilter<'f>, builder: &mut EngineFlatBuilder<'a>) {
+    pub fn add_filter(
+        &mut self,
+        filter: NetworkFilter<'f>,
+        debug_data: NetworkFilterDebugData,
+        builder: &mut EngineFlatBuilder<'a>,
+    ) {
         if filter.is_badfilter() {
             // Note: `get_id()` doesn't include BAD_FILTER bit.
             self.bad_filter_ids.insert(filter.get_id());
@@ -213,7 +238,12 @@ impl<'a, 'f> NetworkRulesBuilder<'a, 'f> {
 
         // Redirects are independent of blocking behavior.
         if filter.is_redirect() {
-            self.add_filter_internal(filter.clone(), NetworkFilterListId::Redirects, builder);
+            self.add_filter_internal(
+                filter.clone(),
+                debug_data.clone(),
+                NetworkFilterListId::Redirects,
+                builder,
+            );
         }
         type FilterId = NetworkFilterListId;
 
@@ -236,16 +266,17 @@ impl<'a, 'f> NetworkRulesBuilder<'a, 'f> {
             return;
         };
 
-        self.add_filter_internal(filter, list_id, builder);
+        self.add_filter_internal(filter, debug_data, list_id, builder);
     }
 
     fn add_filter_internal(
         &mut self,
         network_filter: NetworkFilter<'f>,
+        debug_data: NetworkFilterDebugData,
         list_id: NetworkFilterListId,
         builder: &mut EngineFlatBuilder<'a>,
     ) {
-        self.lists[list_id as usize].add_filter(network_filter, builder);
+        self.lists[list_id as usize].add_filter(network_filter, debug_data, builder);
     }
 }
 
@@ -280,7 +311,8 @@ impl<'a, 'f> FlatSerialize<'a, EngineFlatBuilder<'a>> for NetworkRulesBuilder<'a
 
                     for filter in optimized {
                         let id = filter.get_id();
-                        let filter = FlatSerialize::serialize(filter, builder);
+                        let filter =
+                            FlatSerialize::serialize((filter, Default::default()), builder);
                         rule_list
                             .flat_map_builder
                             .insert(token, NetworkFilterFlatEntry { filter, id });

--- a/src/filters/fb_network_builder.rs
+++ b/src/filters/fb_network_builder.rs
@@ -5,6 +5,7 @@ use std::collections::{HashMap, HashSet};
 use flatbuffers::WIPOffset;
 
 use crate::filters::fb_builder::EngineFlatBuilder;
+use crate::filters::fb_network::NO_SOURCE_LINE_INFO;
 use crate::filters::network::{FilterTokens, NetworkFilter};
 use crate::filters::token_selector::TokenSelector;
 use crate::utils::TokensBuffer;
@@ -36,15 +37,15 @@ struct NetworkFilterFlatEntry<'a> {
 
 #[derive(Debug, Clone)]
 pub(crate) struct NetworkFilterDebugData {
-    pub(crate) source_index: i32,
-    pub(crate) line_number: i32,
+    pub(crate) source_index: u32,
+    pub(crate) line_number: u32,
 }
 
 impl Default for NetworkFilterDebugData {
     fn default() -> Self {
         Self {
-            source_index: -1,
-            line_number: -1,
+            source_index: NO_SOURCE_LINE_INFO,
+            line_number: NO_SOURCE_LINE_INFO,
         }
     }
 }

--- a/src/filters/filter_data_context.rs
+++ b/src/filters/filter_data_context.rs
@@ -13,12 +13,14 @@ pub(crate) type FilterDataContextRef = std::sync::Arc<FilterDataContext>;
 pub(crate) struct FilterDataContext {
     pub(crate) memory: VerifiedFlatbufferMemory,
     pub(crate) unique_domains_hashes_map: HashMap<Hash, u32>,
+    pub(crate) debug: bool,
 }
 
 impl FilterDataContext {
     pub(crate) fn new(memory: VerifiedFlatbufferMemory) -> FilterDataContextRef {
         // Reconstruct the unique_domains_hashes_map from the flatbuffer data
         let root = memory.root();
+        let debug = root.debug();
         let mut unique_domains_hashes_map: HashMap<crate::utils::Hash, u32> = HashMap::new();
         for (index, hash) in root.unique_domains_hashes().iter().enumerate() {
             unique_domains_hashes_map.insert(hash, index as u32);
@@ -26,6 +28,7 @@ impl FilterDataContext {
         FilterDataContextRef::new(Self {
             memory,
             unique_domains_hashes_map,
+            debug,
         })
     }
 }

--- a/src/flatbuffers/fb_network_filter.fbs
+++ b/src/flatbuffers/fb_network_filter.fbs
@@ -28,7 +28,10 @@ table NetworkFilter {
 
   tag: string;
 
+  // Debug mode only
   raw_line: string;
+  source_index: int32 = -1;
+  line_number: int32 = -1;
 }
 
 table NetworkFilterList {
@@ -110,6 +113,15 @@ table CosmeticFilters {
   hostname_values: [HostnameSpecificRules] (required);
 }
 
+table SourceInfo {
+  title: string;
+  homepage: string;
+  network_filter_count: int32;
+  cosmetic_filter_count: int32;
+  parse_error: int32;
+  invalid_lines: [string];
+}
+
 /// A root type containing a serialized Engine.
 table Engine {
   /// Contains several NetworkFilterList matching to different kinds of lists.
@@ -121,6 +133,10 @@ table Engine {
   unique_domains_hashes: [uint64] (required);
 
   cosmetic_filters: CosmeticFilters (required);
+
+  debug: bool;
+
+  source_info: [SourceInfo] (required);
 }
 
 root_type Engine;

--- a/src/flatbuffers/fb_network_filter.fbs
+++ b/src/flatbuffers/fb_network_filter.fbs
@@ -30,8 +30,8 @@ table NetworkFilter {
 
   // Debug mode only
   raw_line: string;
-  source_index: int32 = -1;
-  line_number: int32 = -1;
+  source_index: uint32 = 4294967295; // 0xFFFFFFFF
+  line_number: uint32 = 4294967295;  // 0xFFFFFFFF
 }
 
 table NetworkFilterList {

--- a/src/flatbuffers/fb_network_filter_generated.rs
+++ b/src/flatbuffers/fb_network_filter_generated.rs
@@ -44,6 +44,8 @@ pub mod fb {
         pub const VT_HOSTNAME: flatbuffers::VOffsetT = 16;
         pub const VT_TAG: flatbuffers::VOffsetT = 18;
         pub const VT_RAW_LINE: flatbuffers::VOffsetT = 20;
+        pub const VT_SOURCE_INDEX: flatbuffers::VOffsetT = 22;
+        pub const VT_LINE_NUMBER: flatbuffers::VOffsetT = 24;
 
         #[inline]
         pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -60,6 +62,8 @@ pub mod fb {
             args: &'args NetworkFilterArgs<'args>,
         ) -> flatbuffers::WIPOffset<NetworkFilter<'bldr>> {
             let mut builder = NetworkFilterBuilder::new(_fbb);
+            builder.add_line_number(args.line_number);
+            builder.add_source_index(args.source_index);
             if let Some(x) = args.raw_line {
                 builder.add_raw_line(x);
             }
@@ -100,6 +104,8 @@ pub mod fb {
             let hostname = self.hostname().map(|x| x.to_string());
             let tag = self.tag().map(|x| x.to_string());
             let raw_line = self.raw_line().map(|x| x.to_string());
+            let source_index = self.source_index();
+            let line_number = self.line_number();
             NetworkFilterT {
                 mask,
                 opt_domains,
@@ -110,6 +116,8 @@ pub mod fb {
                 hostname,
                 tag,
                 raw_line,
+                source_index,
+                line_number,
             }
         }
 
@@ -220,6 +228,28 @@ pub mod fb {
                     .get::<flatbuffers::ForwardsUOffset<&str>>(NetworkFilter::VT_RAW_LINE, None)
             }
         }
+        #[inline]
+        pub fn source_index(&self) -> i32 {
+            // Safety:
+            // Created from valid Table for this object
+            // which contains a valid value in this slot
+            unsafe {
+                self._tab
+                    .get::<i32>(NetworkFilter::VT_SOURCE_INDEX, Some(-1))
+                    .unwrap()
+            }
+        }
+        #[inline]
+        pub fn line_number(&self) -> i32 {
+            // Safety:
+            // Created from valid Table for this object
+            // which contains a valid value in this slot
+            unsafe {
+                self._tab
+                    .get::<i32>(NetworkFilter::VT_LINE_NUMBER, Some(-1))
+                    .unwrap()
+            }
+        }
     }
 
     impl flatbuffers::Verifiable for NetworkFilter<'_> {
@@ -265,6 +295,8 @@ pub mod fb {
                     Self::VT_RAW_LINE,
                     false,
                 )?
+                .visit_field::<i32>("source_index", Self::VT_SOURCE_INDEX, false)?
+                .visit_field::<i32>("line_number", Self::VT_LINE_NUMBER, false)?
                 .finish();
             Ok(())
         }
@@ -281,6 +313,8 @@ pub mod fb {
         pub hostname: Option<flatbuffers::WIPOffset<&'a str>>,
         pub tag: Option<flatbuffers::WIPOffset<&'a str>>,
         pub raw_line: Option<flatbuffers::WIPOffset<&'a str>>,
+        pub source_index: i32,
+        pub line_number: i32,
     }
     impl<'a> Default for NetworkFilterArgs<'a> {
         #[inline]
@@ -295,6 +329,8 @@ pub mod fb {
                 hostname: None,
                 tag: None,
                 raw_line: None,
+                source_index: -1,
+                line_number: -1,
             }
         }
     }
@@ -375,6 +411,16 @@ pub mod fb {
             );
         }
         #[inline]
+        pub fn add_source_index(&mut self, source_index: i32) {
+            self.fbb_
+                .push_slot::<i32>(NetworkFilter::VT_SOURCE_INDEX, source_index, -1);
+        }
+        #[inline]
+        pub fn add_line_number(&mut self, line_number: i32) {
+            self.fbb_
+                .push_slot::<i32>(NetworkFilter::VT_LINE_NUMBER, line_number, -1);
+        }
+        #[inline]
         pub fn new(
             _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
         ) -> NetworkFilterBuilder<'a, 'b, A> {
@@ -403,6 +449,8 @@ pub mod fb {
             ds.field("hostname", &self.hostname());
             ds.field("tag", &self.tag());
             ds.field("raw_line", &self.raw_line());
+            ds.field("source_index", &self.source_index());
+            ds.field("line_number", &self.line_number());
             ds.finish()
         }
     }
@@ -418,6 +466,8 @@ pub mod fb {
         pub hostname: Option<String>,
         pub tag: Option<String>,
         pub raw_line: Option<String>,
+        pub source_index: i32,
+        pub line_number: i32,
     }
     impl Default for NetworkFilterT {
         fn default() -> Self {
@@ -431,6 +481,8 @@ pub mod fb {
                 hostname: None,
                 tag: None,
                 raw_line: None,
+                source_index: -1,
+                line_number: -1,
             }
         }
     }
@@ -451,6 +503,8 @@ pub mod fb {
             let hostname = self.hostname.as_ref().map(|x| _fbb.create_string(x));
             let tag = self.tag.as_ref().map(|x| _fbb.create_string(x));
             let raw_line = self.raw_line.as_ref().map(|x| _fbb.create_string(x));
+            let source_index = self.source_index;
+            let line_number = self.line_number;
             NetworkFilter::create(
                 _fbb,
                 &NetworkFilterArgs {
@@ -463,6 +517,8 @@ pub mod fb {
                     hostname,
                     tag,
                     raw_line,
+                    source_index,
+                    line_number,
                 },
             )
         }
@@ -2090,6 +2146,326 @@ pub mod fb {
             )
         }
     }
+    pub enum SourceInfoOffset {}
+    #[derive(Copy, Clone, PartialEq)]
+
+    pub struct SourceInfo<'a> {
+        pub _tab: flatbuffers::Table<'a>,
+    }
+
+    impl<'a> flatbuffers::Follow<'a> for SourceInfo<'a> {
+        type Inner = SourceInfo<'a>;
+        #[inline]
+        unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+            Self {
+                _tab: unsafe { flatbuffers::Table::new(buf, loc) },
+            }
+        }
+    }
+
+    impl<'a> SourceInfo<'a> {
+        pub const VT_TITLE: flatbuffers::VOffsetT = 4;
+        pub const VT_HOMEPAGE: flatbuffers::VOffsetT = 6;
+        pub const VT_NETWORK_FILTER_COUNT: flatbuffers::VOffsetT = 8;
+        pub const VT_COSMETIC_FILTER_COUNT: flatbuffers::VOffsetT = 10;
+        pub const VT_PARSE_ERROR: flatbuffers::VOffsetT = 12;
+        pub const VT_INVALID_LINES: flatbuffers::VOffsetT = 14;
+
+        #[inline]
+        pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+            SourceInfo { _tab: table }
+        }
+        #[allow(unused_mut)]
+        pub fn create<
+            'bldr: 'args,
+            'args: 'mut_bldr,
+            'mut_bldr,
+            A: flatbuffers::Allocator + 'bldr,
+        >(
+            _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+            args: &'args SourceInfoArgs<'args>,
+        ) -> flatbuffers::WIPOffset<SourceInfo<'bldr>> {
+            let mut builder = SourceInfoBuilder::new(_fbb);
+            if let Some(x) = args.invalid_lines {
+                builder.add_invalid_lines(x);
+            }
+            builder.add_parse_error(args.parse_error);
+            builder.add_cosmetic_filter_count(args.cosmetic_filter_count);
+            builder.add_network_filter_count(args.network_filter_count);
+            if let Some(x) = args.homepage {
+                builder.add_homepage(x);
+            }
+            if let Some(x) = args.title {
+                builder.add_title(x);
+            }
+            builder.finish()
+        }
+
+        pub fn unpack(&self) -> SourceInfoT {
+            let title = self.title().map(|x| x.to_string());
+            let homepage = self.homepage().map(|x| x.to_string());
+            let network_filter_count = self.network_filter_count();
+            let cosmetic_filter_count = self.cosmetic_filter_count();
+            let parse_error = self.parse_error();
+            let invalid_lines = self
+                .invalid_lines()
+                .map(|x| x.iter().map(|s| s.to_string()).collect());
+            SourceInfoT {
+                title,
+                homepage,
+                network_filter_count,
+                cosmetic_filter_count,
+                parse_error,
+                invalid_lines,
+            }
+        }
+
+        #[inline]
+        pub fn title(&self) -> Option<&'a str> {
+            // Safety:
+            // Created from valid Table for this object
+            // which contains a valid value in this slot
+            unsafe {
+                self._tab
+                    .get::<flatbuffers::ForwardsUOffset<&str>>(SourceInfo::VT_TITLE, None)
+            }
+        }
+        #[inline]
+        pub fn homepage(&self) -> Option<&'a str> {
+            // Safety:
+            // Created from valid Table for this object
+            // which contains a valid value in this slot
+            unsafe {
+                self._tab
+                    .get::<flatbuffers::ForwardsUOffset<&str>>(SourceInfo::VT_HOMEPAGE, None)
+            }
+        }
+        #[inline]
+        pub fn network_filter_count(&self) -> i32 {
+            // Safety:
+            // Created from valid Table for this object
+            // which contains a valid value in this slot
+            unsafe {
+                self._tab
+                    .get::<i32>(SourceInfo::VT_NETWORK_FILTER_COUNT, Some(0))
+                    .unwrap()
+            }
+        }
+        #[inline]
+        pub fn cosmetic_filter_count(&self) -> i32 {
+            // Safety:
+            // Created from valid Table for this object
+            // which contains a valid value in this slot
+            unsafe {
+                self._tab
+                    .get::<i32>(SourceInfo::VT_COSMETIC_FILTER_COUNT, Some(0))
+                    .unwrap()
+            }
+        }
+        #[inline]
+        pub fn parse_error(&self) -> i32 {
+            // Safety:
+            // Created from valid Table for this object
+            // which contains a valid value in this slot
+            unsafe {
+                self._tab
+                    .get::<i32>(SourceInfo::VT_PARSE_ERROR, Some(0))
+                    .unwrap()
+            }
+        }
+        #[inline]
+        pub fn invalid_lines(
+            &self,
+        ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<&'a str>>> {
+            // Safety:
+            // Created from valid Table for this object
+            // which contains a valid value in this slot
+            unsafe {
+                self._tab.get::<flatbuffers::ForwardsUOffset<
+                    flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<&'a str>>,
+                >>(SourceInfo::VT_INVALID_LINES, None)
+            }
+        }
+    }
+
+    impl flatbuffers::Verifiable for SourceInfo<'_> {
+        #[inline]
+        fn run_verifier(
+            v: &mut flatbuffers::Verifier,
+            pos: usize,
+        ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+            use self::flatbuffers::Verifiable;
+            v.visit_table(pos)?
+                .visit_field::<flatbuffers::ForwardsUOffset<&str>>("title", Self::VT_TITLE, false)?
+                .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
+                    "homepage",
+                    Self::VT_HOMEPAGE,
+                    false,
+                )?
+                .visit_field::<i32>("network_filter_count", Self::VT_NETWORK_FILTER_COUNT, false)?
+                .visit_field::<i32>(
+                    "cosmetic_filter_count",
+                    Self::VT_COSMETIC_FILTER_COUNT,
+                    false,
+                )?
+                .visit_field::<i32>("parse_error", Self::VT_PARSE_ERROR, false)?
+                .visit_field::<flatbuffers::ForwardsUOffset<
+                    flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<&'_ str>>,
+                >>("invalid_lines", Self::VT_INVALID_LINES, false)?
+                .finish();
+            Ok(())
+        }
+    }
+    pub struct SourceInfoArgs<'a> {
+        pub title: Option<flatbuffers::WIPOffset<&'a str>>,
+        pub homepage: Option<flatbuffers::WIPOffset<&'a str>>,
+        pub network_filter_count: i32,
+        pub cosmetic_filter_count: i32,
+        pub parse_error: i32,
+        pub invalid_lines: Option<
+            flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<&'a str>>>,
+        >,
+    }
+    impl<'a> Default for SourceInfoArgs<'a> {
+        #[inline]
+        fn default() -> Self {
+            SourceInfoArgs {
+                title: None,
+                homepage: None,
+                network_filter_count: 0,
+                cosmetic_filter_count: 0,
+                parse_error: 0,
+                invalid_lines: None,
+            }
+        }
+    }
+
+    pub struct SourceInfoBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+        fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+        start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    }
+    impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> SourceInfoBuilder<'a, 'b, A> {
+        #[inline]
+        pub fn add_title(&mut self, title: flatbuffers::WIPOffset<&'b str>) {
+            self.fbb_
+                .push_slot_always::<flatbuffers::WIPOffset<_>>(SourceInfo::VT_TITLE, title);
+        }
+        #[inline]
+        pub fn add_homepage(&mut self, homepage: flatbuffers::WIPOffset<&'b str>) {
+            self.fbb_
+                .push_slot_always::<flatbuffers::WIPOffset<_>>(SourceInfo::VT_HOMEPAGE, homepage);
+        }
+        #[inline]
+        pub fn add_network_filter_count(&mut self, network_filter_count: i32) {
+            self.fbb_.push_slot::<i32>(
+                SourceInfo::VT_NETWORK_FILTER_COUNT,
+                network_filter_count,
+                0,
+            );
+        }
+        #[inline]
+        pub fn add_cosmetic_filter_count(&mut self, cosmetic_filter_count: i32) {
+            self.fbb_.push_slot::<i32>(
+                SourceInfo::VT_COSMETIC_FILTER_COUNT,
+                cosmetic_filter_count,
+                0,
+            );
+        }
+        #[inline]
+        pub fn add_parse_error(&mut self, parse_error: i32) {
+            self.fbb_
+                .push_slot::<i32>(SourceInfo::VT_PARSE_ERROR, parse_error, 0);
+        }
+        #[inline]
+        pub fn add_invalid_lines(
+            &mut self,
+            invalid_lines: flatbuffers::WIPOffset<
+                flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<&'b str>>,
+            >,
+        ) {
+            self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+                SourceInfo::VT_INVALID_LINES,
+                invalid_lines,
+            );
+        }
+        #[inline]
+        pub fn new(
+            _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+        ) -> SourceInfoBuilder<'a, 'b, A> {
+            let start = _fbb.start_table();
+            SourceInfoBuilder {
+                fbb_: _fbb,
+                start_: start,
+            }
+        }
+        #[inline]
+        pub fn finish(self) -> flatbuffers::WIPOffset<SourceInfo<'a>> {
+            let o = self.fbb_.end_table(self.start_);
+            flatbuffers::WIPOffset::new(o.value())
+        }
+    }
+
+    impl core::fmt::Debug for SourceInfo<'_> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            let mut ds = f.debug_struct("SourceInfo");
+            ds.field("title", &self.title());
+            ds.field("homepage", &self.homepage());
+            ds.field("network_filter_count", &self.network_filter_count());
+            ds.field("cosmetic_filter_count", &self.cosmetic_filter_count());
+            ds.field("parse_error", &self.parse_error());
+            ds.field("invalid_lines", &self.invalid_lines());
+            ds.finish()
+        }
+    }
+    #[non_exhaustive]
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct SourceInfoT {
+        pub title: Option<String>,
+        pub homepage: Option<String>,
+        pub network_filter_count: i32,
+        pub cosmetic_filter_count: i32,
+        pub parse_error: i32,
+        pub invalid_lines: Option<Vec<String>>,
+    }
+    impl Default for SourceInfoT {
+        fn default() -> Self {
+            Self {
+                title: None,
+                homepage: None,
+                network_filter_count: 0,
+                cosmetic_filter_count: 0,
+                parse_error: 0,
+                invalid_lines: None,
+            }
+        }
+    }
+    impl SourceInfoT {
+        pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
+            &self,
+            _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>,
+        ) -> flatbuffers::WIPOffset<SourceInfo<'b>> {
+            let title = self.title.as_ref().map(|x| _fbb.create_string(x));
+            let homepage = self.homepage.as_ref().map(|x| _fbb.create_string(x));
+            let network_filter_count = self.network_filter_count;
+            let cosmetic_filter_count = self.cosmetic_filter_count;
+            let parse_error = self.parse_error;
+            let invalid_lines = self.invalid_lines.as_ref().map(|x| {
+                let w: Vec<_> = x.iter().map(|s| _fbb.create_string(s)).collect();
+                _fbb.create_vector(&w)
+            });
+            SourceInfo::create(
+                _fbb,
+                &SourceInfoArgs {
+                    title,
+                    homepage,
+                    network_filter_count,
+                    cosmetic_filter_count,
+                    parse_error,
+                    invalid_lines,
+                },
+            )
+        }
+    }
     pub enum EngineOffset {}
     #[derive(Copy, Clone, PartialEq)]
 
@@ -2112,6 +2488,8 @@ pub mod fb {
         pub const VT_NETWORK_RULES: flatbuffers::VOffsetT = 4;
         pub const VT_UNIQUE_DOMAINS_HASHES: flatbuffers::VOffsetT = 6;
         pub const VT_COSMETIC_FILTERS: flatbuffers::VOffsetT = 8;
+        pub const VT_DEBUG: flatbuffers::VOffsetT = 10;
+        pub const VT_SOURCE_INFO: flatbuffers::VOffsetT = 12;
 
         #[inline]
         pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -2128,6 +2506,9 @@ pub mod fb {
             args: &'args EngineArgs<'args>,
         ) -> flatbuffers::WIPOffset<Engine<'bldr>> {
             let mut builder = EngineBuilder::new(_fbb);
+            if let Some(x) = args.source_info {
+                builder.add_source_info(x);
+            }
             if let Some(x) = args.cosmetic_filters {
                 builder.add_cosmetic_filters(x);
             }
@@ -2137,6 +2518,7 @@ pub mod fb {
             if let Some(x) = args.network_rules {
                 builder.add_network_rules(x);
             }
+            builder.add_debug(args.debug);
             builder.finish()
         }
 
@@ -2153,10 +2535,17 @@ pub mod fb {
                 let x = self.cosmetic_filters();
                 Box::new(x.unpack())
             };
+            let debug = self.debug();
+            let source_info = {
+                let x = self.source_info();
+                x.iter().map(|t| t.unpack()).collect()
+            };
             EngineT {
                 network_rules,
                 unique_domains_hashes,
                 cosmetic_filters,
+                debug,
+                source_info,
             }
         }
 
@@ -2207,6 +2596,32 @@ pub mod fb {
                     .unwrap()
             }
         }
+        #[inline]
+        pub fn debug(&self) -> bool {
+            // Safety:
+            // Created from valid Table for this object
+            // which contains a valid value in this slot
+            unsafe {
+                self._tab
+                    .get::<bool>(Engine::VT_DEBUG, Some(false))
+                    .unwrap()
+            }
+        }
+        #[inline]
+        pub fn source_info(
+            &self,
+        ) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<SourceInfo<'a>>> {
+            // Safety:
+            // Created from valid Table for this object
+            // which contains a valid value in this slot
+            unsafe {
+                self._tab
+                    .get::<flatbuffers::ForwardsUOffset<
+                        flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<SourceInfo>>,
+                    >>(Engine::VT_SOURCE_INFO, None)
+                    .unwrap()
+            }
+        }
     }
 
     impl flatbuffers::Verifiable for Engine<'_> {
@@ -2230,6 +2645,10 @@ pub mod fb {
                     Self::VT_COSMETIC_FILTERS,
                     true,
                 )?
+                .visit_field::<bool>("debug", Self::VT_DEBUG, false)?
+                .visit_field::<flatbuffers::ForwardsUOffset<
+                    flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<SourceInfo>>,
+                >>("source_info", Self::VT_SOURCE_INFO, true)?
                 .finish();
             Ok(())
         }
@@ -2242,6 +2661,12 @@ pub mod fb {
         >,
         pub unique_domains_hashes: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u64>>>,
         pub cosmetic_filters: Option<flatbuffers::WIPOffset<CosmeticFilters<'a>>>,
+        pub debug: bool,
+        pub source_info: Option<
+            flatbuffers::WIPOffset<
+                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<SourceInfo<'a>>>,
+            >,
+        >,
     }
     impl<'a> Default for EngineArgs<'a> {
         #[inline]
@@ -2250,6 +2675,8 @@ pub mod fb {
                 network_rules: None,         // required field
                 unique_domains_hashes: None, // required field
                 cosmetic_filters: None,      // required field
+                debug: false,
+                source_info: None, // required field
             }
         }
     }
@@ -2293,6 +2720,20 @@ pub mod fb {
                 );
         }
         #[inline]
+        pub fn add_debug(&mut self, debug: bool) {
+            self.fbb_.push_slot::<bool>(Engine::VT_DEBUG, debug, false);
+        }
+        #[inline]
+        pub fn add_source_info(
+            &mut self,
+            source_info: flatbuffers::WIPOffset<
+                flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<SourceInfo<'b>>>,
+            >,
+        ) {
+            self.fbb_
+                .push_slot_always::<flatbuffers::WIPOffset<_>>(Engine::VT_SOURCE_INFO, source_info);
+        }
+        #[inline]
         pub fn new(
             _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
         ) -> EngineBuilder<'a, 'b, A> {
@@ -2311,6 +2752,7 @@ pub mod fb {
                 .required(o, Engine::VT_UNIQUE_DOMAINS_HASHES, "unique_domains_hashes");
             self.fbb_
                 .required(o, Engine::VT_COSMETIC_FILTERS, "cosmetic_filters");
+            self.fbb_.required(o, Engine::VT_SOURCE_INFO, "source_info");
             flatbuffers::WIPOffset::new(o.value())
         }
     }
@@ -2321,6 +2763,8 @@ pub mod fb {
             ds.field("network_rules", &self.network_rules());
             ds.field("unique_domains_hashes", &self.unique_domains_hashes());
             ds.field("cosmetic_filters", &self.cosmetic_filters());
+            ds.field("debug", &self.debug());
+            ds.field("source_info", &self.source_info());
             ds.finish()
         }
     }
@@ -2330,6 +2774,8 @@ pub mod fb {
         pub network_rules: Vec<NetworkFilterListT>,
         pub unique_domains_hashes: Vec<u64>,
         pub cosmetic_filters: Box<CosmeticFiltersT>,
+        pub debug: bool,
+        pub source_info: Vec<SourceInfoT>,
     }
     impl Default for EngineT {
         fn default() -> Self {
@@ -2337,6 +2783,8 @@ pub mod fb {
                 network_rules: Default::default(),
                 unique_domains_hashes: Default::default(),
                 cosmetic_filters: Default::default(),
+                debug: false,
+                source_info: Default::default(),
             }
         }
     }
@@ -2358,12 +2806,20 @@ pub mod fb {
                 let x = &self.cosmetic_filters;
                 x.pack(_fbb)
             });
+            let debug = self.debug;
+            let source_info = Some({
+                let x = &self.source_info;
+                let w: Vec<_> = x.iter().map(|t| t.pack(_fbb)).collect();
+                _fbb.create_vector(&w)
+            });
             Engine::create(
                 _fbb,
                 &EngineArgs {
                     network_rules,
                     unique_domains_hashes,
                     cosmetic_filters,
+                    debug,
+                    source_info,
                 },
             )
         }

--- a/src/flatbuffers/fb_network_filter_generated.rs
+++ b/src/flatbuffers/fb_network_filter_generated.rs
@@ -229,24 +229,24 @@ pub mod fb {
             }
         }
         #[inline]
-        pub fn source_index(&self) -> i32 {
+        pub fn source_index(&self) -> u32 {
             // Safety:
             // Created from valid Table for this object
             // which contains a valid value in this slot
             unsafe {
                 self._tab
-                    .get::<i32>(NetworkFilter::VT_SOURCE_INDEX, Some(-1))
+                    .get::<u32>(NetworkFilter::VT_SOURCE_INDEX, Some(4294967295))
                     .unwrap()
             }
         }
         #[inline]
-        pub fn line_number(&self) -> i32 {
+        pub fn line_number(&self) -> u32 {
             // Safety:
             // Created from valid Table for this object
             // which contains a valid value in this slot
             unsafe {
                 self._tab
-                    .get::<i32>(NetworkFilter::VT_LINE_NUMBER, Some(-1))
+                    .get::<u32>(NetworkFilter::VT_LINE_NUMBER, Some(4294967295))
                     .unwrap()
             }
         }
@@ -295,8 +295,8 @@ pub mod fb {
                     Self::VT_RAW_LINE,
                     false,
                 )?
-                .visit_field::<i32>("source_index", Self::VT_SOURCE_INDEX, false)?
-                .visit_field::<i32>("line_number", Self::VT_LINE_NUMBER, false)?
+                .visit_field::<u32>("source_index", Self::VT_SOURCE_INDEX, false)?
+                .visit_field::<u32>("line_number", Self::VT_LINE_NUMBER, false)?
                 .finish();
             Ok(())
         }
@@ -313,8 +313,8 @@ pub mod fb {
         pub hostname: Option<flatbuffers::WIPOffset<&'a str>>,
         pub tag: Option<flatbuffers::WIPOffset<&'a str>>,
         pub raw_line: Option<flatbuffers::WIPOffset<&'a str>>,
-        pub source_index: i32,
-        pub line_number: i32,
+        pub source_index: u32,
+        pub line_number: u32,
     }
     impl<'a> Default for NetworkFilterArgs<'a> {
         #[inline]
@@ -329,8 +329,8 @@ pub mod fb {
                 hostname: None,
                 tag: None,
                 raw_line: None,
-                source_index: -1,
-                line_number: -1,
+                source_index: 4294967295,
+                line_number: 4294967295,
             }
         }
     }
@@ -411,14 +411,14 @@ pub mod fb {
             );
         }
         #[inline]
-        pub fn add_source_index(&mut self, source_index: i32) {
+        pub fn add_source_index(&mut self, source_index: u32) {
             self.fbb_
-                .push_slot::<i32>(NetworkFilter::VT_SOURCE_INDEX, source_index, -1);
+                .push_slot::<u32>(NetworkFilter::VT_SOURCE_INDEX, source_index, 4294967295);
         }
         #[inline]
-        pub fn add_line_number(&mut self, line_number: i32) {
+        pub fn add_line_number(&mut self, line_number: u32) {
             self.fbb_
-                .push_slot::<i32>(NetworkFilter::VT_LINE_NUMBER, line_number, -1);
+                .push_slot::<u32>(NetworkFilter::VT_LINE_NUMBER, line_number, 4294967295);
         }
         #[inline]
         pub fn new(
@@ -466,8 +466,8 @@ pub mod fb {
         pub hostname: Option<String>,
         pub tag: Option<String>,
         pub raw_line: Option<String>,
-        pub source_index: i32,
-        pub line_number: i32,
+        pub source_index: u32,
+        pub line_number: u32,
     }
     impl Default for NetworkFilterT {
         fn default() -> Self {
@@ -481,8 +481,8 @@ pub mod fb {
                 hostname: None,
                 tag: None,
                 raw_line: None,
-                source_index: -1,
-                line_number: -1,
+                source_index: 4294967295,
+                line_number: 4294967295,
             }
         }
     }

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -20,6 +20,15 @@ pub enum RuleTypes {
     CosmeticOnly,
 }
 
+/// Recorded information about a filter list that has been added to a [FilterSet].
+#[derive(Default, Clone, Serialize)]
+pub struct AddedFiltersRecord {
+    /// An index that the [crate::Engine] will use to keep track of this source
+    pub source_index: usize,
+    /// Any header information parsed from the list itself
+    pub metadata: FilterListMetadata,
+}
+
 impl RuleTypes {
     pub fn loads_network_rules(&self) -> bool {
         matches!(self, Self::All | Self::NetworkOnly)
@@ -219,7 +228,7 @@ impl FilterSet {
     /// Adds the contents of an entire filter list to this `FilterSet`. Filters that cannot be
     /// parsed successfully are ignored. Returns any discovered metadata about the list of rules
     /// added.
-    pub fn add_filter_list(&mut self, list_text: String, opts: ParseOptions) -> FilterListMetadata {
+    pub fn add_filter_list(&mut self, list_text: String, opts: ParseOptions) -> AddedFiltersRecord {
         let metadata = match opts.format {
             FilterFormat::Standard => read_list_metadata(&list_text),
             FilterFormat::Hosts => FilterListMetadata::default(),
@@ -229,7 +238,10 @@ impl FilterSet {
             parse_options: opts,
             metadata: metadata.clone(),
         });
-        metadata
+        AddedFiltersRecord {
+            source_index: self.list_sources.len() - 1,
+            metadata,
+        }
     }
 
     /// Adds a collection of filter rules to this `FilterSet`. Filters that cannot be parsed

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -73,6 +73,7 @@ impl Default for ParseOptions {
 pub(crate) struct ListSource {
     pub(crate) list_text: String,
     pub(crate) parse_options: ParseOptions,
+    pub(crate) metadata: FilterListMetadata,
 }
 
 /// Manages a set of rules to be added to an [`crate::Engine`].
@@ -122,7 +123,7 @@ impl Default for FilterSet {
 }
 
 /// Corresponds to the `expires` field of `FilterListMetadata`.
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Debug, PartialEq, Clone, Serialize)]
 pub enum ExpiresInterval {
     Hours(u16),
     Days(u8),
@@ -165,7 +166,7 @@ impl TryFrom<&str> for ExpiresInterval {
 
 /// Includes information about any "special comments" as described by
 /// <https://help.eyeo.com/adblockplus/how-to-write-filters#special-comments>
-#[derive(Default, Serialize)]
+#[derive(Default, Clone, Serialize)]
 pub struct FilterListMetadata {
     /// `! Homepage: http://example.com` - This comment determines which webpage should be linked
     /// as filter list homepage.
@@ -226,6 +227,7 @@ impl FilterSet {
         self.list_sources.push(ListSource {
             list_text,
             parse_options: opts,
+            metadata: metadata.clone(),
         });
         metadata
     }
@@ -246,6 +248,7 @@ impl FilterSet {
         self.list_sources.push(ListSource {
             list_text,
             parse_options: opts,
+            metadata: FilterListMetadata::default(),
         });
     }
 

--- a/src/network_filter_list.rs
+++ b/src/network_filter_list.rs
@@ -7,35 +7,39 @@ use flatbuffers::ForwardsUOffset;
 use crate::filters::fb_network::FlatNetworkFilter;
 use crate::filters::filter_data_context::FilterDataContext;
 use crate::filters::flatbuffer_generated::fb;
-use crate::filters::network::{NetworkFilter, NetworkFilterMask, NetworkMatchable};
+use crate::filters::network::{NetworkFilterMask, NetworkMatchable};
 use crate::flatbuffers::containers::flat_multimap::FlatMultiMapView;
 use crate::flatbuffers::unsafe_tools::fb_vector_to_slice;
 use crate::regex_manager::RegexManager;
 use crate::request::Request;
 use crate::utils::{to_short_hash, ShortHash};
 
-/// Holds relevant information from a single matchin gnetwork filter rule as a result of querying a
-/// [NetworkFilterList] for a given request.
-pub struct CheckResult {
-    pub filter_mask: NetworkFilterMask,
-    pub modifier_option: Option<String>,
-    pub raw_line: Option<String>,
+pub struct CheckResultDebugData {
+    pub raw_line: String,
+    pub source_index: i32,
+    pub line_number: i32,
 }
 
-impl From<&NetworkFilter<'_>> for CheckResult {
-    fn from(filter: &NetworkFilter) -> Self {
-        Self {
-            filter_mask: filter.mask,
-            modifier_option: filter.modifier_option.map(|s| s.to_string()),
-            raw_line: filter.raw_line.as_ref().map(|line| line.to_string()),
-        }
-    }
+/// Holds relevant information from a single matchin gnetwork filter rule as a result of querying a
+/// [NetworkFilterList] for a given request.
+pub(crate) struct CheckResult {
+    pub filter_mask: NetworkFilterMask,
+    pub modifier_option: Option<String>,
+    pub debug_data: Option<CheckResultDebugData>,
 }
 
 impl fmt::Display for CheckResult {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        if let Some(ref raw_line) = self.raw_line {
-            write!(f, "{raw_line}")
+        if let Some(ref debug_data) = self.debug_data {
+            if debug_data.source_index != -1 {
+                write!(
+                    f,
+                    "{}:{}: {}",
+                    debug_data.source_index, debug_data.line_number, debug_data.raw_line
+                )
+            } else {
+                write!(f, "x:x: {}", debug_data.raw_line)
+            }
         } else {
             write!(f, "{}", self.filter_mask)
         }
@@ -88,10 +92,19 @@ impl NetworkFilterList<'_> {
                     if filter.matches(request, regex_manager)
                         && filter.tag().is_none_or(|t| active_tags.contains(t))
                     {
+                        let debug_data = if self.filter_data_context.debug {
+                            Some(CheckResultDebugData {
+                                raw_line: filter.raw_line(),
+                                source_index: filter.source_index(),
+                                line_number: filter.line_number(),
+                            })
+                        } else {
+                            None
+                        };
                         return Some(CheckResult {
                             filter_mask: filter.mask,
                             modifier_option: filter.modifier_option(),
-                            raw_line: filter.raw_line(),
+                            debug_data,
                         });
                     }
                 }
@@ -130,10 +143,19 @@ impl NetworkFilterList<'_> {
                     if filter.matches(request, regex_manager)
                         && filter.tag().is_none_or(|t| active_tags.contains(t))
                     {
+                        let debug_data = if self.filter_data_context.debug {
+                            Some(CheckResultDebugData {
+                                raw_line: filter.raw_line(),
+                                source_index: filter.source_index(),
+                                line_number: filter.line_number(),
+                            })
+                        } else {
+                            None
+                        };
                         filters.push(CheckResult {
                             filter_mask: filter.mask,
                             modifier_option: filter.modifier_option(),
-                            raw_line: filter.raw_line(),
+                            debug_data,
                         });
                     }
                 }

--- a/src/network_filter_list.rs
+++ b/src/network_filter_list.rs
@@ -16,8 +16,8 @@ use crate::utils::{to_short_hash, ShortHash};
 
 pub struct CheckResultDebugData {
     pub raw_line: String,
-    pub source_index: i32,
-    pub line_number: i32,
+    pub source_index: Option<u32>,
+    pub line_number: Option<u32>,
 }
 
 /// Holds relevant information from a single matchin gnetwork filter rule as a result of querying a
@@ -31,11 +31,13 @@ pub(crate) struct CheckResult {
 impl fmt::Display for CheckResult {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         if let Some(ref debug_data) = self.debug_data {
-            if debug_data.source_index != -1 {
+            if let (Some(source_index), Some(line_number)) =
+                (debug_data.source_index, debug_data.line_number)
+            {
                 write!(
                     f,
                     "{}:{}: {}",
-                    debug_data.source_index, debug_data.line_number, debug_data.raw_line
+                    source_index, line_number, debug_data.raw_line
                 )
             } else {
                 write!(f, "x:x: {}", debug_data.raw_line)

--- a/tests/legacy_harness.rs
+++ b/tests/legacy_harness.rs
@@ -1010,7 +1010,7 @@ mod legacy_misc_tests {
         let matched_filter = checked.filter.unwrap();
         assert_eq!(
             matched_filter,
-            "||googlesyndication.com/safeframe/$third-party"
+            "0:0: ||googlesyndication.com/safeframe/$third-party"
         );
 
         // Test when no filter is found, returns None
@@ -1055,10 +1055,10 @@ mod legacy_misc_tests {
         let matched_filter = checked.filter.unwrap();
         assert_eq!(
             matched_filter,
-            "||googlesyndication.com/safeframe/$third-party"
+            "0:0: ||googlesyndication.com/safeframe/$third-party"
         );
         let matched_exception = checked.exception.unwrap();
-        assert_eq!(matched_exception, "@@safeframe");
+        assert_eq!(matched_exception, "x:x: @@safeframe");
     }
 
     #[test]
@@ -1074,7 +1074,7 @@ mod legacy_misc_tests {
         assert!(checked.matched);
         assert!(checked.filter.is_some(), "Expected filter to match");
         let matched_filter = checked.filter.unwrap();
-        assert_eq!(matched_filter, "||brianbondy.com^$important");
+        assert_eq!(matched_filter, "0:0: ||brianbondy.com^$important");
         assert!(
             checked.exception.is_none(),
             "Expected no exception to match"

--- a/tests/unit/blocker.rs
+++ b/tests/unit/blocker.rs
@@ -82,7 +82,7 @@ mod blocker_tests {
         );
         assert_eq!(
             matched_rule.exception,
-            Some("@@||imdb-video.media-imdb.com^$domain=imdb.com".to_string())
+            Some("0:1: @@||imdb-video.media-imdb.com^$domain=imdb.com".to_string())
         );
     }
 
@@ -114,7 +114,8 @@ mod blocker_tests {
         assert_eq!(
             matched_rule.exception,
             Some(
-                "@@||imdb-video.media-imdb.com^$domain=imdb.com,redirect=noop-0.1s.mp3".to_string()
+                "0:1: @@||imdb-video.media-imdb.com^$domain=imdb.com,redirect=noop-0.1s.mp3"
+                    .to_string()
             )
         );
     }

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -190,7 +190,7 @@ mod tests {
     fn deserialization_generate_simple() {
         let mut engine = Engine::new_with_list_text("ad-banner");
         let data = engine.serialize().to_vec();
-        const EXPECTED_HASH: u64 = 3613512756023067609;
+        const EXPECTED_HASH: u64 = 8140715178533393311;
         assert_eq!(hash(&data), EXPECTED_HASH, "{HASH_MISMATCH_MSG}");
         engine.deserialize(&data).unwrap();
     }
@@ -201,7 +201,7 @@ mod tests {
         let mut engine = Engine::new_with_list_text("ad-banner$tag=abc");
         engine.use_tags(&["abc"]);
         let data = engine.serialize().to_vec();
-        const EXPECTED_HASH: u64 = 8313881767139358102;
+        const EXPECTED_HASH: u64 = 11267534334233315862;
         assert_eq!(hash(&data), EXPECTED_HASH, "{HASH_MISMATCH_MSG}");
         engine.deserialize(&data).unwrap();
     }
@@ -243,11 +243,23 @@ mod tests {
                 high_bound,
                 debug_info.flatbuffer_size
             );
+
+            assert_eq!(debug_info.source_info.len(), 1);
+            assert_eq!(
+                debug_info.source_info[0].title,
+                Some("uBlock filters".to_string())
+            );
+            assert_eq!(
+                debug_info.source_info[0].homepage,
+                Some("https://github.com/uBlockOrigin/uAssets".to_string())
+            );
+            assert_eq!(debug_info.source_info[0].network_filter_count, 130790);
+            assert_eq!(debug_info.source_info[0].cosmetic_filter_count, 41855);
         }
         let expected_hash: u64 = if cfg!(feature = "css-validation") {
-            5221182588908584278
+            6040525197658541449
         } else {
-            1031226837485915423
+            18282889522068993308
         };
 
         assert_eq!(hash(&data), expected_hash, "{HASH_MISMATCH_MSG}");

--- a/tests/unit/lists.rs
+++ b/tests/unit/lists.rs
@@ -291,7 +291,11 @@ mod tests {
         .join("\n");
 
         let mut filter_set = FilterSet::new(false);
-        let metadata = filter_set.add_filter_list(list, ParseOptions::default());
+        let AddedFiltersRecord {
+            source_index,
+            metadata,
+        } = filter_set.add_filter_list(list, ParseOptions::default());
+        assert_eq!(source_index, 0);
 
         assert_eq!(metadata.title, Some("0131 Block List".to_string()));
         assert_eq!(
@@ -321,7 +325,11 @@ mod tests {
         .join("\n");
 
         let mut filter_set = FilterSet::new(false);
-        let metadata = filter_set.add_filter_list(list, ParseOptions::default());
+        let AddedFiltersRecord {
+            source_index,
+            metadata,
+        } = filter_set.add_filter_list(list, ParseOptions::default());
+        assert_eq!(source_index, 0);
 
         assert_eq!(metadata.title, Some("ABPVN Advanced".to_string()));
         assert_eq!(


### PR DESCRIPTION
The PR stores more data for debugging, especially if debug = true. It also introduces source_id to distinguish  different lists added to a single engine.
It stores:
* (always) list metadata for every source ;
* (always) counters (networks filters, cosmetic filters;
* (debug mode only) source_id + line number (expect optimizable rules);
* (debug mode only) the lines from lists we failed to parse.