### PR TITLE
Remove optimize param from Engine

### DIFF
--- a/benches/bench_cosmetic_matching.rs
+++ b/benches/bench_cosmetic_matching.rs
@@ -1,3 +1,4 @@
+use adblock::lists::FilterSet;
 use adblock::Engine;
 use criterion::*;
 
@@ -10,7 +11,9 @@ pub fn make_engine() -> Engine {
     let rules = test_utils::rules_from_lists(["data/brave/brave-main-list.txt"]);
     let resource_json = std::fs::read_to_string("data/brave/brave-resources.json").unwrap();
     let resource_list: Vec<Resource> = serde_json::from_str(&resource_json).unwrap();
-    let mut engine = Engine::new_with_list_text_parametrised(rules, Default::default(), true, true);
+    let mut filter_set = FilterSet::new(true);
+    filter_set.add_filter_list(rules, Default::default());
+    let mut engine = Engine::new_with_filter_set(filter_set);
     engine.use_resources(resource_list);
     engine
 }

--- a/benches/bench_matching.rs
+++ b/benches/bench_matching.rs
@@ -107,17 +107,17 @@ fn rule_match(c: &mut Criterion) {
             "data/easylist.to/easylist/easylist.txt",
             "data/easylist.to/easylist/easyprivacy.txt",
         ]);
-        let engine = Engine::new_with_list_text(rules, Default::default());
+        let engine = Engine::new_with_list_text(rules);
         b.iter(|| bench_rule_matching(&engine, &elep_req))
     });
     group.bench_function("easylist", move |b| {
         let rules = rules_from_lists(["data/easylist.to/easylist/easylist.txt"]);
-        let engine = Engine::new_with_list_text(rules, Default::default());
+        let engine = Engine::new_with_list_text(rules);
         b.iter(|| bench_rule_matching(&engine, &el_req))
     });
     group.bench_function("slimlist", move |b| {
         let rules = rules_from_lists(["data/slim-list.txt"]);
-        let engine = Engine::new_with_list_text(rules, Default::default());
+        let engine = Engine::new_with_list_text(rules);
         b.iter(|| bench_rule_matching(&engine, &slim_req))
     });
 
@@ -135,7 +135,7 @@ fn rule_match_parsed_el(c: &mut Criterion) {
         .filter_map(Result::ok)
         .collect();
     let requests_len = requests_parsed.len() as u64;
-    let engine = Engine::new_with_list_text(rules, Default::default());
+    let engine = Engine::new_with_list_text(rules);
 
     group.throughput(Throughput::Elements(requests_len));
     group.sample_size(10);
@@ -154,7 +154,7 @@ fn rule_match_parsed_elep_slimlist(c: &mut Criterion) {
         "data/easylist.to/easylist/easylist.txt",
         "data/easylist.to/easylist/easyprivacy.txt",
     ]);
-    let engine = Engine::new_with_list_text(full_rules, Default::default());
+    let engine = Engine::new_with_list_text(full_rules);
 
     let requests = load_requests();
     let requests_parsed: Vec<_> = requests
@@ -165,7 +165,7 @@ fn rule_match_parsed_elep_slimlist(c: &mut Criterion) {
     let requests_len = requests_parsed.len() as u64;
 
     let slim_rules = rules_from_lists(["data/slim-list.txt"]);
-    let slim_engine = Engine::new_with_list_text(slim_rules, Default::default());
+    let slim_engine = Engine::new_with_list_text(slim_rules);
 
     let requests_copy = load_requests();
     let requests_parsed_copy: Vec<_> = requests_copy
@@ -240,26 +240,22 @@ fn rule_match_browserlike_comparable(c: &mut Criterion) {
             "data/easylist.to/easylist/easylist.txt",
             "data/easylist.to/easylist/easyprivacy.txt",
         ]);
-        let engine =
-            Engine::new_with_list_text_parametrised(rules, Default::default(), false, true);
+        let engine = Engine::new_with_list_text(rules);
         b.iter(|| bench_rule_matching_browserlike(&engine, &requests))
     });
     group.bench_function("el", |b| {
         let rules = rules_from_lists(["data/easylist.to/easylist/easylist.txt"]);
-        let engine =
-            Engine::new_with_list_text_parametrised(rules, Default::default(), false, true);
+        let engine = Engine::new_with_list_text(rules);
         b.iter(|| bench_rule_matching_browserlike(&engine, &requests))
     });
     group.bench_function("slimlist", |b| {
         let rules = rules_from_lists(["data/slim-list.txt"]);
-        let engine =
-            Engine::new_with_list_text_parametrised(rules, Default::default(), false, true);
+        let engine = Engine::new_with_list_text(rules);
         b.iter(|| bench_rule_matching_browserlike(&engine, &requests))
     });
     group.bench_function("brave-list", |b| {
         let rules = rules_from_lists(["data/brave/brave-main-list.txt"]);
-        let engine =
-            Engine::new_with_list_text_parametrised(rules, Default::default(), false, true);
+        let engine = Engine::new_with_list_text(rules);
         b.iter(|| bench_rule_matching_browserlike(&engine, &requests))
     });
 
@@ -284,8 +280,7 @@ fn rule_match_first_request(c: &mut Criterion) {
             let mut total_time = std::time::Duration::ZERO;
             for _ in 0..iters {
                 let rules = rules_from_lists(["data/brave/brave-main-list.txt"]);
-                let engine =
-                    Engine::new_with_list_text_parametrised(rules, Default::default(), false, true);
+                let engine = Engine::new_with_list_text(rules);
 
                 // Measure only the matching time, skip setup and destruction
                 let start_time = std::time::Instant::now();

--- a/benches/bench_memory.rs
+++ b/benches/bench_memory.rs
@@ -244,7 +244,7 @@ fn bench_cb(
     let single_run = || {
         ALLOCATOR.reset();
         let rules = rules_from_lists(["data/brave/brave-main-list.txt"]);
-        let mut engine = Engine::new_with_list_text(rules, Default::default());
+        let mut engine = Engine::new_with_list_text(rules);
         let resource_json = std::fs::read_to_string("data/brave/brave-resources.json").unwrap();
         let resource_list: Vec<Resource> = serde_json::from_str(&resource_json).unwrap();
         std::mem::drop(resource_json);

--- a/benches/bench_redirect_performance.rs
+++ b/benches/bench_redirect_performance.rs
@@ -97,7 +97,7 @@ fn get_redirect_rules() -> Vec<NetworkFilter<'static>> {
 
 /// Loads the supplied rules, and the test set of resources, into a Engine
 fn get_preloaded_engine(rules: Vec<NetworkFilter>) -> Engine {
-    Engine::new_with_parsed_rules(rules, vec![], true)
+    Engine::new_with_parsed_rules(rules, vec![])
 }
 
 fn get_resources_for_filters(#[allow(unused)] filters: &[NetworkFilter]) -> Vec<Resource> {

--- a/benches/bench_rules.rs
+++ b/benches/bench_rules.rs
@@ -84,14 +84,14 @@ fn blocker_new(c: &mut Criterion) {
         "data/easylist.to/easylist/easyprivacy.txt",
     ]);
     let brave_list_rules = rules_from_lists(["data/brave/brave-main-list.txt"]);
-    let engine = Engine::new_with_list_text(brave_list_rules.clone(), Default::default());
+    let engine = Engine::new_with_list_text(brave_list_rules.clone());
     let engine_serialized = engine.serialize().to_vec();
 
     group.bench_function("el+ep", move |b| {
-        b.iter(|| Engine::new_with_list_text(easylist_rules.clone(), Default::default()))
+        b.iter(|| Engine::new_with_list_text(easylist_rules.clone()))
     });
     group.bench_function("brave-list", move |b| {
-        b.iter(|| Engine::new_with_list_text(brave_list_rules.clone(), Default::default()))
+        b.iter(|| Engine::new_with_list_text(brave_list_rules.clone()))
     });
     group.bench_function("brave-list-deserialize", move |b| {
         b.iter(|| {

--- a/benches/bench_serialization.rs
+++ b/benches/bench_serialization.rs
@@ -17,19 +17,19 @@ fn serialization(c: &mut Criterion) {
             "data/easylist.to/easylist/easyprivacy.txt",
         ]);
 
-        let engine = Engine::new_with_list_text(full_rules, Default::default());
+        let engine = Engine::new_with_list_text(full_rules);
         b.iter(|| assert!(!engine.serialize().to_vec().is_empty()))
     });
     group.bench_function("el", move |b| {
         let full_rules = rules_from_lists(["data/easylist.to/easylist/easylist.txt"]);
 
-        let engine = Engine::new_with_list_text(full_rules, Default::default());
+        let engine = Engine::new_with_list_text(full_rules);
         b.iter(|| assert!(!engine.serialize().to_vec().is_empty()))
     });
     group.bench_function("slimlist", move |b| {
         let full_rules = rules_from_lists(["data/slim-list.txt"]);
 
-        let engine = Engine::new_with_list_text(full_rules, Default::default());
+        let engine = Engine::new_with_list_text(full_rules);
         b.iter(|| assert!(!engine.serialize().to_vec().is_empty()))
     });
 
@@ -47,7 +47,7 @@ fn deserialization(c: &mut Criterion) {
             "data/easylist.to/easylist/easyprivacy.txt",
         ]);
 
-        let engine = Engine::new_with_list_text(full_rules, Default::default());
+        let engine = Engine::new_with_list_text(full_rules);
         let serialized = engine.serialize().to_vec();
 
         b.iter(|| {
@@ -58,7 +58,7 @@ fn deserialization(c: &mut Criterion) {
     group.bench_function("el", move |b| {
         let full_rules = rules_from_lists(["data/easylist.to/easylist/easylist.txt"]);
 
-        let engine = Engine::new_with_list_text(full_rules, Default::default());
+        let engine = Engine::new_with_list_text(full_rules);
         let serialized = engine.serialize().to_vec();
 
         b.iter(|| {
@@ -69,7 +69,7 @@ fn deserialization(c: &mut Criterion) {
     group.bench_function("slimlist", move |b| {
         let full_rules = rules_from_lists(["data/slim-list.txt"]);
 
-        let engine = Engine::new_with_list_text(full_rules, Default::default());
+        let engine = Engine::new_with_list_text(full_rules);
         let serialized = engine.serialize().to_vec();
 
         b.iter(|| {

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -17,7 +17,7 @@ fn main() {
     let mut filter_set = FilterSet::new(debug_info);
     filter_set.add_filter_list(rules, ParseOptions::default());
 
-    let engine = Engine::new_with_filter_set(filter_set, true);
+    let engine = Engine::new_with_filter_set(filter_set);
 
     let request = Request::new(
         "http://example.com/-advertisement-icon.",

--- a/examples/generate-dat.rs
+++ b/examples/generate-dat.rs
@@ -12,7 +12,7 @@ fn main() {
     .join("\n");
 
     // Serialize
-    let mut engine = Engine::new_with_list_text(rules, Default::default());
+    let mut engine = Engine::new_with_list_text(rules);
     engine.use_tags(&["twitter-embeds"]);
 
     let request = Request::new(

--- a/js/example.mjs
+++ b/js/example.mjs
@@ -23,7 +23,7 @@ const resources = adblockRust.uBlockResources(
     dataPath + 'test/fake-uBO-files/scriptlets.js'
 );
 
-const engine = new adblockRust.Engine(filterSet, true);
+const engine = new adblockRust.Engine(filterSet);
 engine.useResources(resources);
 
 // Simple match

--- a/js/src/lib.rs
+++ b/js/src/lib.rs
@@ -4,7 +4,7 @@ use adblock::resources::Resource;
 use adblock::Engine as EngineInternal;
 use neon::prelude::*;
 use neon::types::buffer::TypedArray as _;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::cell::RefCell;
 use std::path::Path;
 use std::sync::Mutex;
@@ -74,11 +74,6 @@ fn filter_rules_from_js<'a, C: Context<'a>>(
         return Ok(parts.join("\n"));
     }
     json_ffi::from_js(cx, input)
-}
-
-#[derive(Serialize, Deserialize)]
-struct EngineOptions {
-    pub optimize: Option<bool>,
 }
 
 #[derive(Default)]
@@ -164,19 +159,11 @@ fn engine_constructor(mut cx: FunctionContext) -> JsResult<JsBox<Engine>> {
     let rules = cx.argument::<JsBox<FilterSet>>(0)?;
     let rules = rules.0.borrow().clone();
 
-    let engine_internal = match cx.argument_opt(1) {
-        Some(arg) => {
-            let optimize = match arg.downcast::<JsBoolean, _>(&mut cx) {
-                Ok(b) => b.value(&mut cx),
-                Err(_) => {
-                    let config = json_ffi::from_js::<_, EngineOptions>(&mut cx, arg)?;
-                    config.optimize.unwrap_or(true)
-                }
-            };
-            EngineInternal::new_with_filter_set(rules, optimize)
-        }
-        None => EngineInternal::new_with_filter_set(rules, true),
-    };
+    // Legacy second argument (optimize boolean or options object) is ignored; optimization
+    // follows FilterSet.debug (!debug).
+    let _ = cx.argument_opt(1);
+
+    let engine_internal = EngineInternal::new_with_filter_set(rules);
     Ok(cx.boxed(Engine(Mutex::new(engine_internal))))
 }
 

--- a/js/src/lib.rs
+++ b/js/src/lib.rs
@@ -159,9 +159,17 @@ fn engine_constructor(mut cx: FunctionContext) -> JsResult<JsBox<Engine>> {
     let rules = cx.argument::<JsBox<FilterSet>>(0)?;
     let rules = rules.0.borrow().clone();
 
-    // Legacy second argument (optimize boolean or options object) is ignored; optimization
-    // follows FilterSet.debug (!debug).
-    let _ = cx.argument_opt(1);
+    // The legacy second argument (optimize boolean or options object) is no longer used:
+    // optimization is always enabled via `new_with_filter_set`. Warn if a caller still passes it.
+    if let Some(arg) = cx.argument_opt(1) {
+        if !arg.is_a::<JsNull, _>(&mut cx) && !arg.is_a::<JsUndefined, _>(&mut cx) {
+            console_warn(
+                &mut cx,
+                "Engine constructor: the second argument is deprecated and ignored; \
+                 optimization is always enabled.",
+            )?;
+        }
+    }
 
     let engine_internal = EngineInternal::new_with_filter_set(rules);
     Ok(cx.boxed(Engine(Mutex::new(engine_internal))))

--- a/js/test/bindings.test.mjs
+++ b/js/test/bindings.test.mjs
@@ -40,7 +40,7 @@ describe('FilterSet.addFilters', () => {
     it('hosts format parses IP-hostname entries', () => {
         const fs = new FilterSet();
         fs.addFilters('127.0.0.1 ads.example.com', { format: FilterFormat.HOSTS });
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         assert.equal(
             engine.check('https://ads.example.com/', 'https://pub.com', 'script'),
             true,
@@ -53,7 +53,7 @@ describe('FilterSet.addFilters', () => {
             ['||example.com^', 'example.com##.ad'].join('\n'),
             { rule_types: RuleTypes.NETWORK_ONLY },
         );
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         assert.equal(
             engine.check('https://example.com/test.js', 'https://pub.com', 'script'),
             true,
@@ -67,7 +67,7 @@ describe('FilterSet.addFilters', () => {
       fs.addFilters(["||example.com^", "example.com##.ad"], {
         rule_types: RuleTypes.NETWORK_ONLY,
       });
-      const engine = new Engine(fs, true);
+      const engine = new Engine(fs);
       assert.equal(
         engine.check(
           "https://example.com/test.js",
@@ -84,7 +84,7 @@ describe('FilterSet.addFilters', () => {
             ['||example.com^', 'example.com##.ad'].join('\n'),
             { rule_types: RuleTypes.COSMETIC_ONLY },
         );
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         assert.equal(
             engine.check('https://example.com/test.js', 'https://pub.com', 'script'),
             false,
@@ -125,7 +125,7 @@ describe('FilterSet survives Engine construction (clone semantics)', () => {
     it('FilterSet is still usable after being passed to Engine constructor', () => {
         const fs = new FilterSet();
         fs.addFilters('||example.com^');
-        const _engine = new Engine(fs, true);
+        const _engine = new Engine(fs);
         assert.doesNotThrow(() => fs.addFilters('||another.com^'));
     });
 });
@@ -138,7 +138,7 @@ describe('Engine.check — basic blocking', () => {
     it('blocks matching requests, allows non-matching', () => {
         const fs = new FilterSet();
         fs.addFilters('||ads.example.com^');
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         assert.equal(engine.check('https://ads.example.com/t.js', 'https://pub.com', 'script'), true);
         assert.equal(engine.check('https://safe.com/t.js', 'https://pub.com', 'script'), false);
     });
@@ -146,7 +146,7 @@ describe('Engine.check — basic blocking', () => {
     it('debug=true returns BlockerResult with filter text', () => {
         const fs = new FilterSet(true);
         fs.addFilters('||ads.example.com^');
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         const result = engine.check(
             'https://ads.example.com/t.js', 'https://pub.com', 'script', true,
         );
@@ -155,14 +155,14 @@ describe('Engine.check — basic blocking', () => {
     });
 
     it('throws for an invalid URL', () => {
-        const engine = new Engine(new FilterSet(), true);
+        const engine = new Engine(new FilterSet());
         assert.throws(() => engine.check('not a url', 'https://publisher.com', 'script'));
     });
 
-    it('EngineOptions object works as alternative to boolean', () => {
+    it('ignores legacy optimize constructor argument', () => {
         const fs = new FilterSet();
         fs.addFilters('||blocked.com^');
-        const engine = new Engine(fs, { optimize: false });
+        const engine = new Engine(fs, true);
         assert.equal(
             engine.check('https://blocked.com/img.png', 'https://pub.com', 'image'),
             true,
@@ -178,7 +178,7 @@ describe('Engine.check — exception rules', () => {
     it('exception rule prevents blocking, populates exception field', () => {
         const fs = new FilterSet(true);
         fs.addFilters(['||ads.example.com^', '@@||ads.example.com^$domain=publisher.com'].join('\n'));
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         const result = engine.check(
             'https://ads.example.com/tracker.js', 'https://publisher.com', 'script', true,
         );
@@ -190,7 +190,7 @@ describe('Engine.check — exception rules', () => {
     it('$important overrides exception rules', () => {
         const fs = new FilterSet(true);
         fs.addFilters(['||ads.example.com^$important', '@@||ads.example.com^'].join('\n'));
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         const result = engine.check(
             'https://ads.example.com/t.js', 'https://pub.com', 'script', true,
         );
@@ -208,7 +208,7 @@ describe('Engine.check — $third-party and $1p modifiers', () => {
     it('$third-party rule blocks 3p, allows 1p', () => {
         const fs = new FilterSet();
         fs.addFilters('||tracker.com^$third-party');
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         assert.equal(engine.check('https://tracker.com/t.js', 'https://other.com', 'script'), true);
         assert.equal(engine.check('https://tracker.com/t.js', 'https://tracker.com', 'script'), false);
     });
@@ -216,7 +216,7 @@ describe('Engine.check — $third-party and $1p modifiers', () => {
     it('$1p rule blocks 1p, allows 3p', () => {
         const fs = new FilterSet();
         fs.addFilters('/bad-path$1p');
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         assert.equal(engine.check('https://example.com/bad-path', 'https://example.com', 'script'), true);
         assert.equal(engine.check('https://example.com/bad-path', 'https://other.com', 'script'), false);
     });
@@ -230,7 +230,7 @@ describe('Engine.check — type-specific rules', () => {
     it('$script blocks only script requests', () => {
         const fs = new FilterSet();
         fs.addFilters('||ads.example.com^$script');
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         assert.equal(engine.check('https://ads.example.com/t.js', 'https://pub.com', 'script'), true);
         assert.equal(engine.check('https://ads.example.com/t.png', 'https://pub.com', 'image'), false);
     });
@@ -238,7 +238,7 @@ describe('Engine.check — type-specific rules', () => {
     it('$image blocks only image requests', () => {
         const fs = new FilterSet();
         fs.addFilters('||ads.example.com^$image');
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         assert.equal(engine.check('https://ads.example.com/t.png', 'https://pub.com', 'image'), true);
         assert.equal(engine.check('https://ads.example.com/t.js', 'https://pub.com', 'script'), false);
     });
@@ -246,7 +246,7 @@ describe('Engine.check — type-specific rules', () => {
     it('$stylesheet blocks only stylesheet requests', () => {
         const fs = new FilterSet();
         fs.addFilters('||ads.example.com^$stylesheet');
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         assert.equal(engine.check('https://ads.example.com/s.css', 'https://pub.com', 'stylesheet'), true);
         assert.equal(engine.check('https://ads.example.com/s.js', 'https://pub.com', 'script'), false);
     });
@@ -254,7 +254,7 @@ describe('Engine.check — type-specific rules', () => {
     it('$xmlhttprequest blocks only XHR requests', () => {
         const fs = new FilterSet();
         fs.addFilters('||ads.example.com^$xmlhttprequest');
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         assert.equal(engine.check('https://ads.example.com/api', 'https://pub.com', 'xmlhttprequest'), true);
         assert.equal(engine.check('https://ads.example.com/api', 'https://pub.com', 'image'), false);
     });
@@ -289,7 +289,7 @@ describe('Engine.check — $domain modifier', () => {
     it('blocks only when source matches the domain option', () => {
         const fs = new FilterSet();
         fs.addFilters('/ads.js$domain=publisher.com');
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         assert.equal(engine.check('https://cdn.example.com/ads.js', 'https://publisher.com', 'script'), true);
         assert.equal(engine.check('https://cdn.example.com/ads.js', 'https://other.com', 'script'), false);
     });
@@ -297,7 +297,7 @@ describe('Engine.check — $domain modifier', () => {
     it('~domain excludes the specified domain', () => {
         const fs = new FilterSet();
         fs.addFilters('/ads.js$domain=~safe.com');
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         assert.equal(engine.check('https://cdn.example.com/ads.js', 'https://safe.com', 'script'), false);
         assert.equal(engine.check('https://cdn.example.com/ads.js', 'https://other.com', 'script'), true);
     });
@@ -311,14 +311,14 @@ describe('Engine.check — $badfilter modifier', () => {
     it('cancels a matching blocking rule', () => {
         const fs = new FilterSet();
         fs.addFilters(['||ads.example.com^', '||ads.example.com^$badfilter'].join('\n'));
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         assert.equal(engine.check('https://ads.example.com/t.js', 'https://pub.com', 'script'), false);
     });
 
     it('does not cancel a dissimilar rule', () => {
         const fs = new FilterSet();
         fs.addFilters(['||ads.example.com^', '||other.com^$badfilter'].join('\n'));
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         assert.equal(engine.check('https://ads.example.com/t.js', 'https://pub.com', 'script'), true);
     });
 });
@@ -331,7 +331,7 @@ describe('Engine.check — redirect rules', () => {
     it('redirect field is set when $redirect rule matches and resource is loaded', () => {
         const fs = new FilterSet(true);
         fs.addFilters('||ads.example.com^$script,redirect=noopjs');
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         engine.useResources([{
             name: 'noopjs',
             aliases: [],
@@ -349,7 +349,7 @@ describe('Engine.check — redirect rules', () => {
     it('redirect is null when no redirect rule applies', () => {
         const fs = new FilterSet(true);
         fs.addFilters('||ads.example.com^');
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         const result = engine.check(
             'https://ads.example.com/t.js', 'https://pub.com', 'script', true,
         );
@@ -367,7 +367,7 @@ describe('Engine.check — $removeparam modifier', () => {
     it('strips the specified parameter, preserves others', () => {
         const fs = new FilterSet(true);
         fs.addFilters('||example.com^$removeparam=tracking_id');
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         const result = engine.check(
             'https://example.com/page?tracking_id=abc&keep=1',
             'https://other.com', 'xmlhttprequest', true,
@@ -380,7 +380,7 @@ describe('Engine.check — $removeparam modifier', () => {
     it('rewritten_url is null when the parameter is absent', () => {
         const fs = new FilterSet(true);
         fs.addFilters('||example.com^$removeparam=tracking_id');
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         const result = engine.check(
             'https://example.com/page?unrelated=1',
             'https://other.com', 'xmlhttprequest', true,
@@ -397,7 +397,7 @@ describe('Engine.check — exception rules with tags', () => {
     it('tagged exception activates only after enableTag', () => {
         const fs = new FilterSet(true);
         fs.addFilters(['||ads.example.com^', '@@||ads.example.com^$tag=unbreak'].join('\n'));
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
 
         const before = engine.check(
             'https://ads.example.com/t.js', 'https://pub.com', 'script', true,
@@ -422,7 +422,7 @@ describe('Engine.urlCosmeticResources', () => {
     it('returns matching hide_selectors for the URL', () => {
         const fs = new FilterSet();
         fs.addFilters(['example.com##.ad-banner', 'example.com##.sponsored-post'].join('\n'));
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         const result = engine.urlCosmeticResources('https://example.com/page');
         assert.ok(result.hide_selectors.includes('.ad-banner'));
         assert.ok(result.hide_selectors.includes('.sponsored-post'));
@@ -431,7 +431,7 @@ describe('Engine.urlCosmeticResources', () => {
     it('returns empty hide_selectors for an unmatched URL', () => {
         const fs = new FilterSet();
         fs.addFilters('example.com##.ad-banner');
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         const result = engine.urlCosmeticResources('https://other-site.com/page');
         assert.equal(result.hide_selectors.length, 0);
     });
@@ -439,7 +439,7 @@ describe('Engine.urlCosmeticResources', () => {
     it('generichide exception sets generichide=true', () => {
         const fs = new FilterSet();
         fs.addFilters(['##.generic-ad', '@@||example.com^$generichide'].join('\n'));
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         assert.equal(engine.urlCosmeticResources('https://example.com/page').generichide, true);
         assert.equal(engine.urlCosmeticResources('https://other.com/page').generichide, false);
     });
@@ -447,7 +447,7 @@ describe('Engine.urlCosmeticResources', () => {
     it('site-specific unhide (#@#) prevents selector from appearing', () => {
         const fs = new FilterSet();
         fs.addFilters(['example.com##.ad-banner', 'example.com#@#.ad-banner'].join('\n'));
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         const result = engine.urlCosmeticResources('https://example.com/page');
         assert.ok(!result.hide_selectors.includes('.ad-banner'));
     });
@@ -455,7 +455,7 @@ describe('Engine.urlCosmeticResources', () => {
     it('generic unhide (#@#) adds to exceptions list', () => {
         const fs = new FilterSet();
         fs.addFilters(['##.generic-ad', 'example.com#@#.generic-ad'].join('\n'));
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         const result = engine.urlCosmeticResources('https://example.com/page');
         assert.ok(result.exceptions.includes('.generic-ad'));
     });
@@ -463,7 +463,7 @@ describe('Engine.urlCosmeticResources', () => {
     it('negated domain (~sub.example.com) excludes subdomain', () => {
         const fs = new FilterSet();
         fs.addFilters('example.com,~sub.example.com##.ad');
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         assert.ok(engine.urlCosmeticResources('https://example.com/page').hide_selectors.includes('.ad'));
         assert.ok(!engine.urlCosmeticResources('https://sub.example.com/page').hide_selectors.includes('.ad'));
     });
@@ -474,7 +474,7 @@ describe('Engine.urlCosmeticResources', () => {
             'example.com##.items:has-text(Sponsored)',
             'example.com##.ad-banner:remove()',
         ].join('\n'));
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         const result = engine.urlCosmeticResources('https://example.com/page');
         assert.ok(result.procedural_actions.length >= 2);
     });
@@ -482,7 +482,7 @@ describe('Engine.urlCosmeticResources', () => {
     it('scriptlet injection populates injected_script', () => {
         const fs = new FilterSet();
         fs.addFilters('example.com##+js(noopjs)');
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         // ##+js(noopjs) looks up "noopjs.js"; scriptlets use kind: "template"
         engine.useResources([{
             name: 'noopjs.js',
@@ -503,7 +503,7 @@ describe('Engine.hiddenClassIdSelectors', () => {
     it('returns selectors matching class and id names', () => {
         const fs = new FilterSet();
         fs.addFilters(['##.a-class', '###simple-id'].join('\n'));
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         assert.ok(engine.hiddenClassIdSelectors(['a-class'], [], []).includes('.a-class'));
         assert.ok(engine.hiddenClassIdSelectors([], ['simple-id'], []).includes('#simple-id'));
     });
@@ -511,14 +511,14 @@ describe('Engine.hiddenClassIdSelectors', () => {
     it('returns empty for unknown class/id names', () => {
         const fs = new FilterSet();
         fs.addFilters('##.a-class');
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         assert.deepEqual(engine.hiddenClassIdSelectors(['unknown'], ['unknown'], []), []);
     });
 
     it('exceptions array filters out results', () => {
         const fs = new FilterSet();
         fs.addFilters('##.a-class');
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         assert.ok(engine.hiddenClassIdSelectors(['a-class'], [], []).includes('.a-class'));
         assert.ok(!engine.hiddenClassIdSelectors(['a-class'], [], ['.a-class']).includes('.a-class'));
     });
@@ -532,10 +532,10 @@ describe('Engine serialization', () => {
     it('roundtrip preserves blocking and exception rules', () => {
         const fs = new FilterSet();
         fs.addFilters(['||blocked.com^', '@@||exception.blocked.com^'].join('\n'));
-        const src = new Engine(fs, true);
+        const src = new Engine(fs);
         const buf = src.serialize();
 
-        const dst = new Engine(new FilterSet(), true);
+        const dst = new Engine(new FilterSet());
         dst.deserialize(buf);
         assert.equal(dst.check('https://blocked.com/img.png', 'https://pub.com', 'image'), true);
         assert.equal(dst.check('https://safe.com/img.png', 'https://pub.com', 'image'), false);
@@ -545,11 +545,11 @@ describe('Engine serialization', () => {
     it('tag enablement is NOT serialized — must re-enable after deserialize', () => {
         const fs = new FilterSet();
         fs.addFilters(['adv$tag=stuff', '||blocked.com^'].join('\n'));
-        const src = new Engine(fs, true);
+        const src = new Engine(fs);
         src.enableTag('stuff');
         const buf = src.serialize();
 
-        const dst = new Engine(new FilterSet(), true);
+        const dst = new Engine(new FilterSet());
         dst.deserialize(buf);
 
         // Untagged filter works immediately
@@ -569,11 +569,11 @@ describe('Engine serialization', () => {
             kind: { mime: 'application/javascript' },
             content: btoa('(function(){})()'),
         };
-        const src = new Engine(fs, true);
+        const src = new Engine(fs);
         src.useResources([resource]);
         const buf = src.serialize();
 
-        const dst = new Engine(new FilterSet(), true);
+        const dst = new Engine(new FilterSet());
         dst.deserialize(buf);
 
         // Without reloading: redirect absent
@@ -600,7 +600,7 @@ describe('Engine tags', () => {
     it('tagged filter is inactive before enableTag, active after', () => {
         const fs = new FilterSet();
         fs.addFilters(['adv$tag=stuff'].join('\n'));
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         assert.equal(engine.check('https://example.com/adv', 'https://example.com', 'other'), false);
         engine.enableTag('stuff');
         assert.equal(engine.check('https://example.com/adv', 'https://example.com', 'other'), true);
@@ -610,7 +610,7 @@ describe('Engine tags', () => {
     it('clearTags deactivates all enabled tags', () => {
         const fs = new FilterSet();
         fs.addFilters(['adv$tag=stuff', '||brianbondy.com/$tag=brian'].join('\n'));
-        const engine = new Engine(fs, true);
+        const engine = new Engine(fs);
         engine.enableTag('stuff');
         engine.enableTag('brian');
         assert.equal(engine.check('https://example.com/adv', 'https://example.com', 'other'), true);
@@ -635,7 +635,7 @@ describe('uBlockResources', () => {
             join(dataDir, 'redirect-resources.js'),
         );
         assert.ok(resources.length > 0);
-        const engine = new Engine(new FilterSet(), true);
+        const engine = new Engine(new FilterSet());
         assert.doesNotThrow(() => engine.useResources(resources));
     });
 

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -14,11 +14,6 @@ use crate::regex_manager::{RegexManager, RegexManagerDiscardPolicy};
 use crate::request::Request;
 use crate::resources::ResourceStorage;
 
-/// Options used when constructing a [`Blocker`].
-pub struct BlockerOptions {
-    pub enable_optimizations: bool,
-}
-
 /// Describes how a particular network request should be handled.
 #[derive(Debug, Serialize, Default)]
 pub struct BlockerResult {
@@ -450,27 +445,26 @@ impl Blocker {
     }
 
     #[cfg(test)]
-    pub fn new(
-        network_filters: impl IntoIterator<Item = impl AsRef<str>>,
-        options: &BlockerOptions,
-    ) -> Self {
-        use crate::engine::Engine;
-        use crate::FilterSet;
-
-        let mut filter_set = FilterSet::new(true);
+    pub fn new(network_filters: impl IntoIterator<Item = impl AsRef<str>>) -> Self {
+        let mut filter_set = crate::FilterSet::new(false);
         filter_set.add_filters(network_filters, Default::default());
-        let engine = Engine::new_with_filter_set(filter_set, options.enable_optimizations);
+        let engine = crate::engine::Engine::new_with_filter_set(filter_set);
         Self::from_context(engine.filter_data_context())
     }
 
     #[cfg(test)]
-    pub fn new_with_list_text(text: String, options: &BlockerOptions) -> Self {
-        use crate::engine::Engine;
-        use crate::FilterSet;
+    pub fn new_debug(network_filters: impl IntoIterator<Item = impl AsRef<str>>) -> Self {
+        let mut filter_set = crate::FilterSet::new(true);
+        filter_set.add_filters(network_filters, Default::default());
+        let engine = crate::engine::Engine::new_with_filter_set(filter_set);
+        Self::from_context(engine.filter_data_context())
+    }
 
-        let mut filter_set = FilterSet::new(true);
+    #[cfg(test)]
+    pub fn new_with_list_text(text: String) -> Self {
+        let mut filter_set = crate::FilterSet::new(false);
         filter_set.add_filter_list(text, Default::default());
-        let engine = Engine::new_with_filter_set(filter_set, options.enable_optimizations);
+        let engine = crate::engine::Engine::new_with_filter_set(filter_set);
         Self::from_context(engine.filter_data_context())
     }
 

--- a/src/cosmetic_filter_cache.rs
+++ b/src/cosmetic_filter_cache.rs
@@ -138,7 +138,7 @@ impl CosmeticFilterCache {
 
         let mut filter_set = FilterSet::new(false);
         filter_set.add_filters(rules, Default::default());
-        let engine = Engine::new_with_filter_set(filter_set, true);
+        let engine = Engine::new_with_filter_set(filter_set);
         engine.cosmetic_cache()
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -32,7 +32,7 @@ use std::collections::HashSet;
 ///
 /// You'll first want to combine all of your filter lists in a [`FilterSet`], which will parse list
 /// header metadata. Once all lists have been composed together, you can call
-/// [`Engine::from_filter_set`] to start using them for blocking.
+/// [`Engine::new_with_filter_set`] to start using them for blocking.
 ///
 /// You may also want to supply certain assets for `$redirect` filters and `##+js(...)` scriptlet
 /// injections. These are known as [`Resource`]s, and can be provided with
@@ -67,28 +67,17 @@ pub struct EngineDebugInfo {
 
 impl Default for Engine {
     fn default() -> Self {
-        Self::new_with_filter_set(FilterSet::new(false), false)
+        Self::new_with_filter_set(FilterSet::new(false))
     }
 }
 
 impl Engine {
     /// A helper for tests and benchmarks. Use [`Engine::new_with_filter_set`] instead.
     #[doc(hidden)]
-    pub fn new_with_list_text(list_text: impl Into<String>, opts: ParseOptions) -> Self {
-        Self::new_with_list_text_parametrised(list_text.into(), opts, false, true)
-    }
-
-    /// A helper for tests and benchmarks. Use [`Engine::new_with_filter_set`] instead.
-    #[doc(hidden)]
-    pub fn new_with_list_text_parametrised(
-        list_text: impl Into<String>,
-        opts: ParseOptions,
-        debug: bool,
-        optimize: bool,
-    ) -> Self {
-        let mut filter_set = FilterSet::new(debug);
-        filter_set.add_filter_list(list_text.into(), opts);
-        Self::new_with_filter_set(filter_set, optimize)
+    pub fn new_with_list_text(list_text: impl Into<String>) -> Self {
+        let mut filter_set = FilterSet::new(false);
+        filter_set.add_filter_list(list_text.into(), ParseOptions::default());
+        Self::new_with_filter_set(filter_set)
     }
 
     #[cfg(test)]
@@ -106,10 +95,9 @@ impl Engine {
     pub fn new_with_parsed_rules(
         network_filters: Vec<NetworkFilter>,
         cosmetic_filters: Vec<CosmeticFilter>,
-        optimize: bool,
     ) -> Self {
         let mut builder = EngineFlatBuilder::default();
-        let mut network_rules_builder = NetworkRulesBuilder::new(optimize);
+        let mut network_rules_builder = NetworkRulesBuilder::new(true);
         let mut cosmetic_filter_cache_builder = CosmeticFilterCacheBuilder::default();
 
         for filter in network_filters {
@@ -127,11 +115,12 @@ impl Engine {
     }
 
     /// Loads rules from the given `FilterSet`.
-    pub fn new_with_filter_set(set: FilterSet, optimize: bool) -> Self {
+    pub fn new_with_filter_set(set: FilterSet) -> Self {
         let FilterSet {
             debug,
             list_sources,
         } = set;
+        let optimize = !debug;
         let mut builder = EngineFlatBuilder::default();
         let mut network_rules_builder = NetworkRulesBuilder::new(optimize);
         let mut cosmetic_filter_cache_builder = CosmeticFilterCacheBuilder::default();

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -114,13 +114,21 @@ impl Engine {
         )
     }
 
+    #[doc(hidden)]
+    pub fn new_with_filter_set_no_optimize(set: FilterSet) -> Self {
+        Self::new_with_filter_set_internal(set, false)
+    }
+
     /// Loads rules from the given `FilterSet`.
     pub fn new_with_filter_set(set: FilterSet) -> Self {
+        Self::new_with_filter_set_internal(set, true)
+    }
+
+    fn new_with_filter_set_internal(set: FilterSet, optimize: bool) -> Self {
         let FilterSet {
             debug,
             list_sources,
         } = set;
-        let optimize = !debug;
         let mut builder = EngineFlatBuilder::default();
         let mut network_rules_builder = NetworkRulesBuilder::new(optimize);
         let mut cosmetic_filter_cache_builder = CosmeticFilterCacheBuilder::default();

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -1072,7 +1072,7 @@ impl<'a> NetworkFilter<'a> {
 
     #[cfg(test)]
     pub(crate) fn matches_test(&self, request: &request::Request) -> bool {
-        let engine = crate::Engine::new_with_parsed_rules(vec![self.clone()], vec![], true);
+        let engine = crate::Engine::new_with_parsed_rules(vec![self.clone()], vec![]);
         if self.is_exception() {
             engine.check_network_request_exceptions(request)
         } else {

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -59,7 +59,7 @@ use serde::{Deserialize, Serialize};
 ///     },
 /// );
 ///
-/// let mut engine = Engine::new_with_filter_set(filter_set, true);
+/// let mut engine = Engine::new_with_filter_set(filter_set);
 /// // The `trusted-set-cookie` scriptlet cannot be injected without `COOKIE_ACCESS`
 /// // permission.
 /// engine.use_resources([Resource {

--- a/tests/legacy_harness.rs
+++ b/tests/legacy_harness.rs
@@ -34,7 +34,7 @@ mod legacy_test_filters {
             filter.filter
         );
 
-        let engine = Engine::new_with_list_text(raw_filter, Default::default());
+        let engine = Engine::new_with_list_text(raw_filter);
 
         for to_block in blocked {
             assert!(
@@ -306,10 +306,8 @@ mod legacy_test_filters {
 
         // explicit, separate testcase construction of the "script" option as it is not the deafult
         let request = Request::new("http://tpc.googlesyndication.com/safeframe/1-0-2/html/container.html#xpc=sf-gdn-exp-2&p=http%3A//slashdot.org;", "https://this-is-always-third-party.com", "script", "").unwrap();
-        let engine = Engine::new_with_list_text(
-            "||googlesyndication.com/safeframe/$third-party,script",
-            Default::default(),
-        );
+        let engine =
+            Engine::new_with_list_text("||googlesyndication.com/safeframe/$third-party,script");
         assert!(engine.check_network_request(&request).matched);
     }
 }
@@ -324,7 +322,7 @@ mod legacy_check_match {
         not_blocked: &[&'a str],
         tags: &[&'a str],
     ) {
-        let mut engine = Engine::new_with_list_text(rules.join("\n"), Default::default()); // first one with the provided rules
+        let mut engine = Engine::new_with_list_text(rules.join("\n")); // first one with the provided rules
         engine.use_tags(tags);
 
         let mut engine_deserialized = Engine::default(); // second empty
@@ -401,7 +399,6 @@ mod legacy_check_match {
                     "@@||turner.com^*/ads/freewheel/*/AdManager.js$domain=cnn.com",
                 ]
                 .join("\n"),
-                Default::default(),
             );
             let mut engine_deserialized = Engine::default(); // second empty
             {
@@ -507,7 +504,7 @@ mod legacy_check_options {
     use adblock::Engine;
 
     fn check_option_rule<'a>(rules: &[&'a str], tests: &[(&'a str, &'a str, &'a str, bool)]) {
-        let engine = Engine::new_with_list_text(rules.join("\n"), Default::default()); // first one with the provided rules
+        let engine = Engine::new_with_list_text(rules.join("\n")); // first one with the provided rules
 
         for (url, source_url, request_type, expectation) in tests {
             let request = Request::new(url, source_url, request_type, "").unwrap();
@@ -847,16 +844,25 @@ mod legacy_check_options {
 
 mod legacy_misc_tests {
     use adblock::filters::network::NetworkFilter;
+    use adblock::lists::FilterSet;
     use adblock::request::Request;
     use adblock::Engine;
+
+    fn engine_from_rules_debug(rules: impl IntoIterator<Item = impl AsRef<str>>) -> Engine {
+        let list_text = rules.into_iter().fold(String::new(), |mut acc, rule| {
+            acc.push_str(rule.as_ref());
+            acc.push('\n');
+            acc
+        });
+        let mut filter_set = FilterSet::new(true);
+        filter_set.add_filter_list(list_text, Default::default());
+        Engine::new_with_filter_set(filter_set)
+    }
 
     #[test]
     fn demo_app() {
         // Demo app test
-        let engine = Engine::new_with_list_text(
-            "||googlesyndication.com/safeframe/$third-party",
-            Default::default(),
-        );
+        let engine = Engine::new_with_list_text("||googlesyndication.com/safeframe/$third-party");
 
         let request = Request::new(
             "http://tpc.googlesyndication.com/safeframe/1-0-2/html/container.html",
@@ -885,17 +891,11 @@ mod legacy_misc_tests {
 
     #[test]
     fn serialization_tests() {
-        let engine = Engine::new_with_list_text_parametrised(
-            [
-                "||googlesyndication.com$third-party",
-                "@@||googlesyndication.ca",
-                "a$explicitcancel",
-            ]
-            .join("\n"),
-            Default::default(),
-            true,
-            false,
-        ); // enable debugging and disable optimizations
+        let engine = engine_from_rules_debug([
+            "||googlesyndication.com$third-party",
+            "@@||googlesyndication.ca",
+            "a$explicitcancel",
+        ]);
 
         let serialized = engine.serialize().to_vec();
         let mut engine2 = Engine::default();
@@ -984,16 +984,10 @@ mod legacy_misc_tests {
 
     #[test]
     fn find_matching_filters() {
-        let engine = Engine::new_with_list_text_parametrised(
-            [
-                "||googlesyndication.com/safeframe/$third-party",
-                "||brianbondy.com/ads",
-            ]
-            .join("\n"),
-            Default::default(),
-            true,
-            true,
-        );
+        let engine = engine_from_rules_debug([
+            "||googlesyndication.com/safeframe/$third-party",
+            "||brianbondy.com/ads",
+        ]);
 
         let current_page_frame = "http://slashdot.org";
         let request_type = "script";
@@ -1033,17 +1027,11 @@ mod legacy_misc_tests {
 
     #[test]
     fn find_matching_filters_exceptions() {
-        let engine = Engine::new_with_list_text_parametrised(
-            [
-                "||googlesyndication.com/safeframe/$third-party",
-                "||brianbondy.com/ads",
-                "@@safeframe",
-            ]
-            .join("\n"),
-            Default::default(),
-            true,
-            true,
-        );
+        let engine = engine_from_rules_debug([
+            "||googlesyndication.com/safeframe/$third-party",
+            "||brianbondy.com/ads",
+            "@@safeframe",
+        ]);
 
         let current_page_frame = "http://slashdot.org";
         let request_type = "script";
@@ -1075,12 +1063,8 @@ mod legacy_misc_tests {
     #[test]
     fn matches_with_filter_info_preserves_important() {
         // exceptions have not effect if important filter matches
-        let engine = Engine::new_with_list_text_parametrised(
-            ["||brianbondy.com^$important", "@@||brianbondy.com^"].join("\n"),
-            Default::default(),
-            true,
-            true,
-        );
+        let engine =
+            engine_from_rules_debug(["||brianbondy.com^$important", "@@||brianbondy.com^"]);
 
         let request =
             Request::new("https://brianbondy.com/t", "https://test.com", "script", "").unwrap();

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -150,7 +150,7 @@ fn troubleshoot() {
 }
 
 fn get_blocker_engine() -> Engine {
-    let mut engine = Engine::new_with_filter_set(get_all_filters().clone(), true);
+    let mut engine = Engine::new_with_filter_set(get_all_filters().clone());
 
     engine.use_tags(&["fb-embeds", "twitter-embeds"]);
 
@@ -279,7 +279,7 @@ fn check_live_redirects() {
 /// Ensure that one engine's serialization result can be exactly reproduced by another engine after
 /// deserializing from it.
 fn stable_serialization_through_load() {
-    let engine1 = Engine::new_with_filter_set(get_all_filters().clone(), true);
+    let engine1 = Engine::new_with_filter_set(get_all_filters().clone());
     let ser1 = engine1.serialize().to_vec();
 
     let mut engine2 = Engine::default();

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -59,11 +59,9 @@ fn check_filter_matching() {
 
     assert!(!requests.is_empty(), "List of parsed request info is empty");
 
-    let opts = ParseOptions::default();
-
     for req in requests {
         for filter in req.filters {
-            let network_filter_res = NetworkFilter::parse(&filter, true, opts);
+            let network_filter_res = NetworkFilter::parse(&filter, true, ParseOptions::default());
             assert!(
                 network_filter_res.is_ok(),
                 "Could not parse filter {filter}"
@@ -77,7 +75,7 @@ fn check_filter_matching() {
                     .set(NetworkFilterMask::IS_EXCEPTION, false);
                 filters.push(original_filter);
             }
-            let engine = adblock::Engine::new_with_parsed_rules(filters, vec![], true);
+            let engine = adblock::Engine::new_with_parsed_rules(filters, vec![]);
 
             let request_res = Request::new(&req.url, &req.sourceUrl, &req.r#type, "");
             // The dataset has cases where URL is set to just "http://" or "https://", which we do not support
@@ -119,12 +117,11 @@ fn check_engine_matching() {
             continue;
         }
         for filter in req.filters {
-            let opts = ParseOptions::default();
-            let mut engine = Engine::new_with_list_text(filter.clone(), opts);
+            let mut engine = Engine::new_with_list_text(filter.clone());
             let resources = build_resources_from_filters(std::slice::from_ref(&filter));
             engine.use_resources(resources);
 
-            let network_filter_res = NetworkFilter::parse(&filter, true, opts);
+            let network_filter_res = NetworkFilter::parse(&filter, true, ParseOptions::default());
             assert!(
                 network_filter_res.is_ok(),
                 "Could not parse filter {filter}"
@@ -213,7 +210,7 @@ fn check_rule_matching_browserlike() {
 
     let requests = load_requests();
     let rules = rules_from_lists(&["data/brave/brave-main-list.txt"]);
-    let engine = Engine::new_with_list_text(rules, Default::default());
+    let engine = Engine::new_with_list_text(rules);
     let (blocked, passes) = bench_rule_matching_browserlike(&engine, &requests);
     let msg = "The number of blocked/passed requests has changed. ".to_string()
         + "If this is expected, update the expected values in the test.";

--- a/tests/simple_use.rs
+++ b/tests/simple_use.rs
@@ -10,7 +10,7 @@ fn check_simple_use() {
         "-advertisement/script.",
     ];
 
-    let engine = Engine::new_with_list_text(rules.join("\n"), Default::default());
+    let engine = Engine::new_with_list_text(rules.join("\n"));
 
     let request = Request::new(
         "http://example.com/-advertisement-icon.",

--- a/tests/ublock-coverage.rs
+++ b/tests/ublock-coverage.rs
@@ -1,3 +1,4 @@
+use adblock::lists::FilterSet;
 use adblock::request::Request;
 use adblock::Engine;
 
@@ -48,7 +49,9 @@ fn get_blocker_engine() -> Engine {
         "data/regression-testing/easyprivacy.txt",
     ]);
 
-    Engine::new_with_list_text_parametrised(rules, Default::default(), true, false)
+    let mut filter_set = FilterSet::new(true);
+    filter_set.add_filter_list(rules, Default::default());
+    Engine::new_with_filter_set(filter_set)
 }
 
 fn get_blocker_engine_default(extra_rules: impl IntoIterator<Item = impl AsRef<str>>) -> Engine {
@@ -67,14 +70,16 @@ fn get_blocker_engine_default(extra_rules: impl IntoIterator<Item = impl AsRef<s
         rules.push('\n');
     }
 
-    Engine::new_with_list_text_parametrised(rules, Default::default(), true, false)
+    let mut filter_set = FilterSet::new(true);
+    filter_set.add_filter_list(rules, Default::default());
+    Engine::new_with_filter_set(filter_set)
 }
 
 #[test]
 fn check_specific_rules() {
     {
         // exceptions have not effect if important filter matches
-        let engine = Engine::new_with_list_text("||www.facebook.com/*/plugin", Default::default());
+        let engine = Engine::new_with_list_text("||www.facebook.com/*/plugin");
 
         let request = Request::new(
             "https://www.facebook.com/v3.2/plugins/comments.ph",
@@ -95,7 +100,6 @@ fn check_specific_rules() {
         // exceptions have no effect if important filter matches
         let mut engine = Engine::new_with_list_text(
             "||cdn.taboola.com/libtrc/*/loader.js$script,redirect=noopjs,important,domain=cnet.com",
-            Default::default(),
         );
         let resources = adblock::resources::resource_assembler::assemble_web_accessible_resources(
             Path::new("data/test/fake-uBO-files/web_accessible_resources"),

--- a/tests/unit/blocker.rs
+++ b/tests/unit/blocker.rs
@@ -11,12 +11,7 @@ mod blocker_tests {
     #[test]
     fn single_slash() {
         let filters = ["/|"];
-
-        let blocker_options = BlockerOptions {
-            enable_optimizations: true,
-        };
-
-        let blocker = Blocker::new(filters, &blocker_options);
+        let blocker = Blocker::new(filters);
 
         let request = Request::new(
             "https://example.com/test/",
@@ -41,11 +36,7 @@ mod blocker_tests {
         filters: impl IntoIterator<Item = impl AsRef<str>>,
         requests: &[(Request, bool)],
     ) {
-        let blocker_options: BlockerOptions = BlockerOptions {
-            enable_optimizations: false, // optimizations will reduce number of rules
-        };
-
-        let blocker = Blocker::new(filters, &blocker_options);
+        let blocker = Blocker::new_debug(filters);
 
         requests.iter().for_each(|(req, expected_result)| {
             let matched_rule = blocker.check(req, &Default::default());
@@ -75,12 +66,7 @@ mod blocker_tests {
             "",
         )
         .unwrap();
-
-        let blocker_options: BlockerOptions = BlockerOptions {
-            enable_optimizations: false,
-        };
-
-        let blocker = Blocker::new(filters, &blocker_options);
+        let blocker = Blocker::new_debug(filters);
         let resources = ResourceStorage::in_memory_from_resources([Resource::simple(
             "noop-0.1s.mp3",
             crate::resources::MimeType::AudioMp3,
@@ -114,12 +100,7 @@ mod blocker_tests {
             "",
         )
         .unwrap();
-
-        let blocker_options: BlockerOptions = BlockerOptions {
-            enable_optimizations: false,
-        };
-
-        let blocker = Blocker::new(filters, &blocker_options);
+        let blocker = Blocker::new_debug(filters);
         let resources = ResourceStorage::in_memory_from_resources([Resource::simple(
             "noop-0.1s.mp3",
             crate::resources::MimeType::AudioMp3,
@@ -152,12 +133,7 @@ mod blocker_tests {
             "",
         )
         .unwrap();
-
-        let blocker_options: BlockerOptions = BlockerOptions {
-            enable_optimizations: false,
-        };
-
-        let blocker = Blocker::new(filters, &blocker_options);
+        let blocker = Blocker::new_debug(filters);
         let resources = ResourceStorage::in_memory_from_resources([Resource::simple(
             "noop.txt",
             crate::resources::MimeType::TextPlain,
@@ -222,12 +198,7 @@ mod blocker_tests {
     #[test]
     fn trailing_dot_domain() {
         let filters = ["||dot.example.com.^", "||test.example.com^"];
-
-        let blocker_options = BlockerOptions {
-            enable_optimizations: true,
-        };
-
-        let blocker = Blocker::new(filters, &blocker_options);
+        let blocker = Blocker::new(filters);
 
         let request = Request::new(
             "https://dot.example.com",
@@ -315,11 +286,7 @@ mod blocker_tests {
             ),
         ];
 
-        let blocker_options = BlockerOptions {
-            enable_optimizations: false, // optimizations will reduce number of rules
-        };
-
-        let blocker = Blocker::new(filters, &blocker_options);
+        let blocker = Blocker::new_debug(filters);
         let resources = ResourceStorage::default();
 
         url_results.into_iter().for_each(|(req, expected_result)| {
@@ -347,12 +314,7 @@ mod blocker_tests {
             "@@^disable-all^$csp",
             "^first-party-only^$csp=script-src 'none',1p",
         ];
-
-        let blocker_options = BlockerOptions {
-            enable_optimizations: false,
-        };
-
-        let blocker = Blocker::new(filters, &blocker_options);
+        let blocker = Blocker::new_debug(filters);
 
         {
             // No directives should be returned for requests that are not `document` or `subdocument` content types.
@@ -561,12 +523,7 @@ mod blocker_tests {
             "^block^$important",
             "$removeparam=testCase,~xhr",
         ];
-
-        let blocker_options = BlockerOptions {
-            enable_optimizations: true,
-        };
-
-        let blocker = Blocker::new(filters, &blocker_options);
+        let blocker = Blocker::new(filters);
         let resources = ResourceStorage::in_memory_from_resources([Resource::simple(
             "noopjs",
             crate::resources::MimeType::ApplicationJavascript,
@@ -999,12 +956,7 @@ mod blocker_tests {
         .iter()
         .map(|s| format!("*$removeparam={s}"))
         .collect::<Vec<_>>();
-
-        let blocker_options = BlockerOptions {
-            enable_optimizations: true,
-        };
-
-        let blocker = Blocker::new(filters, &blocker_options);
+        let blocker = Blocker::new(filters);
         let resources = ResourceStorage::default();
 
         for (original, expected) in testcases.into_iter() {
@@ -1027,12 +979,7 @@ mod blocker_tests {
     #[test]
     fn test_removeparam_same_tokens() {
         let filters = ["$removeparam=example1_", "$removeparam=example1-"];
-
-        let blocker_options = BlockerOptions {
-            enable_optimizations: true,
-        };
-
-        let blocker = Blocker::new(filters, &blocker_options);
+        let blocker = Blocker::new(filters);
 
         let result = blocker.check(
             &Request::new(
@@ -1058,12 +1005,7 @@ mod blocker_tests {
             "@@^exceptb10^$redirect-rule=b:10",
             "@@^exceptc20^$redirect-rule=c:20",
         ];
-
-        let blocker_options = BlockerOptions {
-            enable_optimizations: true,
-        };
-
-        let blocker = Blocker::new(filters, &blocker_options);
+        let blocker = Blocker::new(filters);
         fn simple_resource(identifier: &str) -> Resource {
             Resource::simple(
                 identifier,
@@ -1228,11 +1170,7 @@ mod blocker_tests {
             })
             .collect();
 
-        let blocker_options: BlockerOptions = BlockerOptions {
-            enable_optimizations: false, // optimizations will reduce number of rules
-        };
-
-        let mut blocker = Blocker::new(filters, &blocker_options);
+        let mut blocker = Blocker::new_debug(filters);
         let resources = Default::default();
         blocker.enable_tags(&["stuff"]);
         assert_eq!(
@@ -1279,11 +1217,7 @@ mod blocker_tests {
             })
             .collect();
 
-        let blocker_options: BlockerOptions = BlockerOptions {
-            enable_optimizations: false, // optimizations will reduce number of rules
-        };
-
-        let mut blocker = Blocker::new(filters, &blocker_options);
+        let mut blocker = Blocker::new_debug(filters);
         let resources = Default::default();
         blocker.enable_tags(&["stuff"]);
         blocker.enable_tags(&["brian"]);
@@ -1331,11 +1265,7 @@ mod blocker_tests {
             })
             .collect();
 
-        let blocker_options: BlockerOptions = BlockerOptions {
-            enable_optimizations: false, // optimizations will reduce number of rules
-        };
-
-        let mut blocker = Blocker::new(filters, &blocker_options);
+        let mut blocker = Blocker::new_debug(filters);
         let resources = Default::default();
         blocker.enable_tags(&["brian", "stuff"]);
         assert_eq!(
@@ -1366,11 +1296,7 @@ mod blocker_tests {
 
     #[test]
     fn exception_force_check() {
-        let blocker_options: BlockerOptions = BlockerOptions {
-            enable_optimizations: true,
-        };
-
-        let blocker = Blocker::new(["@@*ad_banner.png"], &blocker_options);
+        let blocker = Blocker::new(["@@*ad_banner.png"]);
 
         let resources = Default::default();
 
@@ -1389,11 +1315,7 @@ mod blocker_tests {
 
     #[test]
     fn generichide() {
-        let blocker_options: BlockerOptions = BlockerOptions {
-            enable_optimizations: true,
-        };
-
-        let blocker = Blocker::new(["@@||example.com$generichide\n"], &blocker_options);
+        let blocker = Blocker::new(["@@||example.com$generichide\n"]);
 
         assert!(blocker.check_generic_hide(
             &Request::new("https://example.com", "https://example.com", "other", "").unwrap()
@@ -1408,7 +1330,7 @@ mod placeholder_string_tests {
     fn test_constant_placeholder_string() {
         let mut filter_set = crate::lists::FilterSet::new(false);
         filter_set.add_filter_list("||example.com^\n".to_string(), Default::default());
-        let engine = crate::Engine::new_with_filter_set(filter_set, true);
+        let engine = crate::Engine::new_with_filter_set(filter_set);
         let block = engine.check_network_request(
             &crate::request::Request::new(
                 "https://example.com",
@@ -1427,9 +1349,10 @@ mod placeholder_string_tests {
 
 #[cfg(test)]
 mod legacy_rule_parsing_tests {
-    use crate::blocker::{Blocker, BlockerOptions};
+    use crate::blocker::Blocker;
+    use crate::engine::Engine;
     use crate::filters::network::NetworkFilterMaskHelper;
-    use crate::lists::{parse_filters, FilterFormat, ParseOptions};
+    use crate::lists::{parse_filters, FilterFormat, FilterSet, ParseOptions};
     use crate::test_utils::rules_from_lists;
 
     struct ListCounts {
@@ -1548,11 +1471,10 @@ mod legacy_rule_parsing_tests {
             "Number of collected filters does not match expectation"
         );
 
-        let blocker_options = BlockerOptions {
-            enable_optimizations: false, // optimizations will reduce number of rules
-        };
-
-        let blocker = Blocker::new_with_list_text(rules, &blocker_options);
+        let mut filter_set = FilterSet::new(true);
+        filter_set.add_filter_list(rules, Default::default());
+        let engine = Engine::new_with_filter_set(filter_set);
+        let blocker = Blocker::from_context(engine.filter_data_context());
 
         // Some filters in the filter_map are pointed at by multiple tokens, increasing the total number of items
         assert!(

--- a/tests/unit/blocker.rs
+++ b/tests/unit/blocker.rs
@@ -1473,7 +1473,7 @@ mod legacy_rule_parsing_tests {
 
         let mut filter_set = FilterSet::new(true);
         filter_set.add_filter_list(rules, Default::default());
-        let engine = Engine::new_with_filter_set(filter_set);
+        let engine = Engine::new_with_filter_set_no_optimize(filter_set);
         let blocker = Blocker::from_context(engine.filter_data_context());
 
         // Some filters in the filter_map are pointed at by multiple tokens, increasing the total number of items

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -2,7 +2,9 @@
 mod tests {
     use super::super::*;
     use crate::resources::MimeType;
-    use crate::{lists::FilterFormat, test_utils::rules_from_lists};
+    use crate::{
+        lists::FilterFormat, lists::ParseOptions, test_utils::rules_from_lists, FilterSet,
+    };
     use base64::{engine::Engine as _, prelude::BASE64_STANDARD};
     use seahash::hash;
 
@@ -21,7 +23,7 @@ mod tests {
             ("https://brave.com/about", true),
         ];
 
-        let mut engine = Engine::new_with_list_text(filters.join("\n"), Default::default());
+        let mut engine = Engine::new_with_list_text(filters.join("\n"));
         engine.enable_tags(&["stuff"]);
         engine.enable_tags(&["brian"]);
 
@@ -55,7 +57,7 @@ mod tests {
             ("https://brave.com/about", true),
         ];
 
-        let mut engine = Engine::new_with_list_text(filters.join("\n"), Default::default());
+        let mut engine = Engine::new_with_list_text(filters.join("\n"));
         engine.enable_tags(&["brian", "stuff"]);
         engine.disable_tags(&["stuff"]);
 
@@ -87,7 +89,7 @@ mod tests {
             ("https://brianbondy.com/advert", true),
         ];
 
-        let engine = Engine::new_with_list_text(filters.join("\n"), Default::default());
+        let engine = Engine::new_with_list_text(filters.join("\n"));
 
         url_results.into_iter().for_each(|(url, expected_result)| {
             let request = Request::new(url, "", "", "").unwrap();
@@ -117,7 +119,7 @@ mod tests {
             ("https://brianbondy.com/advert", false),
         ];
 
-        let mut engine = Engine::new_with_list_text(filters.join("\n"), Default::default());
+        let mut engine = Engine::new_with_list_text(filters.join("\n"));
         engine.enable_tags(&["brian", "stuff"]);
 
         url_results.into_iter().for_each(|(url, expected_result)| {
@@ -150,7 +152,7 @@ mod tests {
             ("https://brave.com/about", false),
         ];
 
-        let mut engine = Engine::new_with_list_text(filters.join("\n"), Default::default());
+        let mut engine = Engine::new_with_list_text(filters.join("\n"));
         engine.enable_tags(&["stuff"]);
         engine.enable_tags(&["brian"]);
         let serialized = engine.serialize();
@@ -181,7 +183,7 @@ mod tests {
 
     #[test]
     fn deserialization_generate_simple() {
-        let mut engine = Engine::new_with_list_text("ad-banner", Default::default());
+        let mut engine = Engine::new_with_list_text("ad-banner");
         let data = engine.serialize().to_vec();
         const EXPECTED_HASH: u64 = 16556115079021991714;
         assert_eq!(hash(&data), EXPECTED_HASH, "{HASH_MISMATCH_MSG}");
@@ -190,7 +192,7 @@ mod tests {
 
     #[test]
     fn deserialization_generate_tags() {
-        let mut engine = Engine::new_with_list_text("ad-banner$tag=abc", Default::default());
+        let mut engine = Engine::new_with_list_text("ad-banner$tag=abc");
         engine.use_tags(&["abc"]);
         let data = engine.serialize().to_vec();
         const EXPECTED_HASH: u64 = 4864047469838009851;
@@ -200,8 +202,7 @@ mod tests {
 
     #[test]
     fn deserialization_generate_resources() {
-        let mut engine =
-            Engine::new_with_list_text("ad-banner$redirect=nooptext", Default::default());
+        let mut engine = Engine::new_with_list_text("ad-banner$redirect=nooptext");
 
         engine.use_resources([
             Resource::simple("nooptext", MimeType::TextPlain, ""),
@@ -216,8 +217,7 @@ mod tests {
     #[test]
     fn deserialization_brave_list() {
         let rules = rules_from_lists(["data/brave/brave-main-list.txt"]);
-        let mut engine =
-            Engine::new_with_list_text_parametrised(rules, Default::default(), false, true);
+        let mut engine = Engine::new_with_list_text(rules);
         let data = engine.serialize().to_vec();
 
         #[cfg(feature = "debug-info")]
@@ -253,7 +253,6 @@ mod tests {
     fn redirect_resource_insertion_works() {
         let mut engine = Engine::new_with_list_text(
             ["ad-banner$redirect=nooptext", "script.js$redirect=noop.js"].join("\n"),
-            Default::default(),
         );
 
         let script = r#"
@@ -297,7 +296,7 @@ mod tests {
     fn document() {
         let filters = ["||example.com$document", "@@||sub.example.com$document"];
 
-        let engine = Engine::new_with_list_text(filters.join("\n"), Default::default());
+        let engine = Engine::new_with_list_text(filters.join("\n"));
 
         assert!(
             engine
@@ -332,7 +331,7 @@ mod tests {
     #[test]
     fn implicit_all() {
         {
-            let engine = Engine::new_with_list_text("||example.com^", Default::default());
+            let engine = Engine::new_with_list_text("||example.com^");
             assert!(
                 engine
                     .check_network_request(
@@ -343,8 +342,7 @@ mod tests {
             );
         }
         {
-            let engine =
-                Engine::new_with_list_text("||example.com^$first-party", Default::default());
+            let engine = Engine::new_with_list_text("||example.com^$first-party");
             assert!(
                 engine
                     .check_network_request(
@@ -355,7 +353,7 @@ mod tests {
             );
         }
         {
-            let engine = Engine::new_with_list_text("||example.com^$script", Default::default());
+            let engine = Engine::new_with_list_text("||example.com^$script");
             assert!(
                 !engine
                     .check_network_request(
@@ -366,7 +364,7 @@ mod tests {
             );
         }
         {
-            let engine = Engine::new_with_list_text("||example.com^$~script", Default::default());
+            let engine = Engine::new_with_list_text("||example.com^$~script");
             assert!(
                 !engine
                     .check_network_request(
@@ -379,7 +377,6 @@ mod tests {
         {
             let engine = Engine::new_with_list_text(
                 ["||example.com^$document", "@@||example.com^$generichide"].join("\n"),
-                Default::default(),
             );
             assert!(
                 engine
@@ -391,13 +388,15 @@ mod tests {
             );
         }
         {
-            let engine = Engine::new_with_list_text(
-                "example.com",
+            let mut filter_set = FilterSet::new(false);
+            filter_set.add_filter_list(
+                "example.com".to_string(),
                 ParseOptions {
                     format: FilterFormat::Hosts,
                     ..Default::default()
                 },
             );
+            let engine = Engine::new_with_filter_set(filter_set);
             assert!(
                 engine
                     .check_network_request(
@@ -408,7 +407,7 @@ mod tests {
             );
         }
         {
-            let engine = Engine::new_with_list_text("||example.com/path", Default::default());
+            let engine = Engine::new_with_list_text("||example.com/path");
             assert!(
                 !engine
                     .check_network_request(
@@ -424,7 +423,7 @@ mod tests {
             );
         }
         {
-            let engine = Engine::new_with_list_text("||example.com/path^", Default::default());
+            let engine = Engine::new_with_list_text("||example.com/path^");
             assert!(
                 !engine
                     .check_network_request(
@@ -443,10 +442,7 @@ mod tests {
 
     #[test]
     fn explicit_all() {
-        let engine = Engine::new_with_list_text(
-            "*$all,domain=rarvinzp.click|ytrqcxat.click",
-            Default::default(),
-        );
+        let engine = Engine::new_with_list_text("*$all,domain=rarvinzp.click|ytrqcxat.click");
         for content_type in [
             "script",
             "document",
@@ -492,7 +488,7 @@ mod tests {
             ("https://example2.com/test.html", vec![".block"], true),
         ];
 
-        let engine = Engine::new_with_list_text(filters, Default::default());
+        let engine = Engine::new_with_list_text(filters);
 
         url_results
             .into_iter()
@@ -516,7 +512,7 @@ mod tests {
             "||addthis.com^$important,3p,domain=~missingkids.com|~missingkids.org|~sainsburys.jobs|~sitecore.com|~amd.com",
             "||addthis.com/*/addthis_widget.js$script,redirect=addthis.com/addthis_widget.js",
         ], Default::default());
-        let mut engine = Engine::new_with_filter_set(filter_set, false);
+        let mut engine = Engine::new_with_filter_set(filter_set);
 
         engine.use_resources([Resource::simple(
             "addthis.com/addthis_widget.js",
@@ -534,7 +530,7 @@ mod tests {
     fn check_match_case_regex_filtering() {
         {
             // match case without regex is discarded
-            let engine = Engine::new_with_list_text("ad.png$match-case", Default::default());
+            let engine = Engine::new_with_list_text("ad.png$match-case");
             let request = Request::new(
                 "https://example.com/ad.png",
                 "https://example.com",
@@ -548,7 +544,6 @@ mod tests {
             // /^https:\/\/[0-9a-z]{3,}\.[-a-z]{10,}\.(?:li[fv]e|top|xyz)\/[a-z]{8}\/\?utm_campaign=\w{40,}/$doc,match-case,domain=life|live|top|xyz
             let engine = Engine::new_with_list_text(
                 r#"/^https:\/\/[0-9a-z]{3,}\.[-a-z]{10,}\.(?:li[fv]e|top|xyz)\/[a-z]{8}\/\?utm_campaign=\w{40,}/$doc,match-case,domain=life|live|top|xyz"#,
-                Default::default(),
             );
             let request = Request::new("https://www.exampleaaa.xyz/testtest/?utm_campaign=aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd", "https://www.exampleaaa.xyz/testtest/?utm_campaign=aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd", "document", "").unwrap();
             assert!(engine.check_network_request(&request).matched);
@@ -578,7 +573,6 @@ mod tests {
             // /^http:\/\/[a-z]{5}\.[a-z]{5}\.com\/[a-z]{10}\.apk$/$doc,match-case,domain=com
             let engine = Engine::new_with_list_text(
                 r#"/^http:\/\/[a-z]{5}\.[a-z]{5}\.com\/[a-z]{10}\.apk$/$doc,match-case,domain=com"#,
-                Default::default(),
             );
             let request = Request::new(
                 "http://abcde.abcde.com/aaaaabbbbb.apk",
@@ -621,7 +615,6 @@ mod tests {
             // /^https?:\/\/[a-z]{8,15}\.top\/[a-z]{4,}\.json$/$xhr,3p,match-case
             let engine = Engine::new_with_list_text(
                 r#"/^https?:\/\/[a-z]{8,15}\.top\/[a-z]{4,}\.json$/$xhr,3p,match-case"#,
-                Default::default(),
             );
             let request = Request::new(
                 "https://examples.top/abcd.json",
@@ -657,7 +650,6 @@ mod tests {
             // /^https?:\/\/cdn\.[a-z]{4,6}\.xyz\/app\.js$/$script,3p,match-case
             let engine = Engine::new_with_list_text(
                 r#"/^https?:\/\/cdn\.[a-z]{4,6}\.xyz\/app\.js$/$script,3p,match-case"#,
-                Default::default(),
             );
             let request = Request::new(
                 "https://cdn.abcde.xyz/app.js",
@@ -679,7 +671,6 @@ mod tests {
             // /^https:\/\/cdn\.jsdelivr\.net\/npm\/[-a-z_]{4,22}@latest\/dist\/script\.min\.js$/$script,3p,match-case
             let engine = Engine::new_with_list_text(
                 r#"/^https:\/\/cdn\.jsdelivr\.net\/npm\/[-a-z_]{4,22}@latest\/dist\/script\.min\.js$/$script,3p,match-case"#,
-                Default::default(),
             );
             let request = Request::new(
                 "https://cdn.jsdelivr.net/npm/abcd@latest/dist/script.min.js",
@@ -773,7 +764,7 @@ mod tests {
             },
         );
 
-        let mut engine = Engine::new_with_filter_set(filter_set, true);
+        let mut engine = Engine::new_with_filter_set(filter_set);
         engine.use_resources(resources);
 
         fn wrap_try(scriptlet_content: &str) -> String {
@@ -862,7 +853,7 @@ mod tests {
             r#"example.com##+js(trusted-set-local-storage-item, "test"test, 3)"#,
         ], Default::default());
 
-        let mut engine = Engine::new_with_filter_set(filter_set, true);
+        let mut engine = Engine::new_with_filter_set(filter_set);
         engine.use_resources(resources);
 
         assert_eq!(engine.url_cosmetic_resources("https://dailymail.co.uk").injected_script, r#"function trustedSetLocalStorageItem(key = '', value = '') { setLocalStorageItemFn('local', true, key, value); }
@@ -881,10 +872,8 @@ trustedSetLocalStorageItem("mol.ads.cmp.tcf.cache", "{\"getTCData\":{\"cmpId\":2
 
     #[test]
     fn method_option_blocks_post_xhr_only() {
-        let engine = Engine::new_with_list_text(
-            "||perplexity.ai/rest/metrics/collect^$xhr,1p,method=post",
-            Default::default(),
-        );
+        let engine =
+            Engine::new_with_list_text("||perplexity.ai/rest/metrics/collect^$xhr,1p,method=post");
         let url = "https://perplexity.ai/rest/metrics/collect?foo=bar";
         let source = "https://perplexity.ai/page";
 
@@ -917,7 +906,6 @@ trustedSetLocalStorageItem("mol.ads.cmp.tcf.cache", "{\"getTCData\":{\"cmpId\":2
     fn method_option_exception_head_get() {
         let engine = Engine::new_with_list_text(
             "||tracker.example.com^$xhr\n@@*$xhr,method=head|get,domain=app.axenthost.com,3p",
-            Default::default(),
         );
         let url = "https://tracker.example.com/pixel";
         let source = "https://app.axenthost.com/page";

--- a/tests/unit/filters/network_matchers.rs
+++ b/tests/unit/filters/network_matchers.rs
@@ -806,7 +806,7 @@ mod match_tests {
         {
             use crate::Engine;
             let filter = r#"/^https?:\/\/([0-9a-z\-]+\.)?(9anime|animeland|animenova|animeplus|animetoon|animewow|gamestorrent|goodanime|gogoanime|igg-games|kimcartoon|memecenter|readcomiconline|toonget|toonova|watchcartoononline)\.[a-z]{2,4}\/(?!([Ee]xternal|[Ii]mages|[Ss]cripts|[Uu]ploads|ac|ajax|assets|combined|content|cov|cover|(img\/bg)|(img\/icon)|inc|jwplayer|player|playlist-cat-rss|static|thumbs|wp-content|wp-includes)\/)(.*)/$image,other,script,~third-party,xmlhttprequest,domain=~animeland.hu"#;
-            let engine = Engine::new_with_list_text(filter, Default::default());
+            let engine = Engine::new_with_list_text(filter);
             let url = "https://9anime.to/watch/episode-1";
             let source = "https://9anime.to";
             let request = request::Request::new(url, source, "script", "").unwrap();

--- a/tests/unit/regex_manager.rs
+++ b/tests/unit/regex_manager.rs
@@ -7,7 +7,7 @@ mod tests {
     use mock_instant::thread_local::MockClock;
 
     fn make_engine(line: &str) -> Engine {
-        Engine::new_with_list_text(line, Default::default())
+        Engine::new_with_list_text(line)
     }
 
     fn make_request(url: &str) -> request::Request {

--- a/tests/unit/resources/resource_storage.rs
+++ b/tests/unit/resources/resource_storage.rs
@@ -834,18 +834,12 @@ mod shared_storage_tests {
 
         let shared_storage = Rc::new(in_memory_storage);
 
-        let mut engine1 = crate::Engine::new_with_list_text(
-            "example1.com##+js(test-scriptlet)",
-            Default::default(),
-        );
+        let mut engine1 = crate::Engine::new_with_list_text("example1.com##+js(test-scriptlet)");
         engine1.use_resource_storage(BraveCoreResourceStorage {
             shared_storage: Rc::clone(&shared_storage),
         });
 
-        let mut engine2 = crate::Engine::new_with_list_text(
-            "example2.com##+js(test-scriptlet)",
-            Default::default(),
-        );
+        let mut engine2 = crate::Engine::new_with_list_text("example2.com##+js(test-scriptlet)");
         engine2.use_resource_storage(BraveCoreResourceStorage {
             shared_storage: Rc::clone(&shared_storage),
         });


### PR DESCRIPTION
The PR refactors the public interface to remove excessive `optimize` param.