### PR TITLE
Added support for parsing ABP style injections in cosmetic filters.

### DIFF
--- a/src/filters/cosmetic.rs
+++ b/src/filters/cosmetic.rs
@@ -276,15 +276,8 @@ impl CosmeticFilter {
         })
     }
 
-    fn normalize_abp_inline_style(body: &str) -> String {
-        let trimmed = body.trim().trim_end_matches(';').trim();
-        if trimmed.contains("!important") {
-            format!("{trimmed};")
-        } else {
-            format!("{trimmed} !important;")
-        }
-    }
-
+    /// Turns a string of the format `.selector { background: red }` into
+    /// `Some((".selector", "background: red"))`.
     fn split_abp_brace_suffix(s: &str) -> Option<(&str, &str)> {
         if !s.ends_with('}') {
             return None;
@@ -301,27 +294,26 @@ impl CosmeticFilter {
         Some((selector, body))
     }
 
+    /// Returns `Some(true)` for ` remove: true; ` with optional whitespace and semicolon,
+    /// `Some(false)` for the corresponding false construction, or `None` otherwise.
     fn parse_abp_remove_body(body: &str) -> Option<bool> {
-        let mut rest = body.trim();
-        if !rest.starts_with("remove") {
+        let (key, mut val) = body.split_once(":")?;
+        if key.trim() != "remove" {
             return None;
         }
-        rest = rest["remove".len()..].trim_start();
-        if !rest.starts_with(':') {
-            return None;
+        val = val.trim();
+        if let Some(stripped_val) = val.strip_suffix(';') {
+            val = stripped_val;
         }
-        rest = rest[1..].trim_start();
-        let value = rest.trim_end_matches(|c: char| c == ';' || c.is_ascii_whitespace());
-        Some(value == "true")
+        match val {
+            "true" => Some(true),
+            "false" => Some(false),
+            _ => None,
+        }
     }
 
-    fn is_display_none_important(body: &str) -> bool {
-        let normalized = body
-            .trim()
-            .trim_end_matches(|c: char| c == ';' || c.is_ascii_whitespace());
-        normalized.eq_ignore_ascii_case("display: none !important")
-    }
-
+    /// Parses ABP curly-bracketed style injections and `remove:` directives into corresponding
+    /// `CosmeticFilterAction`s.
     fn parse_abp_style_injection(
         after_sharp: &str,
     ) -> Option<Result<(&str, Option<CosmeticFilterAction>), CosmeticFilterError>> {
@@ -336,9 +328,7 @@ impl CosmeticFilter {
         Some(match Self::parse_abp_remove_body(body) {
             Some(true) => Ok((selector, Some(CosmeticFilterAction::Remove))),
             Some(false) => Err(CosmeticFilterError::InvalidActionSpecifier),
-            None if Self::is_display_none_important(body) => Ok((selector, None)),
-            None => CosmeticFilterAction::new_style(&Self::normalize_abp_inline_style(body))
-                .map(|action| (selector, Some(action))),
+            None => CosmeticFilterAction::new_style(body).map(|action| (selector, Some(action))),
         })
     }
 

--- a/src/filters/cosmetic.rs
+++ b/src/filters/cosmetic.rs
@@ -276,6 +276,72 @@ impl CosmeticFilter {
         })
     }
 
+    fn normalize_abp_inline_style(body: &str) -> String {
+        let trimmed = body.trim().trim_end_matches(';').trim();
+        if trimmed.contains("!important") {
+            format!("{trimmed};")
+        } else {
+            format!("{trimmed} !important;")
+        }
+    }
+
+    fn split_abp_brace_suffix(s: &str) -> Option<(&str, &str)> {
+        if !s.ends_with('}') {
+            return None;
+        }
+        let open = s.rfind('{')?;
+        if open == 0 {
+            return None;
+        }
+        let selector = s[..open].trim_end();
+        let body = s[open + 1..s.len() - 1].trim();
+        if selector.is_empty() {
+            return None;
+        }
+        Some((selector, body))
+    }
+
+    fn parse_abp_remove_body(body: &str) -> Option<bool> {
+        let mut rest = body.trim();
+        if !rest.starts_with("remove") {
+            return None;
+        }
+        rest = rest["remove".len()..].trim_start();
+        if !rest.starts_with(':') {
+            return None;
+        }
+        rest = rest[1..].trim_start();
+        let value = rest.trim_end_matches(|c: char| c == ';' || c.is_ascii_whitespace());
+        Some(value == "true")
+    }
+
+    fn is_display_none_important(body: &str) -> bool {
+        let normalized = body
+            .trim()
+            .trim_end_matches(|c: char| c == ';' || c.is_ascii_whitespace());
+        normalized.eq_ignore_ascii_case("display: none !important")
+    }
+
+    fn parse_abp_style_injection(
+        after_sharp: &str,
+    ) -> Option<Result<(&str, Option<CosmeticFilterAction>), CosmeticFilterError>> {
+        let (selector, body) = match Self::split_abp_brace_suffix(after_sharp) {
+            Some(parts) => parts,
+            None if after_sharp.ends_with('}') => {
+                return Some(Err(CosmeticFilterError::InvalidActionSpecifier));
+            }
+            None => return None,
+        };
+
+        Some(match Self::parse_abp_remove_body(body) {
+            Some(true) => Ok((selector, Some(CosmeticFilterAction::Remove))),
+            Some(false) => Err(CosmeticFilterError::InvalidActionSpecifier),
+            None if Self::is_display_none_important(body) => Ok((selector, None)),
+            None => CosmeticFilterAction::new_style(&Self::normalize_abp_inline_style(body))
+                .map(|action| (selector, Some(action))),
+        })
+    }
+
     /// Parses the contents of a cosmetic filter rule following the `##` or `#@#` separator.
     ///
     /// On success, returns `selector` and `style` according to the rule.
@@ -288,6 +354,10 @@ impl CosmeticFilter {
     ) -> Result<(&str, Option<CosmeticFilterAction>), CosmeticFilterError> {
         if after_sharp.starts_with('^') {
             return Err(CosmeticFilterError::HtmlFilteringUnsupported);
+        }
+
+        if let Some(result) = Self::parse_abp_style_injection(after_sharp) {
+            return result;
         }
 
         const STYLE_TOKEN: &[u8] = b":style(";

--- a/tests/unit/blocker.rs
+++ b/tests/unit/blocker.rs
@@ -1407,7 +1407,7 @@ mod legacy_rule_parsing_tests {
     const EASY_LIST: ListCounts = ListCounts {
         filters: 60368 - 692,
         cosmetic_filters: if cfg!(feature = "css-validation") {
-            24060
+            24072
         } else {
             24078
         },

--- a/tests/unit/cosmetic_filter_cache.rs
+++ b/tests/unit/cosmetic_filter_cache.rs
@@ -307,6 +307,39 @@ mod cosmetic_cache_tests {
     }
 
     #[test]
+    fn abp_style_injection_remove() {
+        let cfcache = cache_from_rules(vec![
+            "example.com##.element {remove: true;}",
+            r#"chip.de##.ft-charts-main > div:not(.List):not(.caps) {remove:true;}"#,
+        ]);
+        let resources = ResourceStorage::default();
+
+        let out = cfcache.hostname_cosmetic_resources(&resources, "example.com", false);
+        let mut expected = UrlSpecificResources::empty();
+        expected.procedural_actions.insert(
+            serde_json::to_string(&ProceduralOrActionFilter {
+                selector: vec![CosmeticFilterOperator::CssSelector(".element".to_string())],
+                action: Some(CosmeticFilterAction::Remove),
+            })
+            .unwrap(),
+        );
+        assert_eq!(out, expected);
+
+        let out = cfcache.hostname_cosmetic_resources(&resources, "chip.de", false);
+        expected.procedural_actions.clear();
+        expected.procedural_actions.insert(
+            serde_json::to_string(&ProceduralOrActionFilter {
+                selector: vec![CosmeticFilterOperator::CssSelector(
+                    r#".ft-charts-main > div:not(.List):not(.caps)"#.to_string(),
+                )],
+                action: Some(CosmeticFilterAction::Remove),
+            })
+            .unwrap(),
+        );
+        assert_eq!(out, expected);
+    }
+
+    #[test]
     fn remove_attr_exceptions() {
         let cfcache = cache_from_rules(vec![
             "example.com,~sub.example.com##.element:remove-attr(style)",

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -237,9 +237,9 @@ mod tests {
             );
         }
         let expected_hash: u64 = if cfg!(feature = "css-validation") {
-            18006544876284176656
+            5342093731695387413
         } else {
-            7678096075090154250
+            2744138504590463392
         };
 
         assert_eq!(hash(&data), expected_hash, "{HASH_MISMATCH_MSG}");

--- a/tests/unit/filters/cosmetic.rs
+++ b/tests/unit/filters/cosmetic.rs
@@ -856,6 +856,102 @@ mod parse_tests {
         let rule = parse_cf("test.com#@#+js(nowebrtc.js)").unwrap();
         assert!(rule.hidden_generic_rule().is_none());
     }
+
+    #[test]
+    fn abp_style_injection() {
+        check_parse_result(
+            "example.com###remove-id {remove: true;}",
+            CosmeticFilterBreakdown {
+                hostnames: sort_hash_domains(vec!["example.com"]),
+                selector: SelectorType::PlainCss("#remove-id".to_string()),
+                action: Some(CosmeticFilterAction::Remove),
+                ..Default::default()
+            },
+        );
+        check_parse_result(
+            r#"example.com##div[style*="width: 45px;"] {remove: true;}"#,
+            CosmeticFilterBreakdown {
+                hostnames: sort_hash_domains(vec!["example.com"]),
+                selector: SelectorType::PlainCss(r#"div[style*="width: 45px;"]"#.to_string()),
+                action: Some(CosmeticFilterAction::Remove),
+                ..Default::default()
+            },
+        );
+        check_parse_result(
+            r#"chip.de##.ft-charts-main > div:not(.List):not(.caps) {remove:true;}"#,
+            CosmeticFilterBreakdown {
+                hostnames: sort_hash_domains(vec!["chip.de"]),
+                selector: SelectorType::PlainCss(
+                    r#".ft-charts-main > div:not(.List):not(.caps)"#.to_string(),
+                ),
+                action: Some(CosmeticFilterAction::Remove),
+                ..Default::default()
+            },
+        );
+        check_parse_result(
+            "example.com###inline-css-id {background-color: #0dc74b;}",
+            CosmeticFilterBreakdown {
+                hostnames: sort_hash_domains(vec!["example.com"]),
+                selector: SelectorType::PlainCss("#inline-css-id".to_string()),
+                action: Some(CosmeticFilterAction::Style(
+                    "background-color: #0dc74b !important;".into(),
+                )),
+                ..Default::default()
+            },
+        );
+        check_parse_result(
+            "example.com##.ad {display: none !important;}",
+            CosmeticFilterBreakdown {
+                hostnames: sort_hash_domains(vec!["example.com"]),
+                selector: SelectorType::PlainCss(".ad".to_string()),
+                action: None,
+                ..Default::default()
+            },
+        );
+        assert!(parse_cf("example.com##.ad {remove: false}").is_err());
+        #[cfg(feature = "css-validation")]
+        assert!(parse_cf("example.com##.ad { background: url(https://evil.com) }").is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "css-validation")]
+    fn abp_style_injection_extended() {
+        let rule = parse_cf("example.com#?#div:has(>div>span.remove-has) {remove: true;}").unwrap();
+        assert_eq!(rule.action, Some(CosmeticFilterAction::Remove));
+        assert_eq!(
+            rule.plain_css_selector(),
+            Some("div:has(>div>span.remove-has)")
+        );
+
+        let rule =
+            parse_cf("example.com#?#span:has-text(remove-has-text) {remove: true;}").unwrap();
+        assert_eq!(rule.action, Some(CosmeticFilterAction::Remove));
+        assert_eq!(rule.selector.len(), 2);
+
+        let rule = parse_cf("example.com#?##span-inline-css {background-color: #0dc74b;}").unwrap();
+        assert_eq!(
+            rule.action,
+            Some(CosmeticFilterAction::Style(
+                "background-color: #0dc74b !important;".into()
+            ))
+        );
+        assert_eq!(rule.plain_css_selector(), Some("#span-inline-css"));
+
+        let rule = parse_cf(
+            "example.com#?#div:-abp-has(>div>span.inline-css-abp-has) {background-color: #0dc74b;}",
+        )
+        .unwrap();
+        assert_eq!(
+            rule.action,
+            Some(CosmeticFilterAction::Style(
+                "background-color: #0dc74b !important;".into()
+            ))
+        );
+        assert_eq!(
+            rule.plain_css_selector(),
+            Some("div:has(>div>span.inline-css-abp-has)")
+        );
+    }
 }
 
 #[cfg(test)]

--- a/tests/unit/filters/cosmetic.rs
+++ b/tests/unit/filters/cosmetic.rs
@@ -858,6 +858,52 @@ mod parse_tests {
     }
 
     #[test]
+    fn abp_style_helpers() {
+        {
+            let input = ".selector { background: red }";
+            let output = CosmeticFilter::split_abp_brace_suffix(input);
+            assert_eq!(output, Some((".selector", "background: red")));
+        }
+        {
+            assert_eq!(
+                CosmeticFilter::parse_abp_remove_body("  remove:  true;  "),
+                Some(true)
+            );
+            assert_eq!(
+                CosmeticFilter::parse_abp_remove_body(" remove: true "),
+                Some(true)
+            );
+            assert_eq!(
+                CosmeticFilter::parse_abp_remove_body("remove:true;"),
+                Some(true)
+            );
+            assert_eq!(
+                CosmeticFilter::parse_abp_remove_body("  remove:  false;  "),
+                Some(false)
+            );
+            assert_eq!(
+                CosmeticFilter::parse_abp_remove_body(" remove: false "),
+                Some(false)
+            );
+            assert_eq!(
+                CosmeticFilter::parse_abp_remove_body("remove:false;"),
+                Some(false)
+            );
+
+            assert_eq!(
+                CosmeticFilter::parse_abp_remove_body("remove:true; background: red;"),
+                None
+            );
+            assert_eq!(
+                CosmeticFilter::parse_abp_remove_body("remove:true; remove: true;"),
+                None
+            );
+            assert_eq!(CosmeticFilter::parse_abp_remove_body("remove:true;;"), None);
+            assert_eq!(CosmeticFilter::parse_abp_remove_body("remove::true"), None);
+        }
+    }
+
+    #[test]
     fn abp_style_injection() {
         check_parse_result(
             "example.com###remove-id {remove: true;}",
@@ -894,17 +940,17 @@ mod parse_tests {
                 hostnames: sort_hash_domains(vec!["example.com"]),
                 selector: SelectorType::PlainCss("#inline-css-id".to_string()),
                 action: Some(CosmeticFilterAction::Style(
-                    "background-color: #0dc74b !important;".into(),
+                    "background-color: #0dc74b;".into(),
                 )),
                 ..Default::default()
             },
         );
         check_parse_result(
-            "example.com##.ad {display: none !important;}",
+            "example.com##.ad {display: none;}",
             CosmeticFilterBreakdown {
                 hostnames: sort_hash_domains(vec!["example.com"]),
                 selector: SelectorType::PlainCss(".ad".to_string()),
-                action: None,
+                action: Some(CosmeticFilterAction::Style("display: none;".into())),
                 ..Default::default()
             },
         );
@@ -932,7 +978,7 @@ mod parse_tests {
         assert_eq!(
             rule.action,
             Some(CosmeticFilterAction::Style(
-                "background-color: #0dc74b !important;".into()
+                "background-color: #0dc74b;".into()
             ))
         );
         assert_eq!(rule.plain_css_selector(), Some("#span-inline-css"));
@@ -944,7 +990,7 @@ mod parse_tests {
         assert_eq!(
             rule.action,
             Some(CosmeticFilterAction::Style(
-                "background-color: #0dc74b !important;".into()
+                "background-color: #0dc74b;".into()
             ))
         );
         assert_eq!(


### PR DESCRIPTION
Closes https://github.com/brave/adblock-rust/issues/415