### PR TITLE
[perf] Optimize optimizer::*

### DIFF
--- a/src/filters/fb_network_builder.rs
+++ b/src/filters/fb_network_builder.rs
@@ -164,7 +164,10 @@ impl<'a, 'f> NetworkFilterListBuilder<'a, 'f> {
             }
         };
 
-        if !self.optimize || !optimizer::is_filter_optimizable_by_patterns(&network_filter) {
+        if !self.optimize
+            || !optimizer::is_filter_optimizable_by_patterns(&network_filter)
+            || multi_tokens != FilterTokens::Empty
+        {
             // Serialize now (even if it matches to a bad filter later);
             // Although store the id for later bad-filter pruning.
             let filter = FlatSerialize::serialize(network_filter, builder);

--- a/src/filters/network.rs
+++ b/src/filters/network.rs
@@ -326,7 +326,7 @@ impl From<&request::RequestType> for NetworkFilterMask {
 pub enum FilterPart<'a> {
     Empty,
     Simple(Cow<'a, str>),
-    AnyOf(Vec<String>),
+    AnyOf(Vec<Cow<'a, str>>),
 }
 
 #[derive(Debug, PartialEq)]
@@ -1036,7 +1036,11 @@ impl<'a> NetworkFilter<'a> {
                 tokens_buffer.push(utils::fast_hash("https"));
             }
 
-            FilterTokens::Other
+            if tokens_buffer.is_empty() {
+                FilterTokens::Empty
+            } else {
+                FilterTokens::Other
+            }
         }
     }
 

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 
 trait Optimization {
-    fn fusion<'a>(&self, filters: &[NetworkFilter<'a>]) -> NetworkFilter<'a>;
+    fn fusion<'a>(&self, filters: Vec<NetworkFilter<'a>>) -> NetworkFilter<'a>;
     fn group_by_criteria(&self, filter: &NetworkFilter<'_>) -> String;
     fn select(&self, filter: &NetworkFilter<'_>) -> bool;
 }
@@ -64,7 +64,7 @@ fn apply_optimisation<'a, T: Optimization>(
     for (_, group) in to_fuse {
         if group.len() > 1 {
             // println!("Fusing {} filters together", group.len());
-            fused.push(optimization.fusion(group.as_slice()));
+            fused.push(optimization.fusion(group));
         } else {
             group.into_iter().for_each(|f| negative.push(f));
         }
@@ -87,53 +87,55 @@ struct SimplePatternGroup {}
 impl Optimization for SimplePatternGroup {
     // Group simple patterns, into a single filter
 
-    fn fusion<'a>(&self, filters: &[NetworkFilter<'a>]) -> NetworkFilter<'a> {
+    fn fusion<'a>(&self, filters: Vec<NetworkFilter<'a>>) -> NetworkFilter<'a> {
         let base_filter = &filters[0]; // FIXME: can technically panic, if filters list is empty
         let mut filter = base_filter.clone();
+
+        let is_regex = filters.iter().any(NetworkFilter::is_regex);
+        let is_complete_regex = filters.iter().any(|f| f.is_complete_regex());
+        filter.mask.set(NetworkFilterMask::IS_REGEX, is_regex);
+        filter
+            .mask
+            .set(NetworkFilterMask::IS_COMPLETE_REGEX, is_complete_regex);
+
+        let mut combined_raw_line = String::new();
 
         // if any filter is empty (meaning matches anything), the entire combiation matches anything
         if filters
             .iter()
             .any(|f| matches!(f.filter, FilterPart::Empty))
         {
-            filter.filter = FilterPart::Empty
+            filter.filter = FilterPart::Empty;
+            filter
         } else {
-            let mut flat_patterns: Vec<String> = Vec::with_capacity(filters.len());
+            let mut flat_patterns: Vec<Cow<'a, str>> = Vec::with_capacity(filters.len());
             for f in filters {
-                match &f.filter {
+                match f.filter {
                     FilterPart::Empty => (),
-                    FilterPart::Simple(s) => flat_patterns.push(s.to_string()),
-                    FilterPart::AnyOf(s) => flat_patterns.extend(s.iter().cloned()),
+                    FilterPart::Simple(s) => flat_patterns.push(s.clone()),
+                    FilterPart::AnyOf(s) => flat_patterns.extend(s),
+                }
+                if let Some(raw_line) = f.raw_line {
+                    if !combined_raw_line.is_empty() {
+                        combined_raw_line.push_str(" <+> ");
+                    }
+
+                    combined_raw_line.push_str(raw_line.as_ref());
                 }
             }
 
             if flat_patterns.is_empty() {
                 filter.filter = FilterPart::Empty;
             } else if flat_patterns.len() == 1 {
-                filter.filter =
-                    FilterPart::Simple(Cow::Owned(flat_patterns.into_iter().next().unwrap()))
+                filter.filter = FilterPart::Simple(flat_patterns.into_iter().next().unwrap())
             } else {
                 filter.filter = FilterPart::AnyOf(flat_patterns)
             }
+
+            filter.raw_line = Some(Cow::Owned(combined_raw_line));
+
+            filter
         }
-
-        let is_regex = filters.iter().any(NetworkFilter::is_regex);
-        filter.mask.set(NetworkFilterMask::IS_REGEX, is_regex);
-        let is_complete_regex = filters.iter().any(|f| f.is_complete_regex());
-        filter
-            .mask
-            .set(NetworkFilterMask::IS_COMPLETE_REGEX, is_complete_regex);
-
-        if base_filter.raw_line.is_some() {
-            filter.raw_line = Some(Cow::Owned(
-                filters
-                    .iter()
-                    .flat_map(|f| f.raw_line.as_deref())
-                    .join(" <+> "),
-            ))
-        }
-
-        filter
     }
 
     fn group_by_criteria(&self, filter: &NetworkFilter<'_>) -> String {

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -98,7 +98,13 @@ impl Optimization for SimplePatternGroup {
             .mask
             .set(NetworkFilterMask::IS_COMPLETE_REGEX, is_complete_regex);
 
-        let mut combined_raw_line = String::new();
+        let combined_raw_line = filters
+            .iter()
+            .filter_map(|f| f.raw_line.as_deref())
+            .join(" <+> ");
+        if !combined_raw_line.is_empty() {
+            filter.raw_line = Some(Cow::Owned(combined_raw_line));
+        }
 
         // if any filter is empty (meaning matches anything), the entire combiation matches anything
         if filters
@@ -106,21 +112,13 @@ impl Optimization for SimplePatternGroup {
             .any(|f| matches!(f.filter, FilterPart::Empty))
         {
             filter.filter = FilterPart::Empty;
-            filter
         } else {
             let mut flat_patterns: Vec<Cow<'a, str>> = Vec::with_capacity(filters.len());
             for f in filters {
                 match f.filter {
                     FilterPart::Empty => (),
-                    FilterPart::Simple(s) => flat_patterns.push(s.clone()),
+                    FilterPart::Simple(s) => flat_patterns.push(s),
                     FilterPart::AnyOf(s) => flat_patterns.extend(s),
-                }
-                if let Some(raw_line) = f.raw_line {
-                    if !combined_raw_line.is_empty() {
-                        combined_raw_line.push_str(" <+> ");
-                    }
-
-                    combined_raw_line.push_str(raw_line.as_ref());
                 }
             }
 
@@ -131,11 +129,9 @@ impl Optimization for SimplePatternGroup {
             } else {
                 filter.filter = FilterPart::AnyOf(flat_patterns)
             }
-
-            filter.raw_line = Some(Cow::Owned(combined_raw_line));
-
-            filter
         }
+
+        filter
     }
 
     fn group_by_criteria(&self, filter: &NetworkFilter<'_>) -> String {

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -183,7 +183,7 @@ mod tests {
     fn deserialization_generate_simple() {
         let mut engine = Engine::new_with_list_text("ad-banner", Default::default());
         let data = engine.serialize().to_vec();
-        const EXPECTED_HASH: u64 = 16556115079021991714;
+        const EXPECTED_HASH: u64 = 3613512756023067609;
         assert_eq!(hash(&data), EXPECTED_HASH, "{HASH_MISMATCH_MSG}");
         engine.deserialize(&data).unwrap();
     }
@@ -193,7 +193,7 @@ mod tests {
         let mut engine = Engine::new_with_list_text("ad-banner$tag=abc", Default::default());
         engine.use_tags(&["abc"]);
         let data = engine.serialize().to_vec();
-        const EXPECTED_HASH: u64 = 4864047469838009851;
+        const EXPECTED_HASH: u64 = 8313881767139358102;
         assert_eq!(hash(&data), EXPECTED_HASH, "{HASH_MISMATCH_MSG}");
         engine.deserialize(&data).unwrap();
     }
@@ -239,9 +239,9 @@ mod tests {
             );
         }
         let expected_hash: u64 = if cfg!(feature = "css-validation") {
-            2977715961033378463
+            17575612365605355400
         } else {
-            14988656075164302061
+            13994449514469268008
         };
 
         assert_eq!(hash(&data), expected_hash, "{HASH_MISMATCH_MSG}");

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -239,9 +239,9 @@ mod tests {
             );
         }
         let expected_hash: u64 = if cfg!(feature = "css-validation") {
-            17575612365605355400
+            12514532033605239604
         } else {
-            13994449514469268008
+            2395390540565376956
         };
 
         assert_eq!(hash(&data), expected_hash, "{HASH_MISMATCH_MSG}");

--- a/tests/unit/optimizer.rs
+++ b/tests/unit/optimizer.rs
@@ -81,7 +81,7 @@ mod optimization_tests_pattern_group {
                 .iter()
                 .for_each(|f| assert!(optimization.select(f), "Expected rule to be selected"));
 
-            let fused = optimization.fusion(&filters);
+            let fused = optimization.fusion(filters);
 
             assert!(!fused.is_regex(), "Expected rule to not be a regex");
             assert_eq!(
@@ -358,7 +358,7 @@ mod optimization_tests_pattern_group {
             .iter()
             .for_each(|f| assert!(optimization.select(f), "Expected rule to be selected"));
 
-        let fused = optimization.fusion(&filters);
+        let fused = optimization.fusion(filters);
 
         assert!(!fused.is_regex(), "Expected rule to not be a regex");
         assert_eq!(


### PR DESCRIPTION
The PR refactor optimizer to save some CPU cycles:
* Limit optimization to  only zero bucket. In it's the major perf contributor, the optimization of the other buckets takes time, but doesn't improve matching speed
* Make  returns `FilterPart::Empty`
* Avoid copying strings


Results:
```
rule-match-browserlike/brave-list (~no changes)
                        time:   [974.51 ms 976.71 ms 979.25 ms]
                 change:
                        time:   [−2.7796% −0.6972% +1.1310%] (p = 0.55 > 0.05)

blocker_new/brave-list (-4%)
                        time:   [50.150 ms 50.451 ms 50.909 ms]
                 change:
                        time:   [−5.2076% −4.1600% −3.2241%] (p = 0.00 < 0.05)
```