### PR TITLE
Parse AdGuard `#$#` CSS injection as style/remove actions

### DIFF
--- a/src/filters/cosmetic.rs
+++ b/src/filters/cosmetic.rs
@@ -429,6 +429,7 @@ impl CosmeticFilter {
             };
 
             let mut translate_abp_syntax = false;
+            let mut adguard_css_injection = false;
 
             // Consume filter options embedded in the `##` marker:
             let mut between_sharps = &line[after_sharp_index..second_sharp_index];
@@ -445,10 +446,15 @@ impl CosmeticFilter {
                 // `#%#` / `#@%#`
                 return Err(CosmeticFilterError::UnsupportedSyntax);
             }
-            if between_sharps.starts_with('$') {
-                // AdGuard `:style` syntax - not supported for now
-                // `#$?#` for CSS rules, `#@$?#` — for exceptions
-                return Err(CosmeticFilterError::UnsupportedSyntax);
+            if let Some(rest) = between_sharps.strip_prefix('$') {
+                // AdGuard CSS injection: `#$#selector { ... }` (and the extended
+                // `#$?#` / exception `#@$#` forms). Only the style/remove form is
+                // handled here — it always carries a `{ ... }` body, which is
+                // parsed by `parse_after_sharp_nonscript` below. ABP snippet
+                // injection also uses `#$#` but has no braces; those produce no
+                // action and are rejected after the selector parse.
+                adguard_css_injection = true;
+                between_sharps = rest;
             }
             if between_sharps.starts_with('?') {
                 // ABP/ADG extended CSS syntax:
@@ -506,6 +512,12 @@ impl CosmeticFilter {
                 }
                 (validated_selector, action)
             };
+
+            if adguard_css_injection && action.is_none() {
+                // `#$#` without a `{ ... }` block is ABP snippet injection, which
+                // is not supported.
+                return Err(CosmeticFilterError::UnsupportedSyntax);
+            }
 
             if (not_entities.is_some() || not_hostnames.is_some())
                 && mask.contains(CosmeticFilterMask::UNHIDE)

--- a/tests/unit/filters/cosmetic.rs
+++ b/tests/unit/filters/cosmetic.rs
@@ -960,6 +960,62 @@ mod parse_tests {
     }
 
     #[test]
+    fn adguard_css_injection() {
+        check_parse_result(
+            "businesshemden.com#$#.mnd-cookie-modal { display: none !important; }",
+            CosmeticFilterBreakdown {
+                hostnames: sort_hash_domains(vec!["businesshemden.com"]),
+                selector: SelectorType::PlainCss(".mnd-cookie-modal".to_string()),
+                action: Some(CosmeticFilterAction::Style(
+                    "display: none !important;".into(),
+                )),
+                ..Default::default()
+            },
+        );
+        check_parse_result(
+            "makeuseof.com#$#body div.fc-consent-root { display: none !important; }",
+            CosmeticFilterBreakdown {
+                hostnames: sort_hash_domains(vec!["makeuseof.com"]),
+                selector: SelectorType::PlainCss("body div.fc-consent-root".to_string()),
+                action: Some(CosmeticFilterAction::Style(
+                    "display: none !important;".into(),
+                )),
+                ..Default::default()
+            },
+        );
+        // `#$#` also accepts the `remove:` directive.
+        check_parse_result(
+            "example.com#$#.ad { remove: true; }",
+            CosmeticFilterBreakdown {
+                hostnames: sort_hash_domains(vec!["example.com"]),
+                selector: SelectorType::PlainCss(".ad".to_string()),
+                action: Some(CosmeticFilterAction::Remove),
+                ..Default::default()
+            },
+        );
+        // ABP snippet injection also uses `#$#` but has no `{ ... }` body — it must
+        // remain unsupported rather than being misparsed as a plain selector.
+        assert!(parse_cf("example.com#$#abort-on-property-read alert").is_err());
+        // Generic (hostname-less) injection is rejected like any other action.
+        assert!(parse_cf("#$#.ad { display: none !important; }").is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "css-validation")]
+    fn adguard_css_injection_extended() {
+        // `#$?#` is the extended (procedural) AdGuard CSS-injection form.
+        let rule =
+            parse_cf("example.com#$?#div:has(>div>span.ad) { display: none !important; }").unwrap();
+        assert_eq!(
+            rule.action,
+            Some(CosmeticFilterAction::Style(
+                "display: none !important;".into()
+            ))
+        );
+        assert_eq!(rule.plain_css_selector(), Some("div:has(>div>span.ad)"));
+    }
+
+    #[test]
     #[cfg(feature = "css-validation")]
     fn abp_style_injection_extended() {
         let rule = parse_cf("example.com#?#div:has(>div>span.remove-has) {remove: true;}").unwrap();

--- a/tests/unit/lists.rs
+++ b/tests/unit/lists.rs
@@ -427,25 +427,17 @@ mod tests {
             ));
         }
         {
+            // AdGuard `#$#` CSS injection is now parsed as a style action.
             let input = "nczas.com#$#.adsbygoogle { position: absolute!important; left: -3000px!important; }";
             let result = parse_filter(input, true, Default::default());
-            assert!(matches!(
-                result,
-                Err(FilterParseError::Cosmetic(
-                    CosmeticFilterError::UnsupportedSyntax
-                ))
-            ));
+            assert!(matches!(result, Ok(ParsedFilter::Cosmetic(..))));
         }
         {
+            // AdGuard `#@$#` is the exception form of CSS injection.
             let input =
                 "kurnik.pl#@$#.adsbygoogle { height: 1px !important; width: 1px !important; }";
             let result = parse_filter(input, true, Default::default());
-            assert!(matches!(
-                result,
-                Err(FilterParseError::Cosmetic(
-                    CosmeticFilterError::UnsupportedSyntax
-                ))
-            ));
+            assert!(matches!(result, Ok(ParsedFilter::Cosmetic(..))));
         }
     }
 }


### PR DESCRIPTION
## Summary

AdGuard's `#$#` CSS-injection syntax (e.g. `businesshemden.com#$#.mnd-cookie-modal { display: none !important; }`) was rejected outright as `UnsupportedSyntax`. This routes it through the same brace-body parser added in #678 for the uBO/ABP `##selector { ... }` form, producing a `Style` (or `remove:` → `Remove`) action.

```
businesshemden.com#$#.mnd-cookie-modal { display: none !important; }
  →  Style(".mnd-cookie-modal" => "display: none !important;")
```

## Details

- The `between_sharps.starts_with('$')` branch now **consumes** the `$` and sets a flag instead of erroring. The existing `?` and leading-`@` handlers then cover the extended `#$?#` and exception `#@$#` forms with no extra code.
- A post-parse guard rejects any `#$#` rule that produced **no action**. This is the key safety check: **ABP snippet injection** also uses `#$#` but has no `{ ... }` body (e.g. `example.com#$#abort-on-property-read alert`), and must stay unsupported rather than being misparsed as a plain CSS selector.
- `#%#` / `#@%#` (AdGuard JS/scriptlet) remain unsupported — scope is limited to the CSS style/remove form.

## Behavior change

Two existing assertions in `tests/unit/lists.rs` that expected `#$#` / `#@$#` to be `UnsupportedSyntax` are updated to expect successful parsing — this is the intended contract change.

## Tests

`cargo fmt --check` clean; full lib suite passes under both default and `css-validation` features. Adds `adguard_css_injection` (style, multi-class selector, `remove:`, ABP-snippet rejection, generic rejection) and `adguard_css_injection_extended` (`#$?#`).