### PR TITLE
deprecate tagged filters

### DIFF
--- a/examples/deserialization.rs
+++ b/examples/deserialization.rs
@@ -51,7 +51,6 @@ fn main() {
             .expect("Deserialization failed");
         // engine = get_blocker_engine();
     }
-    engine.use_tags(&["twitter-embeds"]);
 
     println!("Sleeping");
     std::thread::sleep(std::time::Duration::from_secs(5));

--- a/examples/generate-dat.rs
+++ b/examples/generate-dat.rs
@@ -6,14 +6,13 @@ use std::io::prelude::*;
 fn main() {
     // Rules we want to serialize
     let rules = [
-        String::from("||platform.twitter.com/$tag=twitter-embeds"),
-        String::from("@@||platform.twitter.com/$tag=twitter-embeds"),
+        String::from("||platform.twitter.com^"),
+        String::from("@@||platform.twitter.com^"),
     ]
     .join("\n");
 
     // Serialize
-    let mut engine = Engine::new_with_list_text(rules);
-    engine.use_tags(&["twitter-embeds"]);
+    let engine = Engine::new_with_list_text(rules);
 
     let request = Request::new(
         "https://platform.twitter.com/widgets.js",

--- a/examples/use-dat.rs
+++ b/examples/use-dat.rs
@@ -14,7 +14,6 @@ fn main() {
 
     // Deserialize
     engine.deserialize(&buffer).unwrap();
-    engine.use_tags(&["twitter-embeds"]);
 
     let request = Request::new(
         "https://platform.twitter.com/widgets.js",

--- a/js/src/lib.rs
+++ b/js/src/lib.rs
@@ -300,11 +300,17 @@ fn engine_deserialize(mut cx: FunctionContext) -> JsResult<JsNull> {
 }
 
 fn engine_enable_tag(mut cx: FunctionContext) -> JsResult<JsNull> {
+    console_warn(
+        &mut cx,
+        "Engine.enableTag: tagged filters are deprecated; \
+         rebuild the engine with or without the relevant filters instead.",
+    )?;
     let this = cx.argument::<JsBox<Engine>>(0)?;
 
     let tag: String = cx.argument::<JsString>(1)?.value(&mut cx);
 
     if let Ok(mut engine) = this.0.lock() {
+        #[allow(deprecated)]
         engine.enable_tags(&[&tag])
     } else {
         cx.throw_error("Failed to acquire lock on engine")?
@@ -327,11 +333,17 @@ fn engine_use_resources(mut cx: FunctionContext) -> JsResult<JsNull> {
 }
 
 fn engine_tag_exists(mut cx: FunctionContext) -> JsResult<JsBoolean> {
+    console_warn(
+        &mut cx,
+        "Engine.tagExists: tagged filters are deprecated; \
+         rebuild the engine with or without the relevant filters instead.",
+    )?;
     let this = cx.argument::<JsBox<Engine>>(0)?;
 
     let tag: String = cx.argument::<JsString>(1)?.value(&mut cx);
 
     let result = if let Ok(engine) = this.0.lock() {
+        #[allow(deprecated)]
         engine.tag_exists(&tag)
     } else {
         cx.throw_error("Failed to acquire lock on engine")?
@@ -340,9 +352,15 @@ fn engine_tag_exists(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 }
 
 fn engine_clear_tags(mut cx: FunctionContext) -> JsResult<JsNull> {
+    console_warn(
+        &mut cx,
+        "Engine.clearTags: tagged filters are deprecated; \
+         rebuild the engine with or without the relevant filters instead.",
+    )?;
     let this = cx.argument::<JsBox<Engine>>(0)?;
 
     if let Ok(mut engine) = this.0.lock() {
+        #[allow(deprecated)]
         engine.use_tags(&[]);
     } else {
         cx.throw_error("Failed to acquire lock on engine")?

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -213,6 +213,7 @@ impl Engine {
     ///
     /// Tags can be used to cheaply enable or disable network rules with a corresponding `$tag`
     /// option.
+    #[deprecated(note = "Rebuild the engine with or without the relevant filters instead")]
     pub fn use_tags(&mut self, tags: &[&str]) {
         self.blocker.use_tags(tags);
     }
@@ -221,6 +222,7 @@ impl Engine {
     ///
     /// Tags can be used to cheaply enable or disable network rules with a corresponding `$tag`
     /// option.
+    #[deprecated(note = "Rebuild the engine with or without the relevant filters instead")]
     pub fn enable_tags(&mut self, tags: &[&str]) {
         self.blocker.enable_tags(tags);
     }
@@ -229,6 +231,7 @@ impl Engine {
     ///
     /// Tags can be used to cheaply enable or disable network rules with a corresponding `$tag`
     /// option.
+    #[deprecated(note = "Rebuild the engine with or without the relevant filters instead")]
     pub fn disable_tags(&mut self, tags: &[&str]) {
         self.blocker.disable_tags(tags);
     }
@@ -237,6 +240,7 @@ impl Engine {
     ///
     /// Tags can be used to cheaply enable or disable network rules with a corresponding `$tag`
     /// option.
+    #[deprecated(note = "Rebuild the engine with or without the relevant filters instead")]
     pub fn tag_exists(&self, tag: &str) -> bool {
         self.blocker.tags_enabled().contains(&tag.to_owned())
     }

--- a/tests/legacy_harness.rs
+++ b/tests/legacy_harness.rs
@@ -316,6 +316,7 @@ mod legacy_check_match {
     use adblock::request::Request;
     use adblock::Engine;
 
+    #[allow(deprecated)]
     fn check_match<'a>(
         rules: &[&'a str],
         blocked: &[&'a str],

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -152,12 +152,14 @@ fn troubleshoot() {
 fn get_blocker_engine() -> Engine {
     let mut engine = Engine::new_with_filter_set(get_all_filters().clone());
 
+    #[allow(deprecated)]
     engine.use_tags(&["fb-embeds", "twitter-embeds"]);
 
     engine
 }
 
 #[test]
+#[allow(deprecated)]
 fn check_live_specific_urls() {
     let mut engine = get_blocker_engine();
     {

--- a/tests/ublock-coverage.rs
+++ b/tests/ublock-coverage.rs
@@ -151,6 +151,7 @@ fn check_specifics_default() {
         let checked = engine.check_network_request(&request);
         assert!(!checked.matched, "Matched on {:?}", checked.filter);
     }
+    #[allow(deprecated)]
     {
         engine.use_tags(&["fb-embeds", "twitter-embeds"]);
         let request = Request::new(

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -9,6 +9,7 @@ mod tests {
     use seahash::hash;
 
     #[test]
+    #[allow(deprecated)]
     fn tags_enable_adds_tags() {
         let filters = [
             "adv$tag=stuff",
@@ -43,6 +44,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn tags_disable_works() {
         let filters = [
             "adv$tag=stuff",
@@ -77,6 +79,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn exception_tags_inactive_by_default() {
         let filters = [
             "adv",
@@ -107,6 +110,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn exception_tags_works() {
         let filters = [
             "adv",
@@ -138,6 +142,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn serialization_retains_tags() {
         let filters = [
             "adv$tag=stuff",
@@ -191,6 +196,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn deserialization_generate_tags() {
         let mut engine = Engine::new_with_list_text("ad-banner$tag=abc");
         engine.use_tags(&["abc"]);


### PR DESCRIPTION
Following https://github.com/brave/brave-browser/issues/55165, we can safely deprecate `$tag`. It will be removed in 0.14.x.