### PR TITLE
Support ABP `rewrite=` as an alias for `redirect=`

### DIFF
--- a/src/filters/abstract_network.rs
+++ b/src/filters/abstract_network.rs
@@ -196,8 +196,13 @@ fn parse_filter_options(raw_options: &str) -> Result<Vec<NetworkFilterOption>, N
             ("first-party", negated) | ("1p", negated) => NetworkFilterOption::FirstParty(!negated),
             ("tag", true) => return Err(NetworkFilterError::NegatedTag),
             ("tag", false) => NetworkFilterOption::Tag(String::from(value)),
-            ("redirect", true) => return Err(NetworkFilterError::NegatedRedirection),
-            ("redirect", false) => {
+            // `rewrite` is the ABP-syntax alias for `redirect`. The `abp-resource:`-prefixed
+            // values it uses are shipped by uBO as aliases of the corresponding redirect
+            // resources, so no further translation is needed here.
+            ("redirect", true) | ("rewrite", true) => {
+                return Err(NetworkFilterError::NegatedRedirection)
+            }
+            ("redirect", false) | ("rewrite", false) => {
                 // Ignore this filter if no redirection resource is specified
                 if value.is_empty() {
                     return Err(NetworkFilterError::EmptyRedirection);

--- a/tests/ublock-coverage.rs
+++ b/tests/ublock-coverage.rs
@@ -109,6 +109,35 @@ fn check_specific_rules() {
     }
 }
 
+/// `rewrite=abp-resource:<name>` is the ABP-syntax equivalent of `redirect=<name>`. The
+/// `abp-resource:` aliases come from uBO's own resource data, so this checks against the real
+/// uBO resource fixture rather than a hand-built one.
+#[cfg(feature = "resource-assembler")]
+#[test]
+fn check_rewrite_matches_redirect() {
+    use std::path::Path;
+
+    let resources = adblock::resources::resource_assembler::assemble_web_accessible_resources(
+        Path::new("data/test/fake-uBO-files/web_accessible_resources"),
+        Path::new("data/test/fake-uBO-files/redirect-resources.js"),
+    );
+
+    let redirect_for = |rule: &str| {
+        let mut engine = Engine::from_rules_debug([rule], Default::default());
+        engine.use_resources(resources.clone());
+        let request =
+            Request::new("http://example.com/ads.js", "http://example.com/", "script").unwrap();
+        engine.check_network_request(&request).redirect
+    };
+
+    let rewrite = redirect_for("||example.com/ads.js$script,rewrite=abp-resource:blank-js");
+    assert!(rewrite.is_some(), "rewrite rule did not produce a redirect");
+    assert_eq!(
+        rewrite,
+        redirect_for("||example.com/ads.js$script,redirect=noopjs")
+    );
+}
+
 #[test]
 fn check_specifics_default() {
     let mut engine = get_blocker_engine_default([

--- a/tests/unit/blocker.rs
+++ b/tests/unit/blocker.rs
@@ -1405,7 +1405,7 @@ mod legacy_rule_parsing_tests {
     // * not handling document/subdocument options;
     // * the optimizer that merges multiple rules into one;
     const EASY_LIST: ListCounts = ListCounts {
-        filters: 60368 - 692,
+        filters: 60375 - 692,
         cosmetic_filters: if cfg!(feature = "css-validation") {
             24072
         } else {
@@ -1416,7 +1416,7 @@ mod legacy_rule_parsing_tests {
     };
     // differences in counts explained by hashset size underreporting as detailed in the next two cases
     const EASY_PRIVACY: ListCounts = ListCounts {
-        filters: 55395 - 818, // total - exceptions
+        filters: 55396 - 818, // total - exceptions
         cosmetic_filters: 32,
         exceptions: 818,
         duplicates: 2,

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -301,12 +301,7 @@ mod tests {
             Default::default(),
         );
 
-        let script = r#"
-(function() {
-	;
-})();
-
-        "#;
+        let script = "(function() {})();";
         let mut blank_js = Resource::simple("noopjs", MimeType::ApplicationJavascript, script);
         blank_js.aliases.push("abp-resource:blank-js".to_string());
         engine.use_resources([blank_js]);

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -237,9 +237,9 @@ mod tests {
             );
         }
         let expected_hash: u64 = if cfg!(feature = "css-validation") {
-            5342093731695387413
+            7563240741254203460
         } else {
-            2744138504590463392
+            3761338997348098237
         };
 
         assert_eq!(hash(&data), expected_hash, "{HASH_MISMATCH_MSG}");
@@ -288,6 +288,40 @@ mod tests {
                 BASE64_STANDARD.encode(script)
             )),
             "Expected redirect to contain resource"
+        );
+    }
+
+    #[test]
+    fn rewrite_resource_insertion_works() {
+        // ABP-syntax `rewrite=abp-resource:...` is an alias for `redirect=...`. The
+        // `abp-resource:`-prefixed value is shipped by uBO as an alias of the corresponding
+        // redirect resource, so it should resolve end-to-end without any translation.
+        let mut engine = Engine::from_rules(
+            ["||example.com/ads.js$script,rewrite=abp-resource:blank-js"],
+            Default::default(),
+        );
+
+        let script = r#"
+(function() {
+	;
+})();
+
+        "#;
+        let mut blank_js = Resource::simple("noopjs", MimeType::ApplicationJavascript, script);
+        blank_js.aliases.push("abp-resource:blank-js".to_string());
+        engine.use_resources([blank_js]);
+
+        let url = "http://example.com/ads.js";
+        let request = Request::new(url, "http://example.com/", "script").unwrap();
+        let matched_rule = engine.check_network_request(&request);
+        assert!(matched_rule.matched, "Expected match for {url}");
+        assert_eq!(
+            matched_rule.redirect,
+            Some(format!(
+                "data:application/javascript;base64,{}",
+                BASE64_STANDARD.encode(script)
+            )),
+            "Expected rewrite to resolve to the blank-js resource"
         );
     }
 

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -292,35 +292,6 @@ mod tests {
     }
 
     #[test]
-    fn rewrite_resource_insertion_works() {
-        // ABP-syntax `rewrite=abp-resource:...` is an alias for `redirect=...`. The
-        // `abp-resource:`-prefixed value is shipped by uBO as an alias of the corresponding
-        // redirect resource, so it should resolve end-to-end without any translation.
-        let mut engine = Engine::from_rules(
-            ["||example.com/ads.js$script,rewrite=abp-resource:blank-js"],
-            Default::default(),
-        );
-
-        let script = "(function() {})();";
-        let mut blank_js = Resource::simple("noopjs", MimeType::ApplicationJavascript, script);
-        blank_js.aliases.push("abp-resource:blank-js".to_string());
-        engine.use_resources([blank_js]);
-
-        let url = "http://example.com/ads.js";
-        let request = Request::new(url, "http://example.com/", "script").unwrap();
-        let matched_rule = engine.check_network_request(&request);
-        assert!(matched_rule.matched, "Expected match for {url}");
-        assert_eq!(
-            matched_rule.redirect,
-            Some(format!(
-                "data:application/javascript;base64,{}",
-                BASE64_STANDARD.encode(script)
-            )),
-            "Expected rewrite to resolve to the blank-js resource"
-        );
-    }
-
-    #[test]
     fn document() {
         let filters = ["||example.com$document", "@@||sub.example.com$document"];
 

--- a/tests/unit/filters/network.rs
+++ b/tests/unit/filters/network.rs
@@ -745,6 +745,38 @@ mod parse_tests {
     }
 
     #[test]
+    fn parses_rewrite() {
+        // `rewrite` is an ABP-syntax alias for `redirect`, and the `abp-resource:`-prefixed
+        // value is preserved verbatim (uBO ships it as a redirect resource alias).
+        {
+            let filter = NetworkFilter::parse(
+                "||foo.com$rewrite=abp-resource:blank-js",
+                true,
+                Default::default(),
+            )
+            .unwrap();
+            assert_eq!(
+                filter.modifier_option,
+                Some(String::from("abp-resource:blank-js"))
+            );
+        }
+        // parses ~rewrite as a negated redirection
+        {
+            let filter = NetworkFilter::parse("||foo.com$~rewrite", true, Default::default());
+            assert_eq!(filter.err(), Some(NetworkFilterError::NegatedRedirection));
+        }
+        // parses rewrite without a value
+        {
+            let filter = NetworkFilter::parse("||foo.com$rewrite", true, Default::default());
+            assert_eq!(filter.err(), Some(NetworkFilterError::EmptyRedirection));
+        }
+        {
+            let filter = NetworkFilter::parse("||foo.com$rewrite=", true, Default::default());
+            assert_eq!(filter.err(), Some(NetworkFilterError::EmptyRedirection));
+        }
+    }
+
+    #[test]
     fn parses_removeparam() {
         {
             let filter = NetworkFilter::parse("||foo.com^$removeparam", true, Default::default());

--- a/tests/unit/filters/network.rs
+++ b/tests/unit/filters/network.rs
@@ -746,8 +746,17 @@ mod parse_tests {
 
     #[test]
     fn parses_rewrite() {
-        // `rewrite` is an ABP-syntax alias for `redirect`, and the `abp-resource:`-prefixed
-        // value is preserved verbatim (uBO ships it as a redirect resource alias).
+        // `rewrite=X` must parse identically to `redirect=X`.
+        {
+            let rewrite =
+                NetworkFilter::parse("||foo.com$rewrite=noopjs", true, Default::default()).unwrap();
+            let redirect =
+                NetworkFilter::parse("||foo.com$redirect=noopjs", true, Default::default())
+                    .unwrap();
+            assert_eq!(rewrite.mask, redirect.mask);
+            assert_eq!(rewrite.modifier_option, redirect.modifier_option);
+        }
+        // the `abp-resource:` prefix is preserved verbatim, not stripped
         {
             let filter = NetworkFilter::parse(
                 "||foo.com$rewrite=abp-resource:blank-js",
@@ -760,7 +769,7 @@ mod parse_tests {
                 Some(String::from("abp-resource:blank-js"))
             );
         }
-        // parses ~rewrite as a negated redirection
+        // parses ~rewrite
         {
             let filter = NetworkFilter::parse("||foo.com$~rewrite", true, Default::default());
             assert_eq!(filter.err(), Some(NetworkFilterError::NegatedRedirection));


### PR DESCRIPTION
Fix #687