### PR TITLE
Use rustc-hash v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
  "precomputed-hash",
  "regex",
  "reqwest",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "seahash",
  "selectors",
  "serde",
@@ -1404,7 +1404,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -1425,7 +1425,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -1617,12 +1617,6 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
@@ -1784,7 +1778,7 @@ dependencies = [
  "phf",
  "phf_codegen",
  "precomputed-hash",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "servo_arc",
  "smallvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,7 @@ idna = "1.0.3"
 serde = { workspace = true }
 serde_json = { workspace = true }
 seahash = "4.1.0"
-# rustc-hash v1.1.0 provides a better performance than 2.x, chromium pins the same version.
-rustc-hash = { version = "1.1.0", default-features = false }
+rustc-hash = { version = "2.1", default-features = false }
 memchr = "2.8"
 base64 = "0.22"
 arrayvec = "0.7"

--- a/src/data_format/mod.rs
+++ b/src/data_format/mod.rs
@@ -17,7 +17,7 @@ const ADBLOCK_RUST_DAT_MAGIC: [u8; 4] = [0xd1, 0xd9, 0x3a, 0xaf];
 
 /// The version of the data format.
 /// If the data format version is incremented, the data is considered as incompatible.
-const ADBLOCK_RUST_DAT_VERSION: u8 = 4;
+const ADBLOCK_RUST_DAT_VERSION: u8 = 5;
 
 /// The total length of the header prefix (magic + version + seahash)
 const HEADER_PREFIX_LENGTH: usize = 4 + 1 + 8;

--- a/src/flatbuffers/containers/hash_index.rs
+++ b/src/flatbuffers/containers/hash_index.rs
@@ -213,6 +213,6 @@ mod tests {
         // Verify get_hash is stable.
         // If the value changes, update ADBLOCK_RUST_DAT_VERSION.
         let message = "If the value changes, update ADBLOCK_RUST_DAT_VERSION.";
-        assert_eq!(get_hash(&"adblock-rust"), 15102204115509201409, "{message}");
+        assert_eq!(get_hash(&"adblock-rust"), 5391703202028078439, "{message}");
     }
 }

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -195,7 +195,7 @@ mod tests {
     fn deserialization_generate_simple() {
         let mut engine = Engine::new_with_list_text("ad-banner");
         let data = engine.serialize().to_vec();
-        const EXPECTED_HASH: u64 = 8140715178533393311;
+        const EXPECTED_HASH: u64 = 10610779084220584492;
         assert_eq!(hash(&data), EXPECTED_HASH, "{HASH_MISMATCH_MSG}");
         engine.deserialize(&data).unwrap();
     }
@@ -206,7 +206,7 @@ mod tests {
         let mut engine = Engine::new_with_list_text("ad-banner$tag=abc");
         engine.use_tags(&["abc"]);
         let data = engine.serialize().to_vec();
-        const EXPECTED_HASH: u64 = 11267534334233315862;
+        const EXPECTED_HASH: u64 = 9111262975876879244;
         assert_eq!(hash(&data), EXPECTED_HASH, "{HASH_MISMATCH_MSG}");
         engine.deserialize(&data).unwrap();
     }
@@ -262,9 +262,9 @@ mod tests {
             assert_eq!(debug_info.source_info[0].cosmetic_filter_count, 42318);
         }
         let expected_hash: u64 = if cfg!(feature = "css-validation") {
-            228796068971768546
+            17859942404936466029
         } else {
-            10394360525829993414
+            11154142685266326628
         };
 
         assert_eq!(hash(&data), expected_hash, "{HASH_MISMATCH_MSG}");


### PR DESCRIPTION
Both local and remote comparisons don't show a meaningful difference.
There is no sense to use old rustc-hash v1 version.