### PR TITLE
Expose `DeserializationError`

### DIFF
--- a/src/data_format/mod.rs
+++ b/src/data_format/mod.rs
@@ -28,7 +28,6 @@ pub enum DeserializationError {
     BadChecksum,
     VersionMismatch(u8),
     FlatBufferParsingError(flatbuffers::InvalidFlatbuffer),
-    ValidationError,
 }
 
 pub(crate) fn serialize_dat_file(data: &[u8]) -> Vec<u8> {

--- a/src/data_format/mod.rs
+++ b/src/data_format/mod.rs
@@ -25,7 +25,7 @@ const HEADER_PREFIX_LENGTH: usize = 4 + 1 + 8;
 #[derive(Debug, PartialEq)]
 pub enum DeserializationError {
     BadHeader,
-    BadChecksum,
+    BadChecksum { expected: [u8; 8], actual: [u8; 8] },
     VersionMismatch(u8),
     FlatBufferParsingError(flatbuffers::InvalidFlatbuffer),
 }
@@ -55,13 +55,14 @@ pub(crate) fn deserialize_dat_file(serialized: &[u8]) -> Result<&[u8], Deseriali
 
     // Check the hash to ensure the data isn't corrupted.
     let expected_hash = &serialized[(ADBLOCK_RUST_DAT_MAGIC.len() + 1)..HEADER_PREFIX_LENGTH];
-    if expected_hash != seahash::hash(data).to_le_bytes() {
-        println!(
-            "Expected hash: {:?}, actual hash: {:?}",
-            expected_hash,
-            seahash::hash(data).to_le_bytes()
-        );
-        return Err(DeserializationError::BadChecksum);
+    debug_assert_eq!(HEADER_PREFIX_LENGTH - (ADBLOCK_RUST_DAT_MAGIC.len() + 1), 8);
+    let actual_hash = seahash::hash(data).to_le_bytes();
+    if expected_hash != actual_hash {
+        return Err(DeserializationError::BadChecksum {
+            // Unwrap safety: see debug_assert_eq above
+            expected: expected_hash.try_into().unwrap(),
+            actual: actual_hash,
+        });
     }
     Ok(data)
 }
@@ -97,9 +98,9 @@ mod tests {
         let serialized = serialize_dat_file(data);
         let mut corrupted_serialized = serialized.clone();
         corrupted_serialized[HEADER_PREFIX_LENGTH] = 0;
-        assert_eq!(
-            Err(DeserializationError::BadChecksum),
-            deserialize_dat_file(&corrupted_serialized)
+        std::assert_matches!(
+            deserialize_dat_file(&corrupted_serialized),
+            Err(DeserializationError::BadChecksum { .. })
         );
     }
 }

--- a/src/data_format/mod.rs
+++ b/src/data_format/mod.rs
@@ -22,11 +22,18 @@ const ADBLOCK_RUST_DAT_VERSION: u8 = 5;
 /// The total length of the header prefix (magic + version + seahash)
 const HEADER_PREFIX_LENGTH: usize = 4 + 1 + 8;
 
+/// Failure cases for deserialization of the [crate::Engine].
 #[derive(Debug, PartialEq)]
 pub enum DeserializationError {
+    /// The serialized buffer is missing the expected header bytes, including a fixed 4-byte
+    /// sequence, version number, and checksum.
     BadHeader,
+    /// The header's recorded checksum did not match the data itself.
     BadChecksum { expected: [u8; 8], actual: [u8; 8] },
+    /// The buffer was serialized from a previous, incompatible version of this crate. It should be
+    /// regenerated from list text instead.
     VersionMismatch(u8),
+    /// The serialized data payload was not a valid flatbuffer format.
     FlatBufferParsingError(flatbuffers::InvalidFlatbuffer),
 }
 

--- a/src/data_format/mod.rs
+++ b/src/data_format/mod.rs
@@ -11,6 +11,8 @@
 //! 3. seahash of the data (8 bytes)
 //! 4. data (the rest of the file)
 
+use thiserror::Error;
+
 /// Newer formats start with this magic byte sequence.
 /// Calculated as the leading 4 bytes of `echo -n 'brave/adblock-rust' | sha512sum`.
 const ADBLOCK_RUST_DAT_MAGIC: [u8; 4] = [0xd1, 0xd9, 0x3a, 0xaf];
@@ -23,17 +25,21 @@ const ADBLOCK_RUST_DAT_VERSION: u8 = 5;
 const HEADER_PREFIX_LENGTH: usize = 4 + 1 + 8;
 
 /// Failure cases for deserialization of the [crate::Engine].
-#[derive(Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq)]
 pub enum DeserializationError {
     /// The serialized buffer is missing the expected header bytes, including a fixed 4-byte
     /// sequence, version number, and checksum.
+    #[error("bad header")]
     BadHeader,
     /// The header's recorded checksum did not match the data itself.
+    #[error("bad checksum")]
     BadChecksum { expected: [u8; 8], actual: [u8; 8] },
     /// The buffer was serialized from a previous, incompatible version of this crate. It should be
     /// regenerated from list text instead.
+    #[error("version mismatch")]
     VersionMismatch(u8),
     /// The serialized data payload was not a valid flatbuffer format.
+    #[error("flatbuffer parsing error")]
     FlatBufferParsingError(flatbuffers::InvalidFlatbuffer),
 }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3,7 +3,7 @@
 use crate::blocker::{Blocker, BlockerResult};
 use crate::cosmetic_filter_cache::{CosmeticFilterCache, UrlSpecificResources};
 use crate::cosmetic_filter_cache_builder::CosmeticFilterCacheBuilder;
-use crate::data_format::{DeserializationError, deserialize_dat_file, serialize_dat_file};
+use crate::data_format::{deserialize_dat_file, serialize_dat_file};
 use crate::filters::fb_builder::EngineFlatBuilder;
 use crate::filters::fb_network_builder::{NetworkFilterDebugData, NetworkRulesBuilder};
 use crate::filters::filter_data_context::{FilterDataContext, FilterDataContextRef};
@@ -14,6 +14,8 @@ use crate::lists::{FilterSet, ParseOptions, ParsedLine, parse_filter};
 use crate::regex_manager::RegexManagerDiscardPolicy;
 use crate::request::Request;
 use crate::resources::{Resource, ResourceStorage, ResourceStorageBackend};
+
+pub use crate::data_format::DeserializationError;
 
 use crate::filters::{cosmetic::CosmeticFilter, network::NetworkFilter};
 


### PR DESCRIPTION
The type is part of the public API as per `Engine::deserialize`, yet it is impossible to use it as a downstream consumer because it is not public.

These changes expose the error type and improve its usability by implementing the `thiserror::Error` trait, adding `expected`/`actual` fields to replace the `println!` logging, removing the unused `ValidationError` case, and adding documentation.