### PR TITLE
`set_regex_discard_policy` doesn't need mut

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -393,7 +393,7 @@ impl Engine {
         )
     }
 
-    pub fn set_regex_discard_policy(&mut self, new_discard_policy: RegexManagerDiscardPolicy) {
+    pub fn set_regex_discard_policy(&self, new_discard_policy: RegexManagerDiscardPolicy) {
         self.blocker.set_regex_discard_policy(new_discard_policy);
     }
 


### PR DESCRIPTION
it should be safe:
- `single-thread` enabled: no concurrency
- `single-thread` disabled: `Mutex` guarded