### PR TITLE
Don't count comments as parse errors

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -10,7 +10,7 @@ use crate::filters::filter_data_context::{FilterDataContext, FilterDataContextRe
 use crate::filters::flatbuffer_generated::fb;
 use crate::flatbuffers::containers::flat_serialize::{FlatBuilder, FlatSerialize};
 use crate::flatbuffers::unsafe_tools::VerifiedFlatbufferMemory;
-use crate::lists::{FilterSet, ParseOptions, ParsedLine, parse_filter};
+use crate::lists::{FilterParseError, FilterSet, ParseOptions, ParsedLine, parse_filter};
 use crate::request::Request;
 use crate::resources::{Resource, ResourceStorage, ResourceStorageBackend};
 
@@ -172,6 +172,9 @@ impl Engine {
                     Ok(ParsedLine::Cosmetic(filter)) => {
                         cosmetic_filter_cache_builder.add_filter(filter, &mut builder);
                         cosmetic_filter_count += 1;
+                    }
+                    Err(FilterParseError::Comment | FilterParseError::Empty) => {
+                        continue;
                     }
                     Err(_) => {
                         parse_error += 1;

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -414,6 +414,8 @@ pub enum FilterType {
     Cosmetic,
     /// Something else that isn't supported
     NotSupported,
+    /// A comment
+    Comment,
 }
 
 /// Successful result of parsing a single line from a filter list
@@ -445,6 +447,8 @@ pub enum FilterParseError {
     Unsupported,
     #[error("empty")]
     Empty,
+    #[error("comment")]
+    Comment,
 }
 
 impl From<NetworkFilterError> for FilterParseError {
@@ -483,6 +487,7 @@ pub fn parse_filter<'a>(
                     .map(ParsedLine::Cosmetic)
                     .map_err(|e| e.into())
             }
+            (FilterType::Comment, _) => Err(FilterParseError::Comment),
             _ => Err(FilterParseError::Unsupported),
         },
         FilterFormat::Hosts => {
@@ -564,7 +569,7 @@ fn detect_filter_type(filter: &str) -> FilterType {
         || (filter.starts_with('#') && filter[1..].starts_with(char::is_whitespace))
         || filter.starts_with("[Adblock")
     {
-        return FilterType::NotSupported;
+        return FilterType::Comment;
     }
 
     if filter.starts_with('|') || filter.starts_with("@@|") {

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -74,9 +74,9 @@ mod tests {
             assert_eq!(debug_info.source_info[0].cosmetic_filter_count, 42318);
         }
         let expected_hash: u64 = if cfg!(feature = "css-validation") {
-            12793947999202839780
+            4957970225878131233
         } else {
-            7607188216312554255
+            11080299937182072527
         };
 
         assert_eq!(hash(&data), expected_hash, "{HASH_MISMATCH_MSG}");


### PR DESCRIPTION
The PR updates parsing logic to skip comments (instead counting them as parse errors)