### PR TITLE
Introduce perf-report.yml

### DIFF
--- a/.github/scripts/build-perf-report.py
+++ b/.github/scripts/build-perf-report.py
@@ -19,7 +19,10 @@ def extract_svg(path: pathlib.Path) -> str:
     match = SVG_RE.search(text)
     if not match:
         raise SystemExit(f"no <svg> element in {path}")
-    return match.group(0)
+    svg = match.group(0)
+    # Drop fixed size so CSS can fill the viewport.
+    svg = re.sub(r'\s(width|height)="[^"]*"', "", svg, count=2)
+    return svg
 
 
 def main() -> int:
@@ -65,14 +68,17 @@ def main() -> int:
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Performance report</title>
 <style>
-  body {{ font-family: system-ui, sans-serif; margin: 1.5rem; color: #111; }}
+  html, body {{ margin: 0; color: #111; font-family: system-ui, sans-serif; }}
+  .intro {{ padding: 1.5rem; }}
   pre {{ background: #f4f4f4; padding: 1rem; overflow: auto; }}
-  section {{ margin: 2rem 0; border-top: 1px solid #ddd; padding-top: 1rem; }}
-  svg {{ max-width: 100%; height: auto; }}
   nav ul {{ columns: 2; }}
+  section {{ border-top: 1px solid #ddd; }}
+  section h2 {{ margin: 0; padding: 0.75rem 1.5rem; background: #f4f4f4; }}
+  section svg {{ display: block; width: 100%; height: 100vh; }}
 </style>
 </head>
 <body>
+<div class="intro">
 <h1>Performance report</h1>
 <p><code>{html.escape(args.base_sha)}</code> (base) →
 <code>{html.escape(args.head_sha)}</code> (head)</p>
@@ -85,6 +91,7 @@ def main() -> int:
 {toc}
 </ul>
 </nav>
+</div>
 {chr(10).join(sections)}
 </body>
 </html>

--- a/.github/scripts/build-perf-report.py
+++ b/.github/scripts/build-perf-report.py
@@ -90,7 +90,7 @@ def main() -> int:
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Performance report</title>
+<title>Detailed performance report</title>
 <style>
   html, body {{ margin: 0; color: #111; font-family: system-ui, sans-serif; }}
   .intro {{ padding: 1.5rem; }}

--- a/.github/scripts/build-perf-report.py
+++ b/.github/scripts/build-perf-report.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+
+"""Combine flamegraph SVGs (and the critcmp table) into one self-contained HTML file."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import pathlib
+import re
+import subprocess
+import sys
+
+SVG_RE = re.compile(r"<svg\b.*</svg>", re.DOTALL | re.IGNORECASE)
+
+
+def extract_svg(path: pathlib.Path) -> str:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    match = SVG_RE.search(text)
+    if not match:
+        raise SystemExit(f"no <svg> element in {path}")
+    return match.group(0)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out-dir", type=pathlib.Path, required=True)
+    parser.add_argument("--base-sha", required=True)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--run-url", required=True)
+    parser.add_argument("--repo-dir", type=pathlib.Path, required=True)
+    args = parser.parse_args()
+
+    table = subprocess.run(
+        ["critcmp", "base", "head"],
+        check=True,
+        cwd=args.repo_dir,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    svgs = sorted(args.out_dir.glob("*.svg"))
+    if not svgs:
+        print(f"no .svg files in {args.out_dir}", file=sys.stderr)
+        return 1
+
+    sections: list[str] = []
+    for path in svgs:
+        sections.append(
+            f'<section id="{html.escape(path.stem)}">\n'
+            f"<h2>{html.escape(path.name)}</h2>\n"
+            f"{extract_svg(path)}\n"
+            f"</section>"
+        )
+
+    toc = "\n".join(
+        f'<li><a href="#{html.escape(path.stem)}">{html.escape(path.name)}</a></li>'
+        for path in svgs
+    )
+
+    doc = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Performance report</title>
+<style>
+  body {{ font-family: system-ui, sans-serif; margin: 1.5rem; color: #111; }}
+  pre {{ background: #f4f4f4; padding: 1rem; overflow: auto; }}
+  section {{ margin: 2rem 0; border-top: 1px solid #ddd; padding-top: 1rem; }}
+  svg {{ max-width: 100%; height: auto; }}
+  nav ul {{ columns: 2; }}
+</style>
+</head>
+<body>
+<h1>Performance report</h1>
+<p><code>{html.escape(args.base_sha)}</code> (base) →
+<code>{html.escape(args.head_sha)}</code> (head)</p>
+<p>Run: <a href="{html.escape(args.run_url)}">{html.escape(args.run_url)}</a></p>
+<h2>Benchmarks</h2>
+<pre>{html.escape(table)}</pre>
+<nav>
+<h2>Flamegraphs</h2>
+<ul>
+{toc}
+</ul>
+</nav>
+{chr(10).join(sections)}
+</body>
+</html>
+"""
+
+    html_path = args.out_dir / "perf-report.html"
+    html_path.write_text(doc, encoding="utf-8")
+
+    # PR comment body: numbers + pointer to the HTML artifact.
+    report_md = f"""## Performance report
+
+`{args.base_sha}` (base) → `{args.head_sha}` (head)
+
+```
+{table}
+```
+
+Flamegraphs: download `perf-report.html` artifact from [this run]({args.run_url}) and open it in a browser.
+"""
+    (args.out_dir / "report.md").write_text(report_md, encoding="utf-8")
+    print(report_md)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/build-perf-report.py
+++ b/.github/scripts/build-perf-report.py
@@ -108,8 +108,6 @@ def main() -> int:
 ```
 {table}
 ```
-
-Flamegraphs: download `perf-report.html` artifact from [this run]({args.run_url}) and open it in a browser.
 """
     (args.out_dir / "report.md").write_text(report_md, encoding="utf-8")
     print(report_md)

--- a/.github/scripts/build-perf-report.py
+++ b/.github/scripts/build-perf-report.py
@@ -11,7 +11,7 @@ import re
 import subprocess
 import sys
 
-SVG_RE = re.compile(r"<svg\b.*</svg>", re.DOTALL | re.IGNORECASE)
+SVG_RE = re.compile(r"<svg\b.*?</svg>", re.DOTALL | re.IGNORECASE)
 
 
 def extract_svg(path: pathlib.Path) -> str:

--- a/.github/scripts/build-perf-report.py
+++ b/.github/scripts/build-perf-report.py
@@ -20,9 +20,33 @@ def extract_svg(path: pathlib.Path) -> str:
     if not match:
         raise SystemExit(f"no <svg> element in {path}")
     svg = match.group(0)
-    # Drop fixed size so CSS can fill the viewport.
+    # Drop fixed size so the SVG fills its iframe; inferno's fluiddrawing
+    # mode picks up the viewport via clientWidth/clientHeight.
     svg = re.sub(r'\s(width|height)="[^"]*"', "", svg, count=2)
+    if "style=" not in svg[:80]:
+        svg = svg.replace("<svg", '<svg style="width:100%;height:100%"', 1)
     return svg
+
+
+def svg_iframe(path: pathlib.Path) -> str:
+    """Embed the SVG in an iframe so its scripts run in an isolated document.
+
+    Inlining several flamegraphs into one page breaks search/zoom: they all
+    share ids like #search and document.getElementsByTagName('svg')[0].
+    """
+    inner = (
+        "<!DOCTYPE html><html><head><meta charset=utf-8></head>"
+        '<body style="margin:0;height:100vh">'
+        f"{extract_svg(path)}"
+        "</body></html>"
+    )
+    # srcdoc is an HTML attribute value.
+    escaped = html.escape(inner, quote=True)
+    title = html.escape(path.name)
+    return (
+        f'<iframe title="{title}" srcdoc="{escaped}" '
+        f'loading="lazy" style="width:100%;height:100vh;border:0;display:block"></iframe>'
+    )
 
 
 def main() -> int:
@@ -52,7 +76,7 @@ def main() -> int:
         sections.append(
             f'<section id="{html.escape(path.stem)}">\n'
             f"<h2>{html.escape(path.name)}</h2>\n"
-            f"{extract_svg(path)}\n"
+            f"{svg_iframe(path)}\n"
             f"</section>"
         )
 
@@ -74,7 +98,6 @@ def main() -> int:
   nav ul {{ columns: 2; }}
   section {{ border-top: 1px solid #ddd; }}
   section h2 {{ margin: 0; padding: 0.75rem 1.5rem; background: #f4f4f4; }}
-  section svg {{ display: block; width: 100%; height: 100vh; }}
 </style>
 </head>
 <body>

--- a/.github/scripts/build-perf-report.py
+++ b/.github/scripts/build-perf-report.py
@@ -44,7 +44,7 @@ def svg_iframe(path: pathlib.Path) -> str:
     escaped = html.escape(inner, quote=True)
     title = html.escape(path.name)
     return (
-        f'<iframe title="{title}" srcdoc="{escaped}" '
+        f'<iframe title="{title}" srcdoc="{escaped}" sandbox="allow-scripts" '
         f'loading="lazy" style="width:100%;height:100vh;border:0;display:block"></iframe>'
     )
 

--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -6,13 +6,13 @@
 set -e
 
 echo "Running network filter matching benchmark..."
-cargo bench --bench bench_matching rule-match-browserlike/brave-list -- --output-format bencher
+cargo bench --bench bench_matching 'rule-match-browserlike/brave-list$' -- --output-format bencher
 
 echo "Running first request matching delay benchmark..."
 cargo bench --bench bench_matching rule-match-first-request -- --output-format bencher
 
 echo "Running startup speed benchmark..."
-cargo bench --bench bench_rules blocker_new/brave-list -- --output-format bencher
+cargo bench --bench bench_rules 'blocker_new/brave-list$' -- --output-format bencher
 
 echo "Running memory usage benchmark..."
 cargo bench --bench bench_memory memory-usage -- --output-format bencher --noplot

--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -6,13 +6,13 @@
 set -e
 
 echo "Running network filter matching benchmark..."
-cargo bench --bench bench_matching 'rule-match-browserlike/brave-list$' -- --output-format bencher
+cargo bench --bench bench_matching 'rule-match-browserlike/brave-list' -- --output-format bencher
 
 echo "Running first request matching delay benchmark..."
 cargo bench --bench bench_matching rule-match-first-request -- --output-format bencher
 
 echo "Running startup speed benchmark..."
-cargo bench --bench bench_rules 'blocker_new/brave-list$' -- --output-format bencher
+cargo bench --bench bench_rules 'blocker_new/brave-list' -- --output-format bencher
 
 echo "Running memory usage benchmark..."
 cargo bench --bench bench_memory memory-usage -- --output-format bencher --noplot

--- a/.github/scripts/run-perf-benchmarks.sh
+++ b/.github/scripts/run-perf-benchmarks.sh
@@ -12,7 +12,7 @@ set -eu
 
 BASELINE="$1"
 
-cargo bench --bench bench_matching 'rule-match-browserlike/brave-list$' -- --save-baseline "$BASELINE"
+cargo bench --bench bench_matching 'rule-match-browserlike/brave-list' -- --save-baseline "$BASELINE"
 cargo bench --bench bench_matching rule-match-first-request -- --save-baseline "$BASELINE"
-cargo bench --bench bench_rules 'blocker_new/brave-list$' -- --save-baseline "$BASELINE"
+cargo bench --bench bench_rules 'blocker_new/brave-list' -- --save-baseline "$BASELINE"
 cargo bench --bench bench_cosmetic_matching -- --save-baseline "$BASELINE"

--- a/.github/scripts/run-perf-benchmarks.sh
+++ b/.github/scripts/run-perf-benchmarks.sh
@@ -12,7 +12,7 @@ set -eu
 
 BASELINE="$1"
 
-cargo bench --bench bench_matching rule-match-browserlike/brave-list -- --save-baseline "$BASELINE"
+cargo bench --bench bench_matching 'rule-match-browserlike/brave-list$' -- --save-baseline "$BASELINE"
 cargo bench --bench bench_matching rule-match-first-request -- --save-baseline "$BASELINE"
-cargo bench --bench bench_rules blocker_new/brave-list -- --save-baseline "$BASELINE"
+cargo bench --bench bench_rules 'blocker_new/brave-list$' -- --save-baseline "$BASELINE"
 cargo bench --bench bench_cosmetic_matching -- --save-baseline "$BASELINE"

--- a/.github/scripts/run-perf-benchmarks.sh
+++ b/.github/scripts/run-perf-benchmarks.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Runs the timing benchmarks and stores the results as a criterion baseline,
+# so that two revisions can be compared with `critcmp`.
+#
+# Usage: ./.github/scripts/run-perf-benchmarks.sh <baseline-name>
+
+set -eu
+
+BASELINE="$1"
+
+cargo bench --bench bench_matching rule-match-browserlike/brave-list -- --save-baseline "$BASELINE"
+cargo bench --bench bench_matching rule-match-first-request -- --save-baseline "$BASELINE"
+cargo bench --bench bench_rules blocker_new/brave-list -- --save-baseline "$BASELINE"
+cargo bench --bench bench_cosmetic_matching -- --save-baseline "$BASELINE"

--- a/.github/scripts/run-perf-benchmarks.sh
+++ b/.github/scripts/run-perf-benchmarks.sh
@@ -4,6 +4,9 @@
 # so that two revisions can be compared with `critcmp`.
 #
 # Usage: ./.github/scripts/run-perf-benchmarks.sh <baseline-name>
+#
+# Expects RUSTFLAGS / CARGO_PROFILE_*_DEBUG from the caller (perf-report.yml)
+# so benchmarks and profiles share the same build fingerprint.
 
 set -eu
 

--- a/.github/scripts/run-perf-profile.sh
+++ b/.github/scripts/run-perf-profile.sh
@@ -64,3 +64,4 @@ profile_one() {
 
 profile_one matching bench_matching 'rule-match-browserlike/brave-list$'
 profile_one startup  bench_rules    'blocker_new/brave-list$'
+profile_one cosmetic  bench_cosmetic_matching 'cosmetic-class-id-match/brave-list'

--- a/.github/scripts/run-perf-profile.sh
+++ b/.github/scripts/run-perf-profile.sh
@@ -6,28 +6,23 @@
 #   label:      "base" or "head", used to name the produced files
 #   output-dir: where the .svg / .folded files are written
 #
-# On Linux, also writes demangled `.folded` stacks. Once both `base` and `head`
-# folded files exist for a benchmark, a differential SVG is written too.
-# On other platforms only the SVG from cargo-flamegraph is kept.
+# Linux-only: records with `perf` around `cargo bench` (same binary as
+# run-perf-benchmarks.sh) and writes demangled `.folded` stacks. Once both
+# `base` and `head` folded files exist for a benchmark, a differential SVG is
+# written too.
 #
-# Requires: cargo-flamegraph. On Linux also: perf, inferno, rustfilt.
+# Expects RUSTFLAGS / CARGO_PROFILE_*_DEBUG from the caller (perf-report.yml).
+# Requires: perf, inferno, rustfilt.
 
 set -eu
 
+if [[ "$(uname -s)" != "Linux" ]]; then
+    echo "run-perf-profile.sh requires Linux (perf)" >&2
+    exit 1
+fi
+
 LABEL="$1"
 OUT_DIR="$(cd "$2" && pwd)"
-IS_LINUX=0
-[[ "$(uname -s)" == "Linux" ]] && IS_LINUX=1
-
-# Frame pointers keep unwinding cheap. `--no-rosegment` is Linux/lld-only
-# (macOS ld rejects it); the same flag is also in .cargo/config.toml for the
-# linux-gnu target, but RUSTFLAGS replaces rather than appends config rustflags.
-RUSTFLAGS="-Cforce-frame-pointers=yes"
-if (( IS_LINUX )); then
-    RUSTFLAGS="$RUSTFLAGS -Clink-arg=-Wl,--no-rosegment"
-fi
-export RUSTFLAGS
-export CARGO_PROFILE_BENCH_DEBUG=true
 
 # `--profile-time` makes criterion run the benchmark for N seconds without its
 # own measurement/analysis machinery, which keeps the profile clean.
@@ -51,25 +46,20 @@ profile_one() {
     local prefix="${OUT_DIR}/${name}.${LABEL}"
 
     echo "Profiling ${name} (${bench} ${filter})..."
-    cargo flamegraph \
-        --bench "$bench" \
-        --output "${prefix}.svg" \
-        -- --bench "$filter" --profile-time "$PROFILE_TIME"
 
-    # On Linux, cargo-flamegraph always leaves `perf.data` in cwd. Rebuild the
-    # SVG from demangled folded stacks so symbols are readable.
-    if (( IS_LINUX )); then
-        # perf's default demangler is C++-oriented and turns Rust names into
-        # the unreadable `_E14bench_function...` form. Keep symbols mangled,
-        # collapse, then demangle with rustfilt (rustc-demangle).
-        perf script -i perf.data --no-demangle \
-            | inferno-collapse-perf \
-            | rustfilt > "${prefix}.folded"
-        inferno-flamegraph --title "${name} (${LABEL})" \
-            < "${prefix}.folded" > "${prefix}.svg"
-        rm -f perf.data
-        build_diff_flamegraph "$name"
-    fi
+    perf record --call-graph fp -o perf.data -- \
+        cargo bench --bench "$bench" -- --bench "$filter" --profile-time "$PROFILE_TIME"
+
+    # perf's default demangler is C++-oriented and turns Rust names into the
+    # unreadable `_E14bench_function...` form. Keep symbols mangled, collapse,
+    # then demangle with rustfilt (rustc-demangle).
+    perf script -i perf.data --no-demangle \
+        | inferno-collapse-perf \
+        | rustfilt > "${prefix}.folded"
+    inferno-flamegraph --title "${name} (${LABEL})" \
+        < "${prefix}.folded" > "${prefix}.svg"
+    rm -f perf.data
+    build_diff_flamegraph "$name"
 }
 
 profile_one matching bench_matching 'rule-match-browserlike/brave-list'

--- a/.github/scripts/run-perf-profile.sh
+++ b/.github/scripts/run-perf-profile.sh
@@ -14,7 +14,7 @@
 # Expects RUSTFLAGS / CARGO_PROFILE_*_DEBUG from the caller (perf-report.yml).
 # Requires: perf, inferno, rustfilt.
 
-set -eu
+set -euo pipefail
 
 if [[ "$(uname -s)" != "Linux" ]]; then
     echo "run-perf-profile.sh requires Linux (perf)" >&2

--- a/.github/scripts/run-perf-profile.sh
+++ b/.github/scripts/run-perf-profile.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Records a CPU profile for the benchmarks of interest and renders a flamegraph.
+#
+# Usage: ./.github/scripts/run-perf-profile.sh <label> <output-dir>
+#   label:      "base" or "head", used to name the produced files
+#   output-dir: where the .svg / .folded files are written
+#
+# On Linux, also writes demangled `.folded` stacks. Once both `base` and `head`
+# folded files exist for a benchmark, a differential SVG is written too.
+# On other platforms only the SVG from cargo-flamegraph is kept.
+#
+# Requires: cargo-flamegraph. On Linux also: perf, inferno, rustfilt.
+
+set -eu
+
+LABEL="$1"
+OUT_DIR="$(cd "$2" && pwd)"
+IS_LINUX=0
+[[ "$(uname -s)" == "Linux" ]] && IS_LINUX=1
+
+# Frame pointers keep unwinding cheap. `--no-rosegment` is Linux/lld-only
+# (macOS ld rejects it); the same flag is also in .cargo/config.toml for the
+# linux-gnu target, but RUSTFLAGS replaces rather than appends config rustflags.
+RUSTFLAGS="-Cforce-frame-pointers=yes"
+if (( IS_LINUX )); then
+    RUSTFLAGS="$RUSTFLAGS -Clink-arg=-Wl,--no-rosegment"
+fi
+export RUSTFLAGS
+export CARGO_PROFILE_BENCH_DEBUG=true
+
+# `--profile-time` makes criterion run the benchmark for N seconds without its
+# own measurement/analysis machinery, which keeps the profile clean.
+PROFILE_TIME="${PROFILE_TIME:-10}"
+
+build_diff_flamegraph() {
+    local name="$1"
+    local base="${OUT_DIR}/${name}.base.folded"
+    local head="${OUT_DIR}/${name}.head.folded"
+    [[ -f "$base" && -f "$head" ]] || return 0
+
+    echo "Building differential flamegraph for ${name}..."
+    inferno-diff-folded "$base" "$head" \
+        | inferno-flamegraph --colordiff --title "${name} (base -> head)" \
+        > "${OUT_DIR}/${name}.diff.svg"
+    rm -f "$base" "$head"
+}
+
+profile_one() {
+    local name="$1" bench="$2" filter="$3"
+    local prefix="${OUT_DIR}/${name}.${LABEL}"
+
+    echo "Profiling ${name} (${bench} ${filter})..."
+    cargo flamegraph \
+        --bench "$bench" \
+        --output "${prefix}.svg" \
+        -- --bench "$filter" --profile-time "$PROFILE_TIME"
+
+    # On Linux, cargo-flamegraph always leaves `perf.data` in cwd. Rebuild the
+    # SVG from demangled folded stacks so symbols are readable.
+    if (( IS_LINUX )); then
+        # perf's default demangler is C++-oriented and turns Rust names into
+        # the unreadable `_E14bench_function...` form. Keep symbols mangled,
+        # collapse, then demangle with rustfilt (rustc-demangle).
+        perf script -i perf.data --no-demangle \
+            | inferno-collapse-perf \
+            | rustfilt > "${prefix}.folded"
+        inferno-flamegraph --title "${name} (${LABEL})" \
+            < "${prefix}.folded" > "${prefix}.svg"
+        rm -f perf.data
+        build_diff_flamegraph "$name"
+    fi
+}
+
+profile_one matching bench_matching 'rule-match-browserlike/brave-list'
+profile_one startup  bench_rules    'blocker_new/brave-list'

--- a/.github/scripts/run-perf-profile.sh
+++ b/.github/scripts/run-perf-profile.sh
@@ -36,7 +36,7 @@ build_diff_flamegraph() {
 
     echo "Building differential flamegraph for ${name}..."
     inferno-diff-folded "$base" "$head" \
-        | inferno-flamegraph --colordiffusion --title "${name} (base -> head)" \
+        | inferno-flamegraph --title "${name} (base -> head)" \
         > "${OUT_DIR}/${name}.diff.svg"
     rm -f "$base" "$head"
 }

--- a/.github/scripts/run-perf-profile.sh
+++ b/.github/scripts/run-perf-profile.sh
@@ -36,7 +36,7 @@ build_diff_flamegraph() {
 
     echo "Building differential flamegraph for ${name}..."
     inferno-diff-folded "$base" "$head" \
-        | inferno-flamegraph --colordiff --title "${name} (base -> head)" \
+        | inferno-flamegraph --colordiffusion --title "${name} (base -> head)" \
         > "${OUT_DIR}/${name}.diff.svg"
     rm -f "$base" "$head"
 }

--- a/.github/scripts/run-perf-profile.sh
+++ b/.github/scripts/run-perf-profile.sh
@@ -62,5 +62,5 @@ profile_one() {
     build_diff_flamegraph "$name"
 }
 
-profile_one matching bench_matching 'rule-match-browserlike/brave-list'
-profile_one startup  bench_rules    'blocker_new/brave-list'
+profile_one matching bench_matching 'rule-match-browserlike/brave-list$'
+profile_one startup  bench_rules    'blocker_new/brave-list$'

--- a/.github/scripts/run-perf-profile.sh
+++ b/.github/scripts/run-perf-profile.sh
@@ -48,7 +48,7 @@ profile_one() {
     echo "Profiling ${name} (${bench} ${filter})..."
 
     perf record --call-graph fp -o perf.data -- \
-        cargo bench --bench "$bench" -- --bench "$filter" --profile-time "$PROFILE_TIME"
+        cargo bench --bench "$bench" "$filter" -- --profile-time "$PROFILE_TIME"
 
     # perf's default demangler is C++-oriented and turns Rust names into the
     # unreadable `_E14bench_function...` form. Keep symbols mangled, collapse,

--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -1,27 +1,30 @@
 # On-demand performance report for a PR.
 #
 # Compares the PR head against its merge base and produces:
-# * a benchmark table with the before/after diff (posted as a PR comment)
+# * a benchmark table with the before/after diff
 # * clickable flamegraphs for both revisions
 # * a differential flamegraph of the CPU profile
 #
-# Trigger it by adding the `perf-report` label to a PR, or manually from the
-# Actions tab.
+# Runs when the `perf-report` label is added, on later pushes while that label
+# is still present.
 name: Performance report
 
 on:
   pull_request:
-    types: [labeled]
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   report:
     name: Performance report
-    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'perf-report'
+    # Label must already be on the PR for push/open/reopen; `labeled` also
+    # matches once `perf-report` is among the labels.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'perf-report')
     runs-on: ubuntu-latest-4-cores-public
 
     env:
@@ -39,6 +42,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Install perf and profiling tools
@@ -98,27 +102,7 @@ jobs:
           rm -f /tmp/perf-report/*.svg
 
       - name: Upload perf-report.html
-        id: upload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: /tmp/perf-report/perf-report.html
           archive: false
-
-      - name: Comment on the PR
-        if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
-        run: |
-          {
-            cat /tmp/perf-report/report.md
-            echo
-            echo "Flamegraphs: [${ARTIFACT_URL}](${ARTIFACT_URL})."
-          } > /tmp/perf-report/comment.md
-          gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/perf-report/comment.md
-
-      - name: Remove perf-report label
-        if: always() && github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr edit ${{ github.event.pull_request.number }} --remove-label perf-report

--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -1,0 +1,109 @@
+# On-demand performance report for a PR.
+#
+# Compares the PR head against its merge base and produces:
+# * a benchmark table with the before/after diff (posted as a PR comment)
+# * clickable flamegraphs for both revisions
+# * a differential flamegraph of the CPU profile
+#
+# Trigger it by adding the `perf-report` label to a PR, or manually from the
+# Actions tab.
+name: Performance report
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  report:
+    name: Performance report
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'perf-report'
+    runs-on: ubuntu-latest-4-cores-public
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - name: Install perf and profiling tools
+        run: |
+          # No runner image ships `perf`, so it has to be installed here.
+          sudo apt-get update
+          sudo apt-get install -y linux-tools-common linux-tools-generic
+          # /usr/bin/perf is a wrapper that looks for tools matching the running
+          # kernel, which the runner does not have packages for. Use the binary
+          # from linux-tools-generic directly instead.
+          sudo ln -sf "$(ls -d /usr/lib/linux-tools/*/perf | tail -1)" /usr/local/bin/perf
+          perf --version
+
+      - name: Disable kernel perf event paranoid mode
+        run: |
+          sudo sysctl -w kernel.perf_event_paranoid=0
+
+      - name: Install cargo-flamegraph and profiling tools
+        run: |
+          cargo install --locked flamegraph inferno critcmp rustfilt
+
+      - name: Determine merge base
+        id: base
+        run: |
+          BASE_REF="${{ github.event.pull_request.base.ref || 'master' }}"
+          git fetch --no-tags origin "$BASE_REF"
+          echo "sha=$(git merge-base FETCH_HEAD HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare
+        run: |
+          mkdir -p /tmp/perf-report
+          # The scripts are used for both revisions, so keep a copy outside the
+          # working tree that `git checkout` will not touch.
+          cp -r .github/scripts /tmp/perf-scripts
+
+      - name: Benchmark and profile the merge base
+        run: |
+          git checkout --detach ${{ steps.base.outputs.sha }}
+          /tmp/perf-scripts/run-perf-benchmarks.sh base
+          /tmp/perf-scripts/run-perf-profile.sh base /tmp/perf-report
+
+      - name: Benchmark and profile the PR head
+        run: |
+          git checkout --detach ${{ github.event.pull_request.head.sha || github.sha }}
+          /tmp/perf-scripts/run-perf-benchmarks.sh head
+          /tmp/perf-scripts/run-perf-profile.sh head /tmp/perf-report
+
+      - name: Build the report
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          {
+            echo "## Performance report"
+            echo
+            echo "\`${BASE_SHA}\` (base) → \`${HEAD_SHA}\` (head)"
+            echo
+            echo '```'
+            critcmp base head
+            echo '```'
+            echo
+            echo "Flamegraphs are attached as the \`perf-report\` artifact of [this run](${RUN_URL}):"
+            echo "\`matching\` / \`startup\`, each with a \`base\`, a \`head\` and a differential SVG."
+            echo "Download and open them in a browser to zoom and search."
+          } | tee /tmp/perf-report/report.md
+
+      - name: Upload flamegraphs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: perf-report
+          path: /tmp/perf-report
+
+      - name: Comment on the PR
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/perf-report/report.md

--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -108,3 +108,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/perf-report/report.md
+
+      - name: Remove perf-report label
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr edit ${{ github.event.pull_request.number }} --remove-label perf-report

--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -98,6 +98,7 @@ jobs:
           rm -f /tmp/perf-report/*.svg
 
       - name: Upload perf-report.html
+        id: upload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: /tmp/perf-report/perf-report.html
@@ -107,7 +108,14 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/perf-report/report.md
+          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+        run: |
+          {
+            cat /tmp/perf-report/report.md
+            echo
+            echo "Flamegraphs: [${ARTIFACT_URL}](${ARTIFACT_URL}) (open while logged into GitHub)."
+          } > /tmp/perf-report/comment.md
+          gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/perf-report/comment.md
 
       - name: Remove perf-report label
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -42,9 +42,10 @@ jobs:
           sudo ln -sf "$(ls -d /usr/lib/linux-tools/*/perf | tail -1)" /usr/local/bin/perf
           perf --version
 
-      - name: Disable kernel perf event paranoid mode
+      - name: Disable kernel perf event restrictions
         run: |
           sudo sysctl -w kernel.perf_event_paranoid=0
+          sudo sysctl -w kernel.kptr_restrict=0
 
       - name: Install cargo-flamegraph and profiling tools
         run: |

--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Determine merge base
         id: base
         run: |
-          BASE_REF="${{ github.event.pull_request.base.ref || 'master' }}"
+          BASE_REF="${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}"
           git fetch --no-tags origin "$BASE_REF"
           echo "sha=$(git merge-base FETCH_HEAD HEAD)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -87,30 +87,21 @@ jobs:
           /tmp/perf-scripts/run-perf-profile.sh head /tmp/perf-report
 
       - name: Build the report
-        env:
-          BASE_SHA: ${{ steps.base.outputs.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          {
-            echo "## Performance report"
-            echo
-            echo "\`${BASE_SHA}\` (base) → \`${HEAD_SHA}\` (head)"
-            echo
-            echo '```'
-            critcmp base head
-            echo '```'
-            echo
-            echo "Flamegraphs are attached as the \`perf-report\` artifact of [this run](${RUN_URL}):"
-            echo "\`matching\` / \`startup\`, each with a \`base\`, a \`head\` and a differential SVG."
-            echo "Download and open them in a browser to zoom and search."
-          } | tee /tmp/perf-report/report.md
+          /tmp/perf-scripts/build-perf-report.py \
+            --out-dir /tmp/perf-report \
+            --repo-dir "$GITHUB_WORKSPACE" \
+            --base-sha "${{ steps.base.outputs.sha }}" \
+            --head-sha "${{ github.event.pull_request.head.sha || github.sha }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          # Drop individual SVGs; the HTML embeds them.
+          rm -f /tmp/perf-report/*.svg
 
-      - name: Upload flamegraphs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - name: Upload perf-report.html
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: perf-report
-          path: /tmp/perf-report
+          path: /tmp/perf-report/perf-report.html
+          archive: false
 
       - name: Comment on the PR
         if: github.event_name == 'pull_request'

--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -119,7 +119,7 @@ jobs:
         run: gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/perf-report/report.md
 
       - name: Remove perf-report label
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr edit ${{ github.event.pull_request.number }} --remove-label perf-report

--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -24,6 +24,16 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'perf-report'
     runs-on: ubuntu-latest-4-cores-public
 
+    env:
+      # --no-rosegment: required for accurate perf stacks with lld (Rust >= 1.90).
+      # force-frame-pointers: cheap unwinding for `perf record --call-graph fp`.
+      # See: https://github.com/flamegraph-rs/flamegraph/blob/main/README.md
+      RUSTFLAGS: "-Cforce-frame-pointers=yes -Clink-arg=-Wl,--no-rosegment"
+      # Keep release and bench equivalent (bench inherits release) and leave
+      # symbols in both so perf can resolve stacks.
+      CARGO_PROFILE_RELEASE_DEBUG: "true"
+      CARGO_PROFILE_BENCH_DEBUG: "true"
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -47,9 +57,8 @@ jobs:
           sudo sysctl -w kernel.perf_event_paranoid=0
           sudo sysctl -w kernel.kptr_restrict=0
 
-      - name: Install cargo-flamegraph and profiling tools
-        run: |
-          cargo install --locked flamegraph inferno critcmp rustfilt
+      - name: Install profiling tools
+        run: cargo install --locked inferno critcmp rustfilt
 
       - name: Determine merge base
         id: base

--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -113,7 +113,7 @@ jobs:
           {
             cat /tmp/perf-report/report.md
             echo
-            echo "Flamegraphs: [${ARTIFACT_URL}](${ARTIFACT_URL}) (open while logged into GitHub)."
+            echo "Flamegraphs: [${ARTIFACT_URL}](${ARTIFACT_URL})."
           } > /tmp/perf-report/comment.md
           gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/perf-report/comment.md
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,11 @@ content-blocking = []
 embedded-domain-resolver = ["addr"] # Requires setting an external domain resolver if disabled.
 resource-assembler = []
 
+# Keep debug symbols in optimized builds so that `perf` can resolve
+# benchmark stacks. This does not affect codegen.
+[profile.bench]
+debug = true
+
 [lints.clippy]
 len_zero = "allow"
 uninlined_format_args = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,11 +100,6 @@ content-blocking = []
 embedded-domain-resolver = ["addr"] # Requires setting an external domain resolver if disabled.
 resource-assembler = []
 
-# Keep debug symbols in optimized builds so that `perf` can resolve
-# benchmark stacks. This does not affect codegen.
-[profile.bench]
-debug = true
-
 [lints.clippy]
 len_zero = "allow"
 uninlined_format_args = "warn"


### PR DESCRIPTION
The PR introduces a new optional CI build to generate a detailed perf report. 
* It runs tests before/after and output the results;
* uses linux `perf` + [inferno](https://crates.io/crates/inferno) to produce a flamegraph;
* also provides differential flamegraphs;
* uses `rustfilt` to propery demangle flamegraphs;
* activates once you added `perf-report` label and removes it after the run.

An example report on a test pr with a worse tokenization strategy:
https://github.com/brave/adblock-rust/actions/runs/30578642537/artifacts/8773964960

the flamegraph diff:
<img width="1349" height="363" alt="image" src="https://github.com/user-attachments/assets/b11c70e2-63d9-4e2c-a8f9-090da16c35bb" />
