### PR TITLE
Discontinue CompiledRegex::CompiledSet

### DIFF
--- a/benches/bench_regex.rs
+++ b/benches/bench_regex.rs
@@ -1,6 +1,6 @@
 use criterion::*;
 
-use regex::{Regex, RegexSet, bytes::Regex as BytesRegex};
+use regex::{Regex, bytes::Regex as BytesRegex};
 
 fn bench_simple_regexes(c: &mut Criterion) {
     let mut group = c.benchmark_group("regex");
@@ -49,29 +49,10 @@ fn bench_joined_bytes_regex(c: &mut Criterion) {
     group.finish();
 }
 
-fn bench_regex_set(c: &mut Criterion) {
-    let mut group = c.benchmark_group("regex");
-
-    let pattern = "?/static/adv/foobar/asd?q=1";
-
-    let set = RegexSet::new([
-        r"(?:[^\\w\\d\\._%-])/static/ad-",
-        r"(?:[^\\w\\d\\._%-])/static/ad/.*",
-        r"(?:[^\\w\\d\\._%-])/static/ads/.*",
-        r"(?:[^\\w\\d\\._%-])/static/adv/.*",
-    ])
-    .unwrap();
-
-    group.bench_function("set", move |b| b.iter(|| set.is_match(pattern)));
-
-    group.finish();
-}
-
 criterion_group!(
     benches,
     bench_simple_regexes,
     bench_joined_regex,
-    bench_joined_bytes_regex,
-    bench_regex_set
+    bench_joined_bytes_regex
 );
 criterion_main!(benches);

--- a/src/regex_manager.rs
+++ b/src/regex_manager.rs
@@ -4,10 +4,7 @@
 
 use crate::filters::network::{NetworkFilterMask, NetworkFilterMaskHelper};
 
-use regex::{
-    Regex, bytes::Regex as BytesRegex, bytes::RegexBuilder as BytesRegexBuilder,
-    bytes::RegexSet as BytesRegexSet, bytes::RegexSetBuilder as BytesRegexSetBuilder,
-};
+use regex::{Regex, bytes::Regex as BytesRegex, bytes::RegexBuilder as BytesRegexBuilder};
 use std::sync::LazyLock;
 
 use std::collections::HashMap;
@@ -68,7 +65,6 @@ pub struct RegexDebugEntry {
 #[derive(Debug, Clone)]
 pub(crate) enum CompiledRegex {
     Compiled(BytesRegex),
-    CompiledSet(BytesRegexSet),
     MatchAll,
     RegexParsingError(regex::Error),
 }
@@ -79,11 +75,6 @@ impl CompiledRegex {
             CompiledRegex::MatchAll => true, // simple case for matching everything, e.g. for empty filter
             CompiledRegex::RegexParsingError(_e) => false, // no match if regex didn't even compile
             CompiledRegex::Compiled(r) => r.is_match(pattern.as_bytes()),
-            CompiledRegex::CompiledSet(r) => {
-                // let matches: Vec<_> = r.matches(pattern).into_iter().collect();
-                // println!("Matching {} against RegexSet: {:?}", pattern, matches);
-                r.is_match(pattern.as_bytes())
-            }
         }
     }
 }
@@ -94,7 +85,6 @@ impl fmt::Display for CompiledRegex {
             CompiledRegex::MatchAll => write!(f, ".*"), // simple case for matching everything, e.g. for empty filter
             CompiledRegex::RegexParsingError(_e) => write!(f, "ERROR"), // no match if regex didn't even compile
             CompiledRegex::Compiled(r) => write!(f, "{}", r.as_str()),
-            CompiledRegex::CompiledSet(r) => write!(f, "{}", r.patterns().join(" | ")),
         }
     }
 }
@@ -226,12 +216,13 @@ where
             }
         }
     } else {
-        match BytesRegexSetBuilder::new(escaped_patterns)
-            .unicode(false)
-            .build()
-        {
-            Ok(compiled) => CompiledRegex::CompiledSet(compiled),
-            Err(e) => CompiledRegex::RegexParsingError(e),
+        let pattern = format!("(?:{})", escaped_patterns.join("|"));
+        match BytesRegexBuilder::new(&pattern).unicode(false).build() {
+            Ok(compiled) => CompiledRegex::Compiled(compiled),
+            Err(e) => {
+                // println!("Regex parsing failed ({:?})", e);
+                CompiledRegex::RegexParsingError(e)
+            }
         }
     }
 }

--- a/tests/unit/optimizer.rs
+++ b/tests/unit/optimizer.rs
@@ -6,7 +6,7 @@ mod optimization_tests_pattern_group {
         use crate::lists;
         use crate::regex_manager::CompiledRegex;
         use crate::request::Request;
-        use regex::bytes::RegexSetBuilder as BytesRegexSetBuilder;
+        use regex::bytes::RegexBuilder as BytesRegexBuilder;
 
         fn check_regex_match(regex: &CompiledRegex, pattern: &str, matches: bool) {
             let is_match = regex.is_match(pattern);
@@ -33,19 +33,16 @@ mod optimization_tests_pattern_group {
         }
 
         #[test]
-        fn regex_set_works() {
-            let regex_set = BytesRegexSetBuilder::new([
-                r"/static/ad\.",
-                "/static/ad-",
-                "/static/ad/.*",
-                "/static/ads/.*",
-                "/static/adv/.*",
-            ])
+        fn combined_regex_works() {
+            let regex = BytesRegexBuilder::new(
+                r"(?:/static/ad\.|/static/ad-|/static/ad/.*|/static/ads/.*|/static/adv/.*)",
+            )
             .unicode(false)
-            .build();
+            .build()
+            .unwrap();
 
-            let fused_regex = CompiledRegex::CompiledSet(regex_set.unwrap());
-            assert!(matches!(fused_regex, CompiledRegex::CompiledSet(_)));
+            let fused_regex = CompiledRegex::Compiled(regex);
+            assert!(matches!(fused_regex, CompiledRegex::Compiled(_)));
             check_regex_match(&fused_regex, "/static/ad.", true);
             check_regex_match(&fused_regex, "/static/ad-", true);
             check_regex_match(&fused_regex, "/static/ads-", false);
@@ -287,7 +284,7 @@ mod optimization_tests_pattern_group {
     use crate::lists;
     use crate::regex_manager::CompiledRegex;
     use crate::request::Request;
-    use regex::bytes::RegexSetBuilder as BytesRegexSetBuilder;
+    use regex::bytes::RegexBuilder as BytesRegexBuilder;
 
     fn check_regex_match(regex: &CompiledRegex, pattern: &str, matches: bool) {
         let is_match = regex.is_match(pattern);
@@ -314,19 +311,16 @@ mod optimization_tests_pattern_group {
     }
 
     #[test]
-    fn regex_set_works() {
-        let regex_set = BytesRegexSetBuilder::new([
-            r"/static/ad\.",
-            "/static/ad-",
-            "/static/ad/.*",
-            "/static/ads/.*",
-            "/static/adv/.*",
-        ])
+    fn combined_regex_works() {
+        let regex = BytesRegexBuilder::new(
+            r"(?:/static/ad\.|/static/ad-|/static/ad/.*|/static/ads/.*|/static/adv/.*)",
+        )
         .unicode(false)
-        .build();
+        .build()
+        .unwrap();
 
-        let fused_regex = CompiledRegex::CompiledSet(regex_set.unwrap());
-        assert!(matches!(fused_regex, CompiledRegex::CompiledSet(_)));
+        let fused_regex = CompiledRegex::Compiled(regex);
+        assert!(matches!(fused_regex, CompiledRegex::Compiled(_)));
         check_regex_match(&fused_regex, "/static/ad.", true);
         check_regex_match(&fused_regex, "/static/ad-", true);
         check_regex_match(&fused_regex, "/static/ads-", false);


### PR DESCRIPTION
RegexSet was the wrong instrument to solve our task.
In fact we have never use it's main ability: 
"A regex set as its formulated here provides a touch more power: it will also report which regular expressions in the set match." ([link](https://docs.rs/regex/latest/regex/struct.RegexSet.html))

Replacing it to `RegEx("pattern1 | .. | pattern_n")` even gives you better time and memory usage.

`memory-usage-final/brave-list-1000-requests` is improved by 19%.