### PR TITLE
[perf] Update the strategy to use % as a delimiter

### DIFF
--- a/src/data_format/mod.rs
+++ b/src/data_format/mod.rs
@@ -19,7 +19,7 @@ const ADBLOCK_RUST_DAT_MAGIC: [u8; 4] = [0xd1, 0xd9, 0x3a, 0xaf];
 
 /// The version of the data format.
 /// If the data format version is incremented, the data is considered as incompatible.
-const ADBLOCK_RUST_DAT_VERSION: u8 = 6;
+const ADBLOCK_RUST_DAT_VERSION: u8 = 7;
 
 /// The total length of the header prefix (magic + version + seahash)
 const HEADER_PREFIX_LENGTH: usize = 4 + 1 + 8;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,9 +24,12 @@ pub fn to_short_hash(hash: Hash) -> ShortHash {
     hash as ShortHash
 }
 
+/// Characters that form a token. `%` is a separator so percent-encoded paths
+/// like `%2Faymt%2Faa%2F%3F` yield interior tokens (`2faymt`, `2faa`) instead of
+/// one last-token that `skip_last_token` would drop into the fallback bucket.
 #[inline]
 fn is_allowed_filter(ch: char) -> bool {
-    ch.is_alphanumeric() || ch == '%'
+    ch.is_alphanumeric()
 }
 
 /// A fixed-size array-like vector of hashes with maximum capacity of 256.

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -222,6 +222,6 @@ fn check_rule_matching_browserlike() {
     let engine = Engine::new_with_list_text(rules);
     let (blocked, passes) = bench_rule_matching_browserlike(&engine, &requests);
     let msg = "The number of blocked/passed requests has changed. ".to_string()
-        + "If this is expected, update the expected values in the test.";
-    assert_eq!((blocked, passes), (106682, 136263), "{msg}");
+        + "If this is expected, update the expected values in the test. ";
+    assert_eq!((blocked, passes), (106693, 136252), "{msg}");
 }

--- a/tests/unit/engine.rs
+++ b/tests/unit/engine.rs
@@ -195,7 +195,7 @@ mod tests {
     fn deserialization_generate_simple() {
         let mut engine = Engine::new_with_list_text("ad-banner");
         let data = engine.serialize().to_vec();
-        const EXPECTED_HASH: u64 = 15226361072329777649;
+        const EXPECTED_HASH: u64 = 10113207146074251361;
         assert_eq!(hash(&data), EXPECTED_HASH, "{HASH_MISMATCH_MSG}");
         engine.deserialize(&data).unwrap();
     }
@@ -206,7 +206,7 @@ mod tests {
         let mut engine = Engine::new_with_list_text("ad-banner$tag=abc");
         engine.use_tags(&["abc"]);
         let data = engine.serialize().to_vec();
-        const EXPECTED_HASH: u64 = 5340450827873480113;
+        const EXPECTED_HASH: u64 = 5079383995588202479;
         assert_eq!(hash(&data), EXPECTED_HASH, "{HASH_MISMATCH_MSG}");
         engine.deserialize(&data).unwrap();
     }
@@ -262,9 +262,9 @@ mod tests {
             assert_eq!(debug_info.source_info[0].cosmetic_filter_count, 42318);
         }
         let expected_hash: u64 = if cfg!(feature = "css-validation") {
-            13495148660543078227
+            11163270114727075630
         } else {
-            9490721625747073466
+            9523525740960748746
         };
 
         assert_eq!(hash(&data), expected_hash, "{HASH_MISMATCH_MSG}");

--- a/tests/unit/filters/network.rs
+++ b/tests/unit/filters/network.rs
@@ -1387,6 +1387,38 @@ mod parse_tests {
     }
 
     #[test]
+    fn test_percent_encoded_pattern_tokenization() {
+        // Leading `*` is stripped; `%` splits the encoded path so this is not
+        // dumped into the fallback (token 0) bucket.
+        let filter =
+            NetworkFilter::parse("*%2Faymt%2Faa%2F%3F$image", true, ParseOptions::default())
+                .unwrap();
+        let mut tokens_buffer = utils::TokensBuffer::default();
+        assert_eq!(filter.get_tokens(&mut tokens_buffer), FilterTokens::Other);
+        assert!(
+            tokens_buffer
+                .as_slice()
+                .contains(&utils::fast_hash("2faymt")),
+            "tokens: {:?}",
+            tokens_buffer.iter().copied().collect::<Vec<_>>(),
+        );
+        assert!(tokens_buffer.as_slice().contains(&utils::fast_hash("2faa")));
+
+        let request = crate::request::Request::new(
+            "https://example.com/pixel?u=%2Faymt%2Faa%2F%3F",
+            "https://example.com/",
+            "image",
+            "",
+        )
+        .unwrap();
+        assert!(
+            request.get_tokens().contains(&utils::fast_hash("2faymt")),
+            "request tokens must include the filter token or the bucket is never probed"
+        );
+        assert!(filter.matches_test(&request));
+    }
+
+    #[test]
     fn handles_method_options() {
         const CASES: &[(&str, bool, bool, bool)] = &[
             ("||foo$method=post", false, false, true),

--- a/tests/unit/utils.rs
+++ b/tests/unit/utils.rs
@@ -85,6 +85,16 @@ mod tests {
         assert_eq!(tokenize("foo.barƬ*").as_slice(), t(&["foo"]).as_slice());
         assert_eq!(tokenize("*foo.barƬ").as_slice(), t(&["barƬ"]).as_slice());
         assert_eq!(tokenize("*foo.barƬ*").as_slice(), t(&[]).as_slice());
+
+        // `%` is a separator so percent-encoded sequences tokenize
+        assert_eq!(
+            tokenize("%2Faymt%2Faa%2F%3F").as_slice(),
+            t(&["2Faymt", "2Faa", "2F", "3F"]).as_slice()
+        );
+        assert_eq!(
+            tokenize_filter("%2Faymt%2Faa%2F%3F", false, true).as_slice(),
+            t(&["2Faymt", "2Faa", "2F"]).as_slice()
+        );
     }
 
     #[test]


### PR DESCRIPTION
The PR makes `%` a token delimiter. This allows to generate non-zero tokens for some rules.

```
group                                  base                                    head
-----                                  ----                                    ----
blocker_new/brave-list                 1.00    113.5±2.15ms     8 Elem/sec     1.00    113.3±1.75ms     8 Elem/sec
blocker_new/brave-list-deserialize     1.07     31.9±0.52ms    31 Elem/sec     1.00     29.8±0.09ms    33 Elem/sec
cosmetic-class-id-match/brave-list     1.04      3.5±0.95ms   285 Elem/sec     1.00      3.4±0.91ms   296 Elem/sec
rule-match-browserlike/brave-list      1.07       2.0±0.01s 117.0 KElem/sec    1.00   1899.2±5.36ms 124.9 KElem/sec
rule-match-first-request/brave-list    1.00  1366.7±39.02µs        ? ?/sec     1.02   1388.9±7.16µs        ? ?/sec
url_cosmetic_resources/brave-list      1.00    190.9±0.87µs  5.1 KElem/sec     1.03   196.2±11.83µs  5.0 KElem/sec
```