### PR TITLE
Forbid regex domains from becoming invalid content blocking rules

### DIFF
--- a/src/content_blocking.rs
+++ b/src/content_blocking.rs
@@ -452,6 +452,8 @@ impl TryFrom<NetworkFilter<'_>> for CbRuleEquivalent {
                 }
                 .split('|');
 
+                let mut any_invalid = false;
+
                 domains.for_each(|domain| {
                     let (collection, domain) =
                         if let Some(domain_stripped) = domain.strip_prefix('~') {
@@ -459,6 +461,12 @@ impl TryFrom<NetworkFilter<'_>> for CbRuleEquivalent {
                         } else {
                             (&mut if_domain, domain)
                         };
+
+                    // $domain=/<regex>/ unsupported for now
+                    if domain.starts_with("/") {
+                        any_invalid = true;
+                        return;
+                    }
 
                     let lowercase = domain.to_lowercase();
                     let normalized_domain = if lowercase.is_ascii() {
@@ -471,6 +479,11 @@ impl TryFrom<NetworkFilter<'_>> for CbRuleEquivalent {
 
                     collection.push(format!("*{normalized_domain}"));
                 });
+
+                if any_invalid && if_domain.len() == 0 && unless_domain.len() == 0 {
+                    // TODO create a NoSupportedDomains error type and change this
+                    return Err(CbRuleCreationFailure::FromNotSupported);
+                }
 
                 (non_empty(if_domain), non_empty(unless_domain))
             } else {

--- a/tests/unit/content_blocking.rs
+++ b/tests/unit/content_blocking.rs
@@ -790,6 +790,8 @@ mod filterset_tests {
                 "/test.js^$to=example.com",
                 // leading zero-width space
                 r#"​##a[href^="https://www.g2fame.com/"] > img"#,
+                // unsupported domains
+                r#"||i.imgur.com^$domain=/avguri[0-9]+\.com/|/yasyadong[0-9]+\.tv/|/^torrentqq[0-9]+.com/|/^torrentwhy[0-9]+\.xyz/|/^torrentgram[0-9]+\.com/|/^bobaelink[0-9]+\.xyz/"#,
             ],
             Default::default(),
         );
@@ -844,6 +846,27 @@ mod filterset_tests {
         assert_eq!(
             cb_rules[0].trigger.if_domain.as_ref().unwrap(),
             &["test.net"]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn convert_only_supported_domains() -> Result<(), ()> {
+        let list = [
+            r"||i.imgur.com^$domain=/avguri[0-9]+\.com/|yasyadong.*|/yasyadong[0-9]+\.tv/|sonagitv.*|/^torrentqq[0-9]+.com/|/^torrentwhy[0-9]+\.xyz/|/^torrentgram[0-9]+\.com/|/^bobaelink[0-9]+\.xyz/",
+        ];
+
+        let mut set = FilterSet::new(true);
+        set.add_filters(list, Default::default());
+
+        let (cb_rules, used_rules) = set.into_content_blocking()?;
+        assert_eq!(used_rules.len(), 1);
+        assert_eq!(cb_rules.len(), 2);
+        assert!(cb_rules[0].trigger.if_domain.is_some());
+        assert_eq!(
+            cb_rules[0].trigger.if_domain.as_ref().unwrap(),
+            &["*yasyadong.*", "*sonagitv.*"]
         );
 
         Ok(())


### PR DESCRIPTION
Resolves failure related to the following filter from https://cdn.jsdelivr.net/npm/@list-kr/filterslists@latest/dist/filterslist-uBlockOrigin-classic.txt:

```adblock
||i.imgur.com^$domain=/avguri[0-9]+\.com/|yasyadong.*|/yasyadong[0-9]+\.tv/|sonagitv.*|/^torrentqq[0-9]+.com/|/^torrentwhy[0-9]+\.xyz/|/^torrentgram[0-9]+\.com/|/^bobaelink[0-9]+\.xyz/
```