### PR TITLE
Update Rust to 1.98

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.97"
+channel = "1.98"
 components = ["clippy", "rustfmt" ]


### PR DESCRIPTION
https://blog.rust-lang.org/2026/08/20/Rust-1.98.0/

```
group                                  base                                    head
-----                                  ----                                    ----
blocker_new/brave-list                 1.02    115.7±0.88ms     8 Elem/sec     1.00    113.2±2.13ms     8 Elem/sec
blocker_new/brave-list-deserialize     1.13     34.9±0.57ms    28 Elem/sec     1.00     30.8±0.23ms    32 Elem/sec
cosmetic-class-id-match/brave-list     1.00      3.4±0.91ms   298 Elem/sec     1.01      3.4±0.88ms   295 Elem/sec
rule-match-browserlike/brave-list      1.00       2.1±0.02s 113.9 KElem/sec    1.00       2.1±0.01s 114.3 KElem/sec
rule-match-first-request/brave-list    1.07  1438.0±26.95µs        ? ?/sec     1.00   1347.2±8.44µs        ? ?/sec
url_cosmetic_resources/brave-list      1.01    190.8±1.66µs  5.1 KElem/sec     1.00    188.3±1.09µs  5.2 KElem/sec
```